### PR TITLE
AU-689: unique id for accordions

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -110,6 +110,11 @@ function hdbt_subtheme_preprocess_views_view(&$variables) {
     unset($variables['exposedOptions']['All']);
   }
 }
+function hdbt_subtheme_preprocess_details(&$variables) {
+  $uuid_service = \Drupal::service('uuid');
+  $uuid = $uuid_service->generate();
+  $variables['accordionid']=$uuid;
+}
 
 /**
  * Preprocess views view fields.

--- a/public/themes/custom/hdbt_subtheme/templates/form/details.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/form/details.html.twig
@@ -26,11 +26,11 @@
   %}
   <summary {{ summary_attributes.addClass(summary_classes) }}>
     <div class="accordion_heading_container">
-      <div>{{ title }}</div>
+      <div id="accordion-{{ accordionid }}-heading">{{ title }}</div>
       <span aria-hidden="true" class="hel-icon hel-icon--angle-down hel-icon--size-m"></span>
     </div>
   </summary>
-  <div id="accordion-1-content" role="region" class="Accordion-module_accordionContent__1umso" aria-labelledby="accordion-1-heading" style="">
+  <div id="accordion-{{ accordionid }}-content" role="region" class="Accordion-module_accordionContent__1umso" aria-labelledby="accordion-{{ id }}-heading" style="">
     {% if errors %}
       <div>
         {{ errors }}


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->
Technical accessibility fix.

## What was done
<!-- Describe what was done -->

* the Details accordion have unique ids.
* The aria label points to the correct element (the title was missing)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-689-duplicate-id-in-details`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that on avustuslomake esikatsele page the accordions have unique ID:s and the aria-label matches the id of the title element of the detail.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
