### PR TITLE
fix: AU-800: Add cache contexts for ServicePageAuthBlock

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
@@ -42,7 +42,7 @@ class ServicePageAuthBlock extends BlockBase implements ContainerFactoryPluginIn
    *   The plugin_id for the plugin instance.
    * @param mixed $pluginDefinition
    *   The plugin implementation definition.
-   * @param \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData $helfi_helsinki_profiili
+   * @param \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData $helfiHelsinkiProfiili
    *   The helfi_helsinki_profiili service.
    */
   public function __construct(array $configuration, $pluginId, $pluginDefinition, HelsinkiProfiiliUserData $helfiHelsinkiProfiili) {
@@ -126,7 +126,10 @@ class ServicePageAuthBlock extends BlockBase implements ContainerFactoryPluginIn
     $build['content'] = [
       '#markup' => $link->toString(),
     ];
-
+    $build['#cache']['contexts'] = [
+      'languages:language_content',
+      'url.path',
+    ];
     return $build;
   }
 


### PR DESCRIPTION
# [AU-800](https://helsinkisolutionoffice.atlassian.net/browse/AU-800)
<!-- What problem does this solve? -->

ServicePageAuthBlock shows now correct links in service pages.

## What was done
<!-- Describe what was done -->

Cache contexts were added to the block.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-800-block-cache`
  * `make fresh`
* Run `make drush-cr`
*  Enable caching



## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Visit service page and check that block has correct link 
* [ ] Visti another service page and check that the block shows correct and different link

