### PR TITLE
fix: AU-714: remove mystery number echo

### DIFF
--- a/public/modules/custom/grants_audit_log/src/EventSubscriber/GrantsAuditLogEventSubscriber.php
+++ b/public/modules/custom/grants_audit_log/src/EventSubscriber/GrantsAuditLogEventSubscriber.php
@@ -66,7 +66,6 @@ class GrantsAuditLogEventSubscriber implements EventSubscriberInterface {
     $userId = $this->currentUser->id();
     // Get current user.
     if ($role == 'USER') {
-      echo $userId;
       $isAuthenticatedExternally = \Drupal::service('helfi_helsinki_profiili.userdata')->isAuthenticatedExternally();
       if ($isAuthenticatedExternally) {
         $data = \Drupal::service('helfi_helsinki_profiili.userdata')->getUserData();


### PR DESCRIPTION
# [AU-714](https://helsinkisolutionoffice.atlassian.net/browse/AU-714)
Removes mystery number from views.

## What was done

* Fixed the thing.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-714-remove-mystery-number`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any of the form submission display pages where there were mystery numbers. See that there are no more of them around.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[AU-714]: https://helsinkisolutionoffice.atlassian.net/browse/AU-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ