### PR TITLE
AU-678: Bug fixes

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -464,7 +464,10 @@ function _grants_handler_imported_handler(
 
   $array["#value"] = $value;
   $array['#attributes'] = ['readonly' => 'readonly', 'style' => 'display:none'];
-  $array['#description'] = $show_checkmark ? _grants_handler_add_checkmark_to_text($value) : $value;
+  if ($value) {
+    $array['#description'] = $show_checkmark ? _grants_handler_add_checkmark_to_text($value) : $value;
+  }
+
   $array['#wrapper_attributes']['class'][] = 'grants-handler--prefilled-field';
 }
 

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -385,11 +385,7 @@ class GrantsHandler extends WebformHandlerBase {
         $grantsProfile = $grantsProfileDocument->getContent();
       }
       else {
-        $this->messenger()->addWarning('You must have grants profile created.');
-
-        $url = Url::fromRoute('grants_profile.edit');
-        $redirect = new RedirectResponse($url->toString());
-        $redirect->send();
+        throw new \Exception();
       }
     }
     catch (\Exception $e) {

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -391,7 +391,8 @@ class GrantsHandler extends WebformHandlerBase {
         $redirect = new RedirectResponse($url->toString());
         $redirect->send();
       }
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $this->messenger()
         ->addWarning('You must have grants profile created.');
 
@@ -608,7 +609,8 @@ class GrantsHandler extends WebformHandlerBase {
       try {
         $document = $this->applicationHandler->getAtvDocument($applicationNumber);
         $oldStatus = $document->getStatus();
-      } catch (TempStoreException|AtvDocumentNotFoundException|AtvFailedToConnectException|GuzzleException $e) {
+      }
+      catch (TempStoreException | AtvDocumentNotFoundException | AtvFailedToConnectException | GuzzleException $e) {
       }
 
     }
@@ -662,7 +664,8 @@ class GrantsHandler extends WebformHandlerBase {
       parent::validateForm($form, $form_state, $webform_submission);
       // Log current errors.
       $current_errors = $this->grantsFormNavigationHelper->logPageErrors($webform_submission, $form_state);
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $current_errors = [];
       // @todo add logger
     }
@@ -673,8 +676,8 @@ class GrantsHandler extends WebformHandlerBase {
    * {@inheritdoc}
    */
   public function validateForm(
-    array                      &$form,
-    FormStateInterface         $form_state,
+    array &$form,
+    FormStateInterface $form_state,
     WebformSubmissionInterface $webform_submission
   ) {
 
@@ -883,8 +886,8 @@ class GrantsHandler extends WebformHandlerBase {
     // let's invalidate cache for this submission.
     $this->entityTypeManager->getViewBuilder($webform_submission->getWebform()
       ->getEntityTypeId())->resetCache([
-      $webform_submission,
-    ]);
+        $webform_submission,
+      ]);
 
     if (empty($this->submittedFormData)) {
       return;
@@ -923,7 +926,8 @@ class GrantsHandler extends WebformHandlerBase {
       try {
         $applicationData = $this->applicationHandler->webformToTypedData(
           $this->submittedFormData);
-      } catch (ReadOnlyException $e) {
+      }
+      catch (ReadOnlyException $e) {
         // @todo log errors here.
       }
       $applicationUploadStatus = FALSE;
@@ -968,10 +972,12 @@ class GrantsHandler extends WebformHandlerBase {
               TRUE
             );
         }
-      } catch (\Exception $e) {
+      }
+      catch (\Exception $e) {
         $this->getLogger('grants_handler')
           ->error('Error uploadind application: @error', ['@error' => $e->getMessage()]);
-      } catch (GuzzleException $e) {
+      }
+      catch (GuzzleException $e) {
         $this->getLogger('grants_handler')
           ->error('Error uploadind application: @error', ['@error' => $e->getMessage()]);
       }
@@ -991,7 +997,8 @@ class GrantsHandler extends WebformHandlerBase {
           $this->submittedFormData,
           $this->applicationNumber
         );
-      } catch (\Exception $e) {
+      }
+      catch (\Exception $e) {
         $this->getLogger('grants_handler')->error($e->getMessage());
       }
 
@@ -1006,8 +1013,8 @@ class GrantsHandler extends WebformHandlerBase {
    * {@inheritdoc}
    */
   public function confirmForm(
-    array                      &$form,
-    FormStateInterface         $form_state,
+    array &$form,
+    FormStateInterface $form_state,
     WebformSubmissionInterface $webform_submission
   ) {
 
@@ -1073,7 +1080,8 @@ class GrantsHandler extends WebformHandlerBase {
           ],
         ]
       );
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       $this->getLogger('grants_handler')
         ->error('Error: %error', ['%error' => $e->getMessage()]);
 

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\Core\TypedData\Exception\ReadOnlyException;
 use Drupal\Core\TypedData\TypedDataManager;
+use GuzzleHttp\Exception\GuzzleException;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\grants_profile\TypedData\Definition\GrantsProfileDefinition;
@@ -574,7 +575,7 @@ class GrantsProfileForm extends FormBase {
       $success = $grantsProfileService->saveGrantsProfile($profileDataArray);
     }
     catch (\Exception $e) {
-      $this->logger('grants_profile')->error('Grants profile saving failed.');
+      $this->logger('grants_profile')->error('Grants profile saving failed. Error: @error', ['@error' => $e->getMessage()]);
     }
     $grantsProfileService->clearCache($selectedCompany);
 

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
@@ -7,7 +7,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\Core\TypedData\Exception\ReadOnlyException;
 use Drupal\Core\TypedData\TypedDataManager;
-use GuzzleHttp\Exception\GuzzleException;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\grants_profile\TypedData\Definition\GrantsProfileDefinition;

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -573,15 +573,23 @@ class GrantsProfileService {
       }
 
       if ($companyDetails == NULL) {
-        throw new YjdhException('Company details not found from YTJ');
+        throw new YjdhException('Company details not found');
       }
+
+      if (!$companyDetails["TradeName"]["Name"]) {
+        throw new YjdhException('Company name not set, cannot proceed');
+      }
+      if (!$companyDetails["BusinessId"]) {
+        throw new YjdhException('Company BusinessId not set, cannot proceed');
+      }
+
 
       $profileContent["companyName"] = $companyDetails["TradeName"]["Name"];
       $profileContent["businessId"] = $companyDetails["BusinessId"];
-      $profileContent["companyStatus"] = $companyDetails["CompanyStatus"]["Status"]["PrimaryCode"];
-      $profileContent["companyStatusSpecial"] = $companyDetails["CompanyStatus"]["Status"]["SecondaryCode"];
-      $profileContent["registrationDate"] = $companyDetails["RegistrationHistory"]["RegistryEntry"][0]["RegistrationDate"];
-      $profileContent["companyHome"] = $companyDetails["PostalAddress"]["DomesticAddress"]["City"];
+      $profileContent["companyStatus"] = $companyDetails["CompanyStatus"]["Status"]["PrimaryCode"] ?? '-';
+      $profileContent["companyStatusSpecial"] = $companyDetails["CompanyStatus"]["Status"]["SecondaryCode"] ?? '-';
+      $profileContent["registrationDate"] = $companyDetails["RegistrationHistory"]["RegistryEntry"][0]["RegistrationDate"] ?? '-';
+      $profileContent["companyHome"] = $companyDetails["PostalAddress"]["DomesticAddress"]["City"] ?? '-';
 
     }
 

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -583,7 +583,6 @@ class GrantsProfileService {
         throw new YjdhException('Company BusinessId not set, cannot proceed');
       }
 
-
       $profileContent["companyName"] = $companyDetails["TradeName"]["Name"];
       $profileContent["businessId"] = $companyDetails["BusinessId"];
       $profileContent["companyStatus"] = $companyDetails["CompanyStatus"]["Status"]["PrimaryCode"] ?? '-';

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -143,6 +143,7 @@ class GrantsProfileService {
     $newProfileData['business_id'] = $selectedCompany;
     $newProfileData['user_id'] = $userData["sub"];
     $newProfileData['status'] = self::DOCUMENT_STATUS_NEW;
+    $newProfileData['deletable'] = TRUE;
 
     $newProfileData['tos_record_id'] = $this->newProfileTosRecordId();
     $newProfileData['tos_function_id'] = $this->newProfileTosFunctionId();

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -375,3 +375,12 @@ msgstr "%value ei ole suomalainen postinumero"
 
 msgid "%value is not valid url"
 msgstr "%value ei ole url osoite."
+
+msgid "Company name not set, cannot proceed"
+msgstr "Yritysnimeä ei löydy, profiilin luontia ei voi jatkaa"
+
+msgid "Company BusinessId not set, cannot proceed"
+msgstr "Y-tunnusta ei löydy, profiilin luontia ei voi jatkaa"
+
+msgid "Company details not found"
+msgstr "Yrityksen tietoja ei löydy"

--- a/test/install.sh
+++ b/test/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+python3 -m venv env
+source ./env/bin/activate
+pip install -r requirements.txt
+rfbrowser init

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+source env/bin/activate
+TEST_BASEURL=https://hel-fi-drupal-grant-applications.docker.so/ robot -d logs/ tests/*.robot


### PR DESCRIPTION
# [AU-678](https://helsinkisolutionoffice.atlassian.net/browse/AU-678)
<!-- What problem does this solve? -->

Some YTJ/Yrtti data is not available in some company data, and we had it as requirement. This addresses issue by filling fields with "-" so that one can fill application without having all those "required" fields present.

Also add extra check so checkmark function does not fail if any field value is not set.

## What was done
<!-- Describe what was done -->

* Add some checks & balances to profile handling.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-678`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login with user that has company with KOTIPAIKKA field missing. Use this hetu: 020967-9992 and choose Itä-Suomen alihankkijat. 
* [ ] Add profile things, note KOTIPAIKKA missing, save profile
* [ ] Create new application, fill all the way to RECEIVED and see that things work.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x ] This PR does not need designers review


[AU-678]: https://helsinkisolutionoffice.atlassian.net/browse/AU-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ