### PR TITLE
AU-682 Handle mandate process interruptions properly

### DIFF
--- a/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
+++ b/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
@@ -15,7 +15,6 @@ use Drupal\grants_mandate\GrantsMandateService;
 use Drupal\grants_profile\GrantsProfileService;
 use Laminas\Diactoros\Response\RedirectResponse;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\grants_mandate\GrantsMandateException;
 
 /**
  * Returns responses for grants_mandate routes.
@@ -69,7 +68,7 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
   protected LoggerChannel $logger;
 
   /**
-   * CompanyController constructor.
+   * Grants Mandate Controller constructor.
    */
   public function __construct(
     RequestStack $requestStack,
@@ -103,9 +102,9 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
    * Callback for YPA service in DVV valtuutuspalvelu.
    *
    * @return \Laminas\Diactoros\Response\RedirectResponse
-   *   REdirect to profile page.
+   *   Redirect to profile page in case of success. Return
+   *   to mandate login page in case of error.
    *
-   * @throws \GrantsMandateException
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function mandateCallbackYpa() {
@@ -138,7 +137,10 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
 
       $this->logger->error('Error: %error', ['%error' => $msg->render()]);
 
-      throw new GrantsMandateException("Code Exchange failed, state: " . $state);
+      $this->messenger()->addError(t('Mandate process was interrupted or there was an error. Please try again.'));
+      // Redirect user to grants profile page.
+      $redirectUrl = Url::fromRoute('grants_mandate.mandateform');
+      return new RedirectResponse($redirectUrl->toString());
     }
 
     // Redirect user to grants profile page.


### PR DESCRIPTION
# [AU-682](https://helsinkisolutionoffice.atlassian.net/browse/AU-682)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-682-mandate-interruption`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as test user.
* [ ] Go to mandate login page
* [ ] Start login but press 'Keskeytä' instead of going thourgh the login
* [ ] You return to mandate login page and see error message instead of mysterious white page of death.



[AU-682]: https://helsinkisolutionoffice.atlassian.net/browse/AU-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ