### PR TITLE
fix: AU-XX Corrent wrong translations in grants_handler .po

### DIFF
--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -251,10 +251,10 @@ msgid "Name (z-a)"
 msgstr "Hakemuksen nimi (ö-a)"
 
 msgid "Application number (a-z)"
-msgstr "Rajaa hakua"
+msgstr "Hakemusnumero (a-ö)"
 
 msgid "Application number (z-a)"
-msgstr "Rajaa hakua"
+msgstr "Hakemusnumero (ö-a)"
 
 msgid "Application number"
 msgstr "Hakemusnumero"


### PR DESCRIPTION
# [AU-XX]

Fix two broken Finnish translations in the .po file.