### PR TITLE
AU-191: change title in error notice

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-form.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-form.html.twig
@@ -44,7 +44,7 @@
     <div class="hds-notification__content">
       <div class="hds-notification__label" role="heading" aria-level="2">
         <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
-        <span>{{ 'Error'|t }}</span>
+        <span>{{ 'Missing or incomplete information'|t }}</span>
       </div>
       <div class="hds-notification__body">
         <ul>

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -137,5 +137,8 @@ msgctxt "Front page latest news paragraph title"
 msgid "Latest news"
 msgstr "Ajankohtaista avustuksista"
 
+msgid "Missing or incomplete information"
+msgstr "Puuttuvat tai vajaat tiedot"
+
 msgid "Error in page"
 msgstr "Virhe sivulla"

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -11,3 +11,10 @@ msgstr "Avsluta från ansökningshandling"
 
 msgid 'Are you sure you want to leave? Leave without saving.'
 msgstr "Är du säker att du vill stänga blanketten? Avsluta utan att spara."
+
+msgid "Missing or incomplete information"
+msgstr "Saknade eller ofullständig information"
+
+msgid "Error in page"
+msgstr "Fel på sidan"
+


### PR DESCRIPTION
# [AU-191](https://helsinkisolutionoffice.atlassian.net/browse/AU-191)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change title in error notice

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-191-virheilmoitus-title`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go fill an application, go to second tab and check that error notice title is "Puuttuvat tai vajaat tiedot"



[AU-191]: https://helsinkisolutionoffice.atlassian.net/browse/AU-191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ