### PR TITLE
AU-732 Update audit log module version to include tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_ahjo": "^1.0",
         "drupal/helfi_atv": "^0.9.0",
-        "drupal/helfi_audit_log": "0.9",
+        "drupal/helfi_audit_log": "dev-feature/AU-732-add-test",
         "drupal/helfi_azure_fs": "^1.1",
         "drupal/helfi_drupal_tools": "dev-main",
         "drupal/helfi_formtool_embed": "dev-develop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b3a97966a2a57e67f901d753731f209",
+    "content-hash": "e3a9e6f263583d2d9583dee687ee1100",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5621,16 +5621,16 @@
         },
         {
             "name": "drupal/helfi_audit_log",
-            "version": "0.9",
+            "version": "dev-feature/AU-732-add-test",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log.git",
-                "reference": "f76d8cad31b59254cbcff890699ba98aca425996"
+                "reference": "dc260a2cecd904b76de8604b166078820543d92e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/f76d8cad31b59254cbcff890699ba98aca425996",
-                "reference": "f76d8cad31b59254cbcff890699ba98aca425996",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/dc260a2cecd904b76de8604b166078820543d92e",
+                "reference": "dc260a2cecd904b76de8604b166078820543d92e",
                 "shasum": ""
             },
             "require-dev": {
@@ -5643,10 +5643,10 @@
             ],
             "description": "Helfi - Audit log",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/0.9",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/feature/AU-732-add-test",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/issues"
             },
-            "time": "2023-02-09T08:48:43+00:00"
+            "time": "2023-03-14T11:13:29+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",
@@ -7802,10 +7802,6 @@
                 "GPL"
             ],
             "authors": [
-                {
-                    "name": "crawleyhost",
-                    "homepage": "https://www.drupal.org/user/3636059"
-                },
                 {
                     "name": "fmitchell",
                     "homepage": "https://www.drupal.org/user/213574"
@@ -20570,6 +20566,7 @@
     "stability-flags": {
         "drupal/block_field": 5,
         "drupal/content_access": 15,
+        "drupal/helfi_audit_log": 20,
         "drupal/helfi_drupal_tools": 20,
         "drupal/helfi_formtool_embed": 20,
         "drupal/helfi_yjdh": 20,


### PR DESCRIPTION
Do not merge this PR!

# [AU-732](https://helsinkisolutionoffice.atlassian.net/browse/AU-732)
<!-- What problem does this solve? -->
Audit log module received new tests. This PR enables running them easily.

## What was done
<!-- Describe what was done -->

* New tests and configuration for audit log module

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature\AU-732-add-tests`
  * `make fresh` or `composer install`
  

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Run `vendor/bin/phpunit -c public/core public/modules/contrib/helfi_audit_log` in Drupal root

## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR](https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/pull/3)


[AU-732]: https://helsinkisolutionoffice.atlassian.net/browse/AU-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ