### PR TITLE
AU-574: Makefile robot tests

### DIFF
--- a/test/tests/browser-testing.robot
+++ b/test/tests/browser-testing.robot
@@ -41,6 +41,8 @@ Update User Bank Account
 Open Browser To Home Page
     Set Browser Timeout   30s
     New Browser           ${BROWSER}
+    # Needed for local environment testing
+    New Context           ignoreHTTPSErrors=True
     New Page              %{TEST_BASEURL}
     Get Title             ==    Avustukset | Hel.fi Avustusasiointi
 

--- a/tools/make/project/robot.mk
+++ b/tools/make/project/robot.mk
@@ -1,0 +1,9 @@
+PHONY += test-robot
+test-robot: ## Run Robot framework tests in docker container
+	docker run \
+			-v $(PWD)/test/logs:/opt/robotframework/reports:Z \
+			-v $(PWD)/test:/opt/robotframework/tests:Z \
+			-e TEST_BASEURL=https://$(DRUPAL_HOSTNAME)/ \
+			--add-host $(DRUPAL_HOSTNAME):172.17.0.1 \
+			-it \
+			ppodgorsek/robot-framework:5.0.0


### PR DESCRIPTION
# [AU-574](https://helsinkisolutionoffice.atlassian.net/browse/AU-574)
<!-- What problem does this solve? -->

Runs robot framework test in local docker container

## What was done
<!-- Describe what was done -->

Added docker container and makefile commands to run robot tests locally in a container.

## How to test

```
make up
make (check that test-robot command is listed)
make test-robot
```

Running the command should start the robot framework test process, note that depending on the current tests, they may not all pass. 


[AU-574]: https://helsinkisolutionoffice.atlassian.net/browse/AU-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ