### PR TITLE
Hotfix: Fix login form

### DIFF
--- a/conf/cmi/openid_connect.settings.yml
+++ b/conf/cmi/openid_connect.settings.yml
@@ -1,7 +1,7 @@
 always_save_userinfo: true
 connect_existing_users: false
 override_registration_settings: false
-user_login_display: replace
+user_login_display: below
 userinfo_mappings:
   timezone: zoneinfo
 _core:

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -64,7 +64,10 @@ if ($drush_options_uri && !in_array($drush_options_uri, $routes)) {
 
 $settings['config_sync_directory'] = '../conf/cmi';
 $settings['file_public_path'] = getenv('DRUPAL_FILES_PUBLIC') ?: 'sites/default/files';
-$settings['file_private_path'] = getenv('DRUPAL_FILES_PRIVATE');
+
+# $settings['file_private_path'] = getenv('DRUPAL_FILES_PRIVATE');
+$settings['file_private_path'] = 'sites/default/files/private';
+
 $settings['file_temp_path'] = getenv('DRUPAL_TMP_PATH') ?: '/tmp';
 $settings['install_profile'] = 'minimal';
 


### PR DESCRIPTION
Login form has disappeared from test environment. This adds it back so testers can get in without tunnistamo access.