### PR TITLE
fix: AU-591: Limit messages and applications in Oma asiointi -block to two

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.module
+++ b/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.module
@@ -25,6 +25,7 @@ function grants_oma_asiointi_theme() {
       'applicationTypes' => NULL,
       'lang' => NULL,
       'link' => NULL,
+      'allMessages' => NULL,
     ],
   ];
   $theme['grants_oma_asiointi_hero_block'] = [

--- a/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.module
+++ b/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.module
@@ -19,13 +19,14 @@ function grants_oma_asiointi_theme() {
     'render element' => 'build',
     'variables' => [
       'hascompany' => NULL,
+      'allMessages' => NULL,
       'messages' => NULL,
       'submissions' => NULL,
       'userProfileData' => NULL,
       'applicationTypes' => NULL,
       'lang' => NULL,
       'link' => NULL,
-      'allMessages' => NULL,
+      'allMessagesLink' => NULL,
     ],
   ];
   $theme['grants_oma_asiointi_hero_block'] = [

--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
@@ -198,16 +198,17 @@ class OmaAsiointiBlock extends BlockBase implements ContainerFactoryPluginInterf
     krsort($submissions);
     krsort($messages);
     $link = Link::createFromRoute($this->t('Go to My Services'), 'grants_oma_asiointi.front');
-    $allMessages = Link::createFromRoute($this->t('See all messages'), 'grants_oma_asiointi.front');
+    $allMessagesLink = Link::createFromRoute($this->t('See all messages'), 'grants_oma_asiointi.front');
     $build = [
       '#theme' => 'grants_oma_asiointi_block',
+      '#allMessages' => $messages,
       '#messages' => array_slice($messages, 0, 2),
       '#submissions' => array_slice($submissions, 0, 2),
       '#userProfileData' => $helsinkiProfileData['myProfile'],
       '#applicationTypes' => ApplicationHandler::$applicationTypes,
       '#lang' => $lang->getId(),
       '#link' => $link,
-      '#allMessages' => $allMessages,
+      '#allMessagesLink' => $allMessagesLink,
     ];
 
     return $build;

--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
@@ -195,16 +195,19 @@ class OmaAsiointiBlock extends BlockBase implements ContainerFactoryPluginInterf
     }
 
     $lang = \Drupal::languageManager()->getCurrentLanguage();
-    ksort($submissions);
+    krsort($submissions);
+    krsort($messages);
     $link = Link::createFromRoute($this->t('Go to My Services'), 'grants_oma_asiointi.front');
+    $allMessages = Link::createFromRoute($this->t('See all messages'), 'grants_oma_asiointi.front');
     $build = [
       '#theme' => 'grants_oma_asiointi_block',
-      '#messages' => $messages,
-      '#submissions' => array_slice($submissions, 0, 10),
+      '#messages' => array_slice($messages, 0, 2),
+      '#submissions' => array_slice($submissions, 0, 2),
       '#userProfileData' => $helsinkiProfileData['myProfile'],
       '#applicationTypes' => ApplicationHandler::$applicationTypes,
       '#lang' => $lang->getId(),
       '#link' => $link,
+      '#allMessages' => $allMessages,
     ];
 
     return $build;

--- a/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
+++ b/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
@@ -29,6 +29,10 @@
                   <p><a href="{{ path('grants_handler.view_application', {'submission_id': message['caseId']}) }}"><span class="hel-icon hel-icon--arrow-right hel-icon--size-s" aria-label="{{ "Open message"|t }}"></span></a></p>
               </div>
             {% endfor %}
+
+            {% if messages|length > 0 %}
+              {{ allMessages }}
+            {% endif %}
           {% else %}
             <p>{{ "No new messages"|t }}</p>
           {% endif %}

--- a/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
+++ b/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
@@ -30,7 +30,7 @@
               </div>
             {% endfor %}
 
-            {% if messages|length > 0 %}
+            {% if messages|length > 2 %}
               {{ allMessages }}
             {% endif %}
           {% else %}

--- a/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
+++ b/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
@@ -30,8 +30,8 @@
               </div>
             {% endfor %}
 
-            {% if messages|length > 2 %}
-              {{ allMessages }}
+            {% if allMessages|length > 2 %}
+              {{ allMessagesLink }}
             {% endif %}
           {% else %}
             <p>{{ "No new messages"|t }}</p>

--- a/public/modules/custom/grants_oma_asiointi/translations/fi.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/fi.po
@@ -63,7 +63,7 @@ msgstr "Yhteisön hakemukset"
 msgid "Community applications"
 msgstr "Yhteisön hakemukset"
 
-
-
+msgid "See all messages"
+msgstr "Katso kaikki viestit"
 
 

--- a/public/modules/custom/grants_oma_asiointi/translations/sv.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/sv.po
@@ -5,3 +5,6 @@ msgstr ""
 
 msgid "My data"
 msgstr "Mina uppgifter"
+
+msgid "See all messages"
+msgstr "Se alla meddelanden"


### PR DESCRIPTION
# [AU-591](https://helsinkisolutionoffice.atlassian.net/browse/AU-591)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Limit shown messages and applications to two
* Show all messages -link when over two unread messages

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-591-oma-asiointi`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that only two messages and applications are shown
* [ ] Check that you see See all messages -link if you have over two messages



[AU-591]: https://helsinkisolutionoffice.atlassian.net/browse/AU-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ