### PR TITLE
AU-701: show oma asiointi only when company selected

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -480,3 +480,18 @@ function hdbt_subtheme_form_alter(&$form, FormStateInterface $form_state, $form_
     $form['openid_connect_client_tunnistamo_login']['#value'] = t('Log in');
   }
 }
+
+/**
+ * Implements template_preprocess_paragraph().
+ */
+function hdbt_subtheme_preprocess_paragraph(&$variables) {
+  /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
+  $paragraph = $variables['paragraph'];
+  $parentBundle = $paragraph->bundle();
+  if ($parentBundle == 'oma_asiointi') {
+    /** @var \Drupal\grants_profile\GrantsProfileService $grantsProfileService */
+    $grantsProfileService = \Drupal::service('grants_profile.service');
+    $selectedCompany = $grantsProfileService->getSelectedCompany();
+    $variables['company'] = $selectedCompany;
+  }
+}

--- a/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--oma-asiointi.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/paragraph/paragraph--oma-asiointi.html.twig
@@ -1,4 +1,4 @@
-{% if 'helsinkiprofiili' in user.getroles(TRUE)  %}
+{% if 'helsinkiprofiili' in user.getroles(TRUE) and company is not same as NULL %}
   <div class="component component--oma-asiointi-block oma-asiointi-block">
     <div class="component__container">
       {{ content }}


### PR DESCRIPTION
# [AU-701](https://helsinkisolutionoffice.atlassian.net/browse/AU-701)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Show front page oma asiointi block only when company is selected

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-701-oma-asiointi-uusi`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to front page logged out and check that you don't see Oma asiointi -block
* [ ]  Go to front page logged in without a company selected and check that you don't see Oma asiointi -block
* [ ] Go to front page logged in with a company selected and check that you do see Oma asiointi -block


[AU-701]: https://helsinkisolutionoffice.atlassian.net/browse/AU-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ