### PR TITLE
fix: AU-734 accordion to match the current version of accordion

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/content/node--faq.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/content/node--faq.html.twig
@@ -68,21 +68,30 @@
  * @ingroup themeable
  */
 #}
-{{ attach_library('hdbt/accordion') }}
-<div class="component--accordion">
-  <div class="accordion__wrapper handorgel">
 
-    <{{ heading_level|default('h3') }} class="accordion-item__header handorgel__header">
-    <button class="accordion-item__button accordion-item__button--toggle handorgel__header__button">
-      {{ label|default('Missing heading'|t) }}
+{{ attach_library('hdbt/accordion') }}
+
+{% set accordion_id = "accordion-item--" ~ random() %}
+{% set controlled_content_id = "accordion-item-content--" ~ random() %}
+{% set close_button_labelled_by_id = "accordion-item__button--close--" ~ random() %}
+
+<div class="accordion__wrapper helfi-accordion-item" data-accordion-id="{{ accordion_id }}">
+  <{{ heading_level|default('h3') }} class="accordion-item__header helfi-accordion__header" data-accordion-id="{{ accordion_id }}">
+  <button class="accordion-item__button accordion-item__button--toggle helfi-accordion__header__button" aria-expanded="true" aria-controls="{{ controlled_content_id }}">
+
+    {{ label|default('Missing heading'|t) }}
+  </button>
+</{{ heading_level|default('h3')}}>
+<div class="accordion-item__content helfi-accordion__content" id="{{ controlled_content_id }}">
+  <div class="accordion-item__content__inner helfi-accordion__content__inner">
+
+    {{ content|default('Missing content'|t) }}
+
+    <button class="accordion-item__button accordion-item__button--close" aria-controls="{{ controlled_content_id }}" aria-labelledby="{{ close_button_labelled_by_id }}">
+      <span class="is-hidden" id="{{ close_button_labelled_by_id }}">{{ 'Close element: '|t({}, {'context': 'The helper text for close accordion visibility button'}) }}{{ label|default('Missing heading'|t) }}</span>
+      {{ 'Close'|t }}
     </button>
-  </{{ heading_level|default('h3')}}>
-  <div class="accordion-item__content handorgel__content">
-    <div class="accordion-item__content__inner handorgel__content__inner">
-      {{ content|default('Missing content'|t) }}
-      <span class="accordion-item__button accordion-item__button--close" role="button" tabindex="0">
-        {{ 'Close'|t }}{% include '@hdbt/misc/icon.twig' ignore missing with {icon: 'angle-up'} %}
-      </span>
-    </div>
   </div>
 </div>
+</div>
+

--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--ukk.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--ukk.html.twig
@@ -109,7 +109,7 @@
                 {% endif %}
 
                 {% if rows %}
-                    <div class="view-content">
+                    <div class="view-content component--accordion">
                         {{ rows }}
                     </div>
                 {% elseif empty %}


### PR DESCRIPTION
# [AU-734 - Fix Broken Accordions](https://helsinkisolutionoffice.atlassian.net/browse/AU-734)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Made the accordions on the UKK page match the accordions that are used on the TPR pages to fix the broken functionality after the fix of functionality in the other PR.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-734-accordion-faq-page`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to the FAQ page, check that the accordion works
* [ ] Go to the TPR page, see that the accordion works.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/202
