### PR TITLE
AU-755: style yhteisön tiedot in application

### DIFF
--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -50,6 +50,9 @@ elements: |-
       '#attributes':
         class:
           - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': '<div class="grants-profile-prh-info">Tiedot on haettu Patentti- ja rekisterihallinnon rekisteristä (PRH), eikä niitä voi tämän takia muokata.</div>'
       applicant_type:
         '#type': hidden
         '#title': 'Hakijan tyyppi'
@@ -57,30 +60,20 @@ elements: |-
         '#type': textfield
         '#title': 'Yhteisön nimi'
         '#readonly': true
-        '#required': true
       grants_profile__items_container:
         '#type': container
         company_number:
           '#type': textfield
           '#title': Y-Tunnus
           '#readonly': true
-          '#required': true
-        registration_date:
-          '#type': textfield
-          '#title': Rekisteröimispäivä
-          '#readonly': true
-          '#required': true
         home:
           '#type': textfield
           '#title': Kotipaikka
           '#readonly': true
-          '#required': true
-      prh_markup:
-        '#type': webform_markup
-        '#markup': |-
-          <div class="grants-profile-prh-info">
-                      <span aria-hidden="true" class="hel-icon hel-icon--check-circle-fill hel-icon--size-s"></span> Merkityt tiedot on haettu Patentti- ja rekisterihallinnon rekisteristä (PRH), eikä niitä voi tämän takia muokata.
-                    </div>
+        registration_date:
+          '#type': textfield
+          '#title': Rekisteröimispäivä
+          '#readonly': true
     perustamisvuosi:
       '#type': webform_section
       '#title': Perustamisvuosi
@@ -475,9 +468,9 @@ elements: |-
         '#options':
           1: Kyllä
           0: Ei
-        '#required': true
         '#options_display': side_by_side
         '#options_description_display': help
+        '#required': true
     ensimmainen_otsikko:
       '#type': webform_section
       '#title': Jäsenmaksut

--- a/public/modules/custom/grants_handler/templates/profile-data-icon.html.twig
+++ b/public/modules/custom/grants_handler/templates/profile-data-icon.html.twig
@@ -1,1 +1,1 @@
-{{ text_value }} {% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'check-circle-fill'} %}
+{{ text_value }}

--- a/public/themes/custom/hdbt_subtheme/src/scss/components/grants-profile/_grants-profile.scss
+++ b/public/themes/custom/hdbt_subtheme/src/scss/components/grants-profile/_grants-profile.scss
@@ -178,7 +178,6 @@ div.grants-handler--prefilled-field, .grants-profile-prh-info {
   }
   .webform-element-description {
     color: var(--color-black);
-    font-size: var(--fontsize-body-l);
     line-height: var(--spacing-m);
     position: relative;
   }
@@ -187,14 +186,22 @@ div.grants-handler--prefilled-field, .grants-profile-prh-info {
   }
 }
 .grants-profile--imported-section .webform-section-flex-wrapper {
-  display:block;
+  background-color: var(--color-silver-light);
+  padding-top: var(--spacing-l);
+  padding-left: var(--spacing-l);
+  padding-right: var(--spacing-l);
+  padding-bottom: var(--spacing-2-xs);
+  border-bottom: 8px solid var(--color-engel-dark);
+  display: block;
   width: 100%;
+
   h2.webform-section-title {
+    font-size: var(--fontsize-heading-l);
+    padding-top: 0;
+    margin-top: 0;
     width: 100%;
-    padding-bottom: var(--spacing-layout-xs);
-    margin-bottom: var(--spacing-layout-xs);
-    max-width: 100%;
-    border-bottom: 1px var(--color-silver) solid;
+    font-weight: 400;
+    max-width: 100%
   }
   .webform-section-wrapper {
     padding: 0;
@@ -203,11 +210,7 @@ div.grants-handler--prefilled-field, .grants-profile-prh-info {
     margin-bottom: 0;
   }
   #edit-grants-profile-items-container {
-    border-top: 1px var(--color-silver) solid;
-    border-bottom: 1px var(--color-silver) solid;
     margin-top: var(--spacing-layout-xs);
-    padding-top: var(--spacing-layout-xs);
-    padding-bottom: var(--spacing-layout-xs);
     margin-bottom: var(--spacing-layout-xs);
     display: flex;
     width: 100%;
@@ -226,6 +229,11 @@ div.grants-handler--prefilled-field, .grants-profile-prh-info {
       font-weight: bold;
     }
 
+  }
+  .form-item-prh-markup {
+    padding-bottom: var(--spacing-layout-xs);
+    padding-top: var(--spacing-layout-xs);
+    border-bottom: 2px solid var(--color-silver);
   }
 }
 .grants-profile__local-tasks__wrapper {


### PR DESCRIPTION
# [AU-755](https://helsinkisolutionoffice.atlassian.net/browse/AU-755)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-755-kayttajatiedot-lomake`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as end user and go fill an application
* [ ] Check that yhteisön tiedot is styled as in the picture

![image](https://user-images.githubusercontent.com/26737690/224346723-59e27ac9-6368-4eb8-860f-73c6c6f33fa6.png)
