### PR TITLE
AU-248: Add front page latest news -paragraph

### DIFF
--- a/conf/cmi/field.field.node.landing_page.field_content.yml
+++ b/conf/cmi/field.field.node.landing_page.field_content.yml
@@ -6,10 +6,12 @@ dependencies:
     - field.storage.node.field_content
     - node.type.landing_page
     - paragraphs.paragraphs_type.banner
+    - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.content_cards
     - paragraphs.paragraphs_type.content_liftup
     - paragraphs.paragraphs_type.from_library
+    - paragraphs.paragraphs_type.front_page_latest_news
     - paragraphs.paragraphs_type.liftup_with_image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.phasing
@@ -32,16 +34,17 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
+      content_cards: content_cards
+      content_liftup: content_liftup
       columns: columns
       banner: banner
       list_of_links: list_of_links
       liftup_with_image: liftup_with_image
-      content_cards: content_cards
-      content_liftup: content_liftup
       from_library: from_library
-      remote_video: remote_video
-      phasing: phasing
       chart: chart
+      remote_video: remote_video
+      front_page_latest_news: front_page_latest_news
+      phasing: phasing
     negate: 0
     target_bundles_drag_drop:
       accordion:
@@ -50,23 +53,41 @@ settings:
       accordion_item:
         weight: -21
         enabled: false
+      asiointipalvelu:
+        weight: 39
+        enabled: false
       banner:
         weight: -26
         enabled: true
+      bloc:
+        weight: 41
+        enabled: false
       chart:
         weight: 25
         enabled: true
       columns:
         weight: -27
         enabled: true
+      contact_card:
+        weight: 44
+        enabled: false
+      contact_card_listing:
+        weight: 45
+        enabled: false
       content_cards:
         weight: -33
         enabled: true
       content_liftup:
         weight: -32
         enabled: true
+      event_list:
+        weight: 48
+        enabled: false
       from_library:
         weight: 21
+        enabled: true
+      front_page_latest_news:
+        weight: 50
         enabled: true
       gallery:
         weight: -20
@@ -89,16 +110,49 @@ settings:
       list_of_links_item:
         weight: -16
         enabled: false
+      news_list:
+        weight: 58
+        enabled: false
+      paragraph_verkkolomake:
+        weight: 59
+        enabled: false
       phasing:
         weight: 50
         enabled: true
       phasing_item:
         weight: 30
         enabled: false
+      popular_service_item:
+        weight: 62
+        enabled: false
+      popular_services:
+        weight: 63
+        enabled: false
       remote_video:
         weight: 27
         enabled: true
+      service_list:
+        weight: 65
+        enabled: false
+      sidebar_text:
+        weight: 66
+        enabled: false
+      social_media_link:
+        weight: 67
+        enabled: false
+      target_group_link_item:
+        weight: 68
+        enabled: false
+      target_group_links:
+        weight: 69
+        enabled: false
       text:
         weight: -15
+        enabled: false
+      unit_search:
+        weight: 71
+        enabled: false
+      webform:
+        weight: 72
         enabled: false
 field_type: entity_reference_revisions

--- a/conf/cmi/language/fi/core.entity_form_display.node.landing_page.default.yml
+++ b/conf/cmi/language/fi/core.entity_form_display.node.landing_page.default.yml
@@ -1,0 +1,9 @@
+content:
+  field_content:
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+  field_hero:
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs

--- a/conf/cmi/paragraphs.paragraphs_type.front_page_latest_news.yml
+++ b/conf/cmi/paragraphs.paragraphs_type.front_page_latest_news.yml
@@ -1,0 +1,10 @@
+uuid: 246539c6-f699-4903-96ec-6a2ee0da27e6
+langcode: fi
+status: true
+dependencies: {  }
+id: front_page_latest_news
+label: 'Front page latest news'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -419,11 +419,15 @@ display:
         groups:
           1: AND
       style:
-        type: default
+        type: html_list
         options:
-          row_class: ''
+          grouping: {  }
+          row_class: news-listing__item
           default_row_class: true
           uses_fields: true
+          type: ul
+          wrapper_class: item-list
+          class: 'news-listing news-listing--latest-medium-teasers'
       row:
         type: 'entity:node'
         options:
@@ -577,7 +581,10 @@ display:
       use_more_text: 'See all news'
       link_display: custom_url
       link_url: /news
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
     cache_metadata:
       max-age: -1
       contexts:

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-latest-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--front-page-latest-news.html.twig
@@ -1,0 +1,13 @@
+{% block paragraph %}
+  {% embed "@hdbt/misc/component.twig" with
+    {
+      component_classes: [ 'component--latest-news' ],
+      component_title: 'Latest news'|t({}, {'context': 'Front page latest news paragraph title'}),
+      component_content_class: 'latest-news',
+    }
+  %}
+    {% block component_content %}
+      {{ drupal_view('frontpage_news', 'latest_news') }}
+    {% endblock component_content %}
+  {% endembed %}
+{% endblock paragraph %}

--- a/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--frontpage-news--latest-news.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/container--more-link--frontpage-news--latest-news.html.twig
@@ -1,0 +1,12 @@
+{% set link_attributes = {
+  'class': [
+    'hds-button',
+    'hds-button--primary',
+  ],
+} %}
+{% set link_title %}
+  <span class="hds-button__label">{{ element['#title'] }}</span>
+  {% include "@hdbt/misc/icon.twig" with {icon: 'arrow-right' } %}
+{% endset %}
+
+{{ link(link_title, element['#url'], link_attributes) }}


### PR DESCRIPTION
# [AU-248](https://helsinkisolutionoffice.atlassian.net/browse/AU-248)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* New paragraph type 'Front page latest news', should be available on landing page

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to landing page and test if you can add latest news -paragraph


[AU-248]: https://helsinkisolutionoffice.atlassian.net/browse/AU-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-248]: https://helsinkisolutionoffice.atlassian.net/browse/AU-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ