### PR TITLE
AU-126: place footer menus

### DIFF
--- a/conf/cmi/block.block.footertopnavigationsecond_2.yml
+++ b/conf/cmi/block.block.footertopnavigationsecond_2.yml
@@ -1,24 +1,22 @@
-uuid: 5c160396-3f7f-4d3b-98d3-d8bcebd32172
-langcode: en
+uuid: eba74589-90df-441b-98d6-9d7250273d2d
+langcode: fi
 status: true
 dependencies:
   config:
-    - system.menu.footer-bottom-navigation
+    - system.menu.footer-top-navigation-2
   module:
     - menu_block_current_language
   theme:
     - hdbt_subtheme
-_core:
-  default_config_hash: Lq0uz6Wcg4xRo7w6BmzuzPTwOXtY8Q4qmYGUcGCvBLA
-id: hdbt_subtheme_footerbottomnavigation
+id: footertopnavigationsecond_2
 theme: hdbt_subtheme
-region: footer_bottom
+region: footer_top
 weight: 0
 provider: null
-plugin: 'menu_block_current_language:footer-bottom-navigation'
+plugin: 'menu_block_current_language:footer-top-navigation-2'
 settings:
-  id: 'menu_block_current_language:footer-bottom-navigation'
-  label: 'Helsingin kaupunki'
+  id: 'menu_block_current_language:footer-top-navigation-2'
+  label: 'Ota yhteyttä'
   label_display: visible
   provider: menu_block_current_language
   level: 1

--- a/public/themes/custom/hdbt_subtheme/src/scss/library/variables/_typography.scss
+++ b/public/themes/custom/hdbt_subtheme/src/scss/library/variables/_typography.scss
@@ -1,2 +1,20 @@
 // Font variables from HDS.
 @import "~hds-design-tokens/lib/typography/all.scss";
+
+blockquote {
+  position: relative;
+  padding-left: 1.5rem;
+  margin: 0;
+
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 4px;
+    height: 100%;
+    background-color: var(--color-engel);
+    border-radius: 2px;
+  }
+}


### PR DESCRIPTION
# [AU-126](https://helsinkisolutionoffice.atlassian.net/browse/AU-126)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add Footer top navigation second and rename titles

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-126-footer`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that both navigation blocks are in place in block layout (they are not yet visible in front end because menu items need to be added in test server)


[AU-126]: https://helsinkisolutionoffice.atlassian.net/browse/AU-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ