### PR TITLE
fix: AU-796: Fix subvention validations.

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -558,7 +558,10 @@ class ApplicationHandler {
       $thirdPartySettings = $wf->getThirdPartySettings('grants_metadata');
 
       $thisApplicationTypeConfig = array_filter($applicationTypes, function ($appType) use ($thirdPartySettings) {
-        if (isset($thirdPartySettings["applicationTypeID"]) && $thirdPartySettings["applicationTypeID"] === (string) $appType["applicationTypeId"]) {
+        if (
+          isset($thirdPartySettings["applicationTypeID"]) &&
+          $thirdPartySettings["applicationTypeID"] ===
+          (string) $appType["applicationTypeId"]) {
           return TRUE;
         }
         return FALSE;

--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -70,8 +70,10 @@ class CompensationsComposite extends WebformCompositeBase {
     $zeroes = 0;
     unset($values['subventions']['items']);
     foreach ($values['subventions'] as $item) {
-      if ($item['amount'] == '0,00€' || empty($item['amount'])) {
-        $zeroes++;
+      if(isset($item['amount'])){
+        if ($item['amount'] == '0,00€' || empty($item['amount'])) {
+          $zeroes++;
+        }
       }
     }
 

--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -70,7 +70,7 @@ class CompensationsComposite extends WebformCompositeBase {
     $zeroes = 0;
     unset($values['subventions']['items']);
     foreach ($values['subventions'] as $item) {
-      if(isset($item['amount'])){
+      if (isset($item['amount'])) {
         if ($item['amount'] == '0,00€' || empty($item['amount'])) {
           $zeroes++;
         }

--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -78,7 +78,7 @@ class CompensationsComposite extends WebformCompositeBase {
     }
 
     if ($zeroes === $subventionNumber) {
-      $formState->setErrorByName('subventions', t('You must insert atleast one subvention amount'));
+      $formState->setErrorByName('subventions', t('You must insert at least one subvention amount'));
     }
   }
 

--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -28,9 +28,6 @@ class CompensationsComposite extends WebformCompositeBase {
   public static function getCompositeElements(array $element): array {
     $elements = [];
 
-    // $elements['subvention_type_id'] = [
-    // '#type' => 'hidden',
-    // ];
     $elements['subventionTypeTitle'] = [
       '#type' => 'textfield',
       '#title' => t('Subvention name'),
@@ -44,20 +41,51 @@ class CompensationsComposite extends WebformCompositeBase {
     $elements['amount'] = [
       '#type' => 'textfield',
       '#title' => t('Subvention amount'),
-      '#required' => TRUE,
       '#input_mask' => "'alias': 'currency', 'prefix': '', 'suffix': '€','groupSeparator': ' ','radixPoint':','",
       '#attributes' => ['class' => ['input--borderless']],
+      '#element_validate' => ['\Drupal\grants_handler\Element\CompensationsComposite::validateAmount'],
     ];
 
     return $elements;
   }
 
   /**
+   * Validate subvention amount.
+   *
+   * The rule here is that in SOME field must have amount inserted.
+   * So this errors if no values are given.
+   *
+   * @param array $element
+   *   Element tobe validated.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   Form state.
+   * @param array $form
+   *   The form.
+   */
+  public static function validateAmount(array &$element, FormStateInterface $formState, array &$form) {
+
+    $values = $formState->getValues();
+
+    $subventionNumber = count($values['subventions']['items']);
+    $zeroes = 0;
+    unset($values['subventions']['items']);
+    foreach ($values['subventions'] as $item) {
+      if ($item['amount'] == '0,00€' || empty($item['amount'])) {
+        $zeroes++;
+      }
+    }
+
+    if ($zeroes === $subventionNumber) {
+      $formState->setErrorByName('subventions', t('You must insert atleast one subvention amount'));
+    }
+  }
+
+  /**
    * {@inheritdoc}
    */
-  public static function valueCallback(&$element, $input, FormStateInterface $form_state) {
+  public static function valueCallback(&$element, $input, FormStateInterface $formState) {
 
-    $parent = parent::valueCallback($element, $input, $form_state);
+    $parent = parent::valueCallback($element, $input, $formState);
 
     if (!empty($parent)) {
       return $parent;
@@ -69,21 +97,10 @@ class CompensationsComposite extends WebformCompositeBase {
     ];
 
     if (isset($parent['subventionType']) && $parent['subventionType'] != "") {
-      // $retval['subvention_type_id'] = $parent['subventionType'];
       $retval['subventionType'] = $parent['subventionType'];
       $retval['amount'] = $parent['amount'];
-      // $retval['subventionType'] = $typeOptions[$parent['subventionType']];
     }
     return $retval;
-  }
-
-  /**
-   * Processes a composite webform element.
-   */
-  public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form) {
-    $element = parent::processWebformComposite($element, $form_state, $complete_form);
-
-    return $element;
   }
 
 }

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -355,3 +355,7 @@ msgstr "Täytetty"
 msgctxt "Unset Profile Fields"
 msgid "Unknown"
 msgstr "Ei tiedossa"
+
+msgid "You must insert at least one subvention amount"
+msgstr "Sinun on syötettävä vähintään yhdelle avustuslajille summa"
+

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -24,3 +24,6 @@ msgstr "Avslutad"
 msgctxt "Unset Profile Fields"
 msgid "Unknown"
 msgstr "Okänt"
+
+msgid "You must insert at least one subvention amount"
+msgstr "Du måste föra in minst ett subventionsbelopp"


### PR DESCRIPTION
# [AU-796](https://helsinkisolutionoffice.atlassian.net/browse/AU-796)
<!-- What problem does this solve? -->

There was error in subvention validations, where you had to have ALL fields in subventions filled or form errored. Desired functionality is that ONE of the fields is required, no matter what that is.

## What was done
<!-- Describe what was done -->

* Added validation for subvention fields that check empty or 0,00€ values

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to KASKO form, create a new one.
* [x] Leave subvention values as defaults and try to go to next page. Should see error.
* [ ] Same thing with values inserted and then removed, should fail.
* [ ] And the code standards.




[AU-796]: https://helsinkisolutionoffice.atlassian.net/browse/AU-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ