### PR TITLE
AU-717: reorder blocks

### DIFF
--- a/conf/cmi/block.block.announcements_2.yml
+++ b/conf/cmi/block.block.announcements_2.yml
@@ -8,7 +8,7 @@ dependencies:
     - hdbt_subtheme
 id: announcements_2
 theme: hdbt_subtheme
-region: before_content
+region: breadcrumb
 weight: -13
 provider: null
 plugin: announcements

--- a/conf/cmi/block.block.hdbt_subtheme_breadcrumbs.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_breadcrumbs.yml
@@ -11,7 +11,7 @@ _core:
 id: hdbt_subtheme_breadcrumbs
 theme: hdbt_subtheme
 region: breadcrumb
-weight: -11
+weight: -14
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_messages.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_messages.yml
@@ -10,8 +10,8 @@ _core:
   default_config_hash: cIXgZqCUh5llJLOsOxqd5Tfm0ExTbsfImZVx3yS_jsA
 id: hdbt_subtheme_messages
 theme: hdbt_subtheme
-region: messages
-weight: -3
+region: content
+weight: -14
 provider: null
 plugin: system_messages_block
 settings:

--- a/conf/cmi/block.block.sivunotsikko.yml
+++ b/conf/cmi/block.block.sivunotsikko.yml
@@ -9,7 +9,7 @@ dependencies:
 id: sivunotsikko
 theme: hdbt_subtheme
 region: content
-weight: -14
+weight: -13
 provider: null
 plugin: page_title_block
 settings:


### PR DESCRIPTION
# [AU-717](https://helsinkisolutionoffice.atlassian.net/browse/AU-717)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved around announcements and status messages

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-717-reorder-blocks`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] If there are none, create an announcement in content
* [ ] Go to front page incognito and login, and you should get a status message
* [ ] Check that the order is following: Breadcrumb, announcement, hero, status message
![image](https://user-images.githubusercontent.com/26737690/219613896-8433d248-1a2c-49e0-bd55-d3f6837b1487.png)



[AU-717]: https://helsinkisolutionoffice.atlassian.net/browse/AU-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ