### PR TITLE
Feature/au 659 proxy to subdomain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "drupal/helfi_hauki": "^1.0",
         "drupal/helfi_helsinki_profiili": "dev-develop",
         "drupal/helfi_platform_config": "^2.9",
-        "drupal/helfi_proxy": "^3.0",
         "drupal/helfi_tpr": "^2.1",
         "drupal/helfi_tunnistamo": "^2.0",
         "drupal/helfi_yjdh": "dev-develop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0986acf3ce9b1ea7fc00afa9ccc8397",
+    "content-hash": "026476956f667750fac975745cebc947",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5978,47 +5978,6 @@
             "time": "2023-01-10T06:20:07+00:00"
         },
         {
-            "name": "drupal/helfi_proxy",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy.git",
-                "reference": "467379e347873021e9218e330732b29c51fdad1a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-proxy/zipball/467379e347873021e9218e330732b29c51fdad1a",
-                "reference": "467379e347873021e9218e330732b29c51fdad1a",
-                "shasum": ""
-            },
-            "require": {
-                "drupal/helfi_api_base": "*",
-                "drupal/purge": "^3.0",
-                "drupal/varnish_purge": "^2.1",
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "php": "^8.0"
-            },
-            "conflict": {
-                "drupal/helfi_tunnistamo": "<=2.2.1"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "drupal/coder": "^8.3",
-                "phpspec/prophecy-phpunit": "^2"
-            },
-            "type": "drupal-module",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Provides various fixes so we can serve multiple Drupal instances in one domain.",
-            "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/tree/3.0.2",
-                "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-proxy/issues"
-            },
-            "time": "2023-01-16T09:45:08+00:00"
-        },
-        {
             "name": "drupal/helfi_tpr",
             "version": "2.1.7",
             "source": {
@@ -7895,65 +7854,6 @@
             }
         },
         {
-            "name": "drupal/purge",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/purge.git",
-                "reference": "8.x-3.4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.4.zip",
-                "reference": "8.x-3.4",
-                "shasum": "deb4eccfe88af35445e8064a9a4a8a056bfb917f"
-            },
-            "require": {
-                "drupal/core": "^9.2 || ^10"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-3.4",
-                    "datestamp": "1663189449",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "branch-alias": {
-                    "dev-8.x-3.x": "3.x-dev"
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Niels van Mourik",
-                    "homepage": "http://www.nielsvm.org"
-                },
-                {
-                    "name": "japerry",
-                    "homepage": "https://www.drupal.org/user/45640"
-                },
-                {
-                    "name": "nielsvm",
-                    "homepage": "https://www.drupal.org/user/163285"
-                },
-                {
-                    "name": "SqyD",
-                    "homepage": "https://www.drupal.org/user/106525"
-                }
-            ],
-            "description": "Provides a generic external cache invalidation API and queue service.",
-            "homepage": "https://www.drupal.org/project/purge",
-            "support": {
-                "source": "https://git.drupalcode.org/project/purge"
-            }
-        },
-        {
             "name": "drupal/radioactivity",
             "version": "4.0.3",
             "source": {
@@ -9012,66 +8912,6 @@
             "homepage": "https://www.drupal.org/project/update_helper",
             "support": {
                 "source": "https://git.drupalcode.org/project/update_helper"
-            }
-        },
-        {
-            "name": "drupal/varnish_purge",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/varnish_purge.git",
-                "reference": "8.x-2.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/varnish_purge-8.x-2.1.zip",
-                "reference": "8.x-2.1",
-                "shasum": "695eb7d81816e013e81d36207cfac162dd3cbe9f"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9"
-            },
-            "require-dev": {
-                "drupal/purge": "*",
-                "drupal/purge_tokens": "*",
-                "drupal/varnish_purger-varnish_purger": "*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-2.1",
-                    "datestamp": "1615977068",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "MiSc",
-                    "homepage": "https://www.drupal.org/user/382892"
-                },
-                {
-                    "name": "deadbeef",
-                    "homepage": "https://www.drupal.org/user/93644"
-                },
-                {
-                    "name": "javivf",
-                    "homepage": "https://www.drupal.org/user/2789335"
-                },
-                {
-                    "name": "littlethoughts",
-                    "homepage": "https://www.drupal.org/user/2479724"
-                }
-            ],
-            "homepage": "https://www.drupal.org/project/varnish_purge",
-            "support": {
-                "source": "https://git.drupalcode.org/project/varnish_purge"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -78,7 +78,6 @@ module:
   helfi_media: 0
   helfi_news_item: 0
   helfi_platform_config: 0
-  helfi_proxy: 0
   helfi_toc: 0
   helfi_tpr: 0
   helfi_tpr_config: 0

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -186,17 +186,11 @@ function grants_handler_page_attachments(array &$attachments) {
   // Get baseurl.
   $base_url = \Drupal::request()->getSchemeAndHttpHost();
 
-  /** @var \Drupal\helfi_proxy\ActiveSitePrefix $service */
-  $service = \Drupal::service('helfi_proxy.active_prefix');
-
   // Get current language.
   $currentLanguage = Drupal::languageManager()->getCurrentLanguage();
 
-  // Get url prefix for proxy.
-  $prefix = $service->getPrefix($currentLanguage->getId());
-
   // Set url to variable.
-  $attachments['#attached']['drupalSettings']['grants_handler']['site_url'] = $base_url . '/' . $currentLanguage->getId() . '/' . $prefix;
+  $attachments['#attached']['drupalSettings']['grants_handler']['site_url'] = $base_url . '/' . $currentLanguage->getId() . '/';
 
 }
 

--- a/public/modules/custom/grants_handler/grants_handler.services.yml
+++ b/public/modules/custom/grants_handler/grants_handler.services.yml
@@ -28,7 +28,7 @@ services:
                  '@database'
     ]
   grants_handler.navigation_helper:
-    class: \Drupal\grants_handler\GrantsHandlerNavigationHelper
+    class: Drupal\grants_handler\GrantsHandlerNavigationHelper
     arguments: [
         '@database', '@messenger',
         '@entity_type.manager',
@@ -63,3 +63,8 @@ services:
     arguments: ['@helfi_helsinki_profiili.userdata','@grants_profile.service']
     tags:
       - { name: breadcrumb_builder, priority: 10001 }
+
+  grants_handler.twig_extension:
+    class: Drupal\grants_handler\GrantsHandlerTwigExtension
+    tags:
+      - { name: twig.extension }

--- a/public/modules/custom/grants_handler/src/GrantsHandlerTwigExtension.php
+++ b/public/modules/custom/grants_handler/src/GrantsHandlerTwigExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\grants_handler;
+
+use Twig\TwigTest;
+
+/**
+ * Twig extension.
+ */
+class GrantsHandlerTwigExtension extends \Twig_Extension {
+
+  /**
+   * {@inheritdoc}
+   */
+  // Public function getFunctions(): array {
+  // return [
+  // new \Twig\TwigFunction('foo', function ($argument = NULL) {
+  // return 'Foo: ' . $argument;
+  // }),
+  // ];
+  // }.
+
+  /**
+   * {@inheritdoc}
+   */
+  // Public function getFilters(): array {
+  // return [
+  // new \Twig\TwigFilter('bar', function ($text) {
+  // return str_replace('bar', 'BAR', $text);
+  // }),
+  // ];
+  // }.
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTests(): array {
+    return [
+      new TwigTest('numeric', function ($value) {
+        return is_numeric($value);
+      }),
+    ];
+  }
+
+}

--- a/public/modules/custom/grants_handler/templates/grants-handler-completion.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-handler-completion.html.twig
@@ -26,7 +26,12 @@
       <div class="grants-handler__completion__info-row">
         <div class="grants-handler__completion__item--submitted">
           <h3>{{ "Submission date"|t }}</h3>
-          {{ applicationTimestamp|format_date('long') }}
+          {% if applicationTimestamp is numeric %}
+            {{ applicationTimestamp|format_date('long') }}
+          {% else %}
+            no timestamp
+          {% endif %}
+
         </div>
         <div class="grants-handler__completion__item--number">
           <h3>{{ "Application number"|t }}</h3>

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -25,17 +25,3 @@ $config['openid_connect.client.tunnistamo']['settings']['client_scopes'] = geten
 $config['openid_connect.client.tunnistamoadmin']['settings']['client_id'] = getenv('TUNNISTAMOADMIN_CLIENT_ID');
 $config['openid_connect.client.tunnistamoadmin']['settings']['client_secret'] = getenv('TUNNISTAMOADMIN_CLIENT_SECRET');
 $config['openid_connect.client.tunnistamoadmin']['settings']['client_scopes'] = getenv('TUNNISTAMOADMIN_CLIENT_SCOPES');
-
-
-//$config['helfi_proxy.settings']['default_proxy_domain'] = 'helfi-proxy.docker.so';
-$config['helfi_proxy.settings']['prefixes'] = [
-  'en' => 'grants',
-  'fi' => 'avustukset',
-  'sv' => 'bidrags'
-];
-$config['helfi_proxy.settings']['asset_path'] = 'avustukset-assets';
-
-
-if ($robots_header_enabled = getenv('DRUPAL_X_ROBOTS_TAG_HEADER')) {
-  $config['helfi_proxy.settings']['robots_header_enabled'] = (bool) $robots_header_enabled;
-}

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -1,3 +1,1 @@
 <?php
-
-#$config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/staging-avustukset/openid-connect/tunnistamo';

--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -1,10 +1,1 @@
 <?php
-
-#$config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/staging-avustukset/openid-connect/tunnistamo';
-
-$config['helfi_proxy.settings']['asset_path'] = 'staging-avustukset-assets';
-$config['helfi_proxy.settings']['prefixes'] = [
-  'en' => 'staging-grants',
-  'fi' => 'staging-avustukset',
-  'sv' => 'staging-bidrags'
-];

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -1,10 +1,1 @@
 <?php
-
-#$config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/test-avustukset/openid-connect/tunnistamo';
-
-$config['helfi_proxy.settings']['asset_path'] = 'test-avustukset-assets';
-$config['helfi_proxy.settings']['prefixes'] = [
-  'en' => 'test-grants',
-  'fi' => 'test-avustukset',
-  'sv' => 'test-bidrags'
-];


### PR DESCRIPTION
# [AU-659](https://helsinkisolutionoffice.atlassian.net/browse/AU-659)
<!-- What problem does this solve? -->
Since we cannot be proxied to hel.fi due to technical incompatibilities we need to move to subdomain set up. These changes will achieve that.

Also fixed fatal error on completion page when submitted timestamp is missing.

## What was done
<!-- Describe what was done -->

* Helfi_proxy + dependencies removed
* proxy configurations removed
* Added twig filter for checking if timestamps are numeric. If not, then dont show it.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout PR`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See that everything works without proxy parts in urls
* [ ] Check logging in via Tunnistamo, that no url errors.



[AU-659]: https://helsinkisolutionoffice.atlassian.net/browse/AU-659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ