### PR TITLE
AU-674: Add eventsubscriber to redirect events and add language parameter

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.services.yml
+++ b/public/modules/custom/grants_handler/grants_handler.services.yml
@@ -68,3 +68,11 @@ services:
     class: Drupal\grants_handler\GrantsHandlerTwigExtension
     tags:
       - { name: twig.extension }
+
+  grants_handler.tunnistamo_lang_redirect_subscriber:
+    class: Drupal\grants_handler\EventSubscriber\TunnistamoLangRedirectUrlSubscriber
+    tags:
+      - { name: event_subscriber }
+    arguments:
+      [ '@language_manager' ]
+

--- a/public/modules/custom/grants_handler/src/EventSubscriber/TunnistamoLangRedirectUrlSubscriber.php
+++ b/public/modules/custom/grants_handler/src/EventSubscriber/TunnistamoLangRedirectUrlSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\grants_handler\EventSubscriber;
+
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Url;
+use Drupal\helfi_tunnistamo\Event\RedirectUrlEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+
+class TunnistamoLangRedirectUrlSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
+   *   The language manager.
+   */
+  public function __construct(
+    private LanguageManagerInterface $languageManager
+  ) {
+  }
+
+  /**
+   * Responds to Tunnistamo redirect url event.
+   *
+   * @param \Drupal\helfi_tunnistamo\Event\RedirectUrlEvent $event
+   *   Response event.
+   */
+  public function onRedirectUrlEvent(RedirectUrlEvent $event) : void {
+
+    $uriOptions['language'] = $this->languageManager->getCurrentLanguage();
+
+    // Tunnistamo return URL is always configured to use /fi prefix.
+    $returnUrl = sprintf(
+      '/%s/openid-connect/%s', $uriOptions['language']->getId(), $event->getClient()->getParentEntityId()
+    );
+
+    if (!$returnUrl) {
+      return;
+    }
+
+    try {
+      $event->setRedirectUrl(Url::fromUserInput($returnUrl, $uriOptions)->setAbsolute());
+    }
+    catch (\InvalidArgumentException $e) {
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      RedirectUrlEvent::class => ['onRedirectUrlEvent'],
+    ];
+  }
+
+}

--- a/public/modules/custom/grants_handler/src/EventSubscriber/TunnistamoLangRedirectUrlSubscriber.php
+++ b/public/modules/custom/grants_handler/src/EventSubscriber/TunnistamoLangRedirectUrlSubscriber.php
@@ -9,7 +9,13 @@ use Drupal\Core\Url;
 use Drupal\helfi_tunnistamo\Event\RedirectUrlEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-
+/**
+ * Subscribe to Tunnistamo redirect events to add language parameter to uri.
+ *
+ * We want to eventually support all languages in authentication with Tunnistamo
+ * so we need to support all language parameters. Helfi_proxy module does this
+ * for proxied urls, we cannot use that so here is implementation without proxy.
+ */
 class TunnistamoLangRedirectUrlSubscriber implements EventSubscriberInterface {
 
   /**
@@ -33,7 +39,7 @@ class TunnistamoLangRedirectUrlSubscriber implements EventSubscriberInterface {
 
     $uriOptions['language'] = $this->languageManager->getCurrentLanguage();
 
-    // Tunnistamo return URL is always configured to use /fi prefix.
+    // Support all languages with tunnistamo urls.
     $returnUrl = sprintf(
       '/%s/openid-connect/%s', $uriOptions['language']->getId(), $event->getClient()->getParentEntityId()
     );


### PR DESCRIPTION

# [AU-674](https://helsinkisolutionoffice.atlassian.net/browse/AU-674)
<!-- What problem does this solve? -->

Currently our Tunnistamo implementation allow language parameters in Tunnistamo callback urls when they are proxied in hel.fi.

But since we moved on from proxy, but we still need the language parameter we need to implement event subscriber ourselves. This PR does just that.

## What was done
<!-- Describe what was done -->

* Added event subscriber to handle tunnistamo redirects.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-674-language-parameter-for-tunnistamo`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that Tunnistamo authentication works normally with language parameters. (tunnistamo errors if language parameter is not present.)


[AU-674]: https://helsinkisolutionoffice.atlassian.net/browse/AU-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ