### PR TITLE
feat: AU-695: allowed roles

### DIFF
--- a/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
+++ b/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
@@ -68,6 +68,13 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
   protected LoggerChannel $logger;
 
   /**
+   * Allowed roles.
+   *
+   * @var array
+   */
+  protected array $allowedRoles;
+
+  /**
    * Grants Mandate Controller constructor.
    */
   public function __construct(
@@ -83,6 +90,35 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
     $this->grantsMandateService = $grantsMandateService;
     $this->grantsProfileService = $grantsProfileService;
     $this->logger = $this->getLogger('grants_mandate');
+    $this->allowedRoles = [
+      'http://valtuusrekisteri.suomi.fi/avustushakemuksen_tekeminen',
+      'PJ',
+      'J',
+    ];
+    $config = \Drupal::config('grants_mandate.settings');
+    $extraRoles = $config->get('extra_access_roles');
+    if ($extraRoles && is_array($extraRoles)) {
+      $this->allowedRoles = array_merge($this->allowedRoles, $extraRoles);
+    }
+  }
+
+  /**
+   * Check if user has required role in their mandate.
+   *
+   * @var array $roles
+   *   Array of user's roles.
+   *
+   * @return bool
+   *   Is user allowed to use this mandate.
+   */
+  protected function hasAllowedRole(array $roles) {
+    $allowedRoles = $this->allowedRoles;
+    foreach ($roles as $role) {
+      if (in_array($role, $allowedRoles)) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**
@@ -118,6 +154,17 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
     if (is_string($code) && $code != '') {
       $this->grantsMandateService->changeCodeToToken($code, $callbackUrl);
       $roles = $this->grantsMandateService->getRoles();
+      $isAllowed = FALSE;
+      if ($roles && isset($roles[0]) && $roles[0]['roles']) {
+        $rolesArray = $roles[0]['roles'];
+        $isAllowed = $this->hasAllowedRole($rolesArray);
+      }
+      if (!$isAllowed) {
+        $this->messenger()->addError(t('Your mandate does not allow you to use this service.'));
+        // Redirect user to grants profile page.
+        $redirectUrl = Url::fromRoute('grants_mandate.mandateform');
+        return new RedirectResponse($redirectUrl->toString());
+      }
 
       $this->grantsProfileService->setSelectedCompany(reset($roles));
     }

--- a/public/modules/custom/grants_mandate/translations/fi.po
+++ b/public/modules/custom/grants_mandate/translations/fi.po
@@ -45,4 +45,5 @@ msgstr "Sinulla pitää olla yhteisö ja valtuutus valittuna ennen hakemuksen j�
 msgid "Mandate process was interrupted or there was an error. Please try again."
 msgstr "Valtuutusprosessi keskeytyi, yritä uudelleen."
 
-
+msgid "Your mandate does not allow you to use this service."
+msgstr "Valtuutuksesi ei sallin sinun käyttää tätä palvelua."

--- a/public/sites/default/development.settings.php
+++ b/public/sites/default/development.settings.php
@@ -1,10 +1,3 @@
 <?php
 
-#$config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/dev-avustukset/openid-connect/tunnistamo';
-
-$config['helfi_proxy.settings']['asset_path'] = 'dev-avustukset-assets';
-$config['helfi_proxy.settings']['prefixes'] = [
-  'en' => 'dev-grants',
-  'fi' => 'dev-avustukset',
-  'sv' => 'dev-bidrags'
-];
+$config['grants_mandate.settings']['extra_access_roles'] = ['NIMKO'];

--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -1,1 +1,2 @@
 <?php
+$config['grants_mandate.settings']['extra_access_roles'] = ['NIMKO'];

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -1,1 +1,2 @@
 <?php
+$config['grants_mandate.settings']['extra_access_roles'] = ['NIMKO'];


### PR DESCRIPTION
# [AU-695](https://helsinkisolutionoffice.atlassian.net/browse/AU-695)
<!-- What problem does this solve? -->

Nyt koodi tarkastaa valtuutusvaiheessa että käyttäjällä on asianmukainen pääsyoikeus.

Moduulissa on kovakoodattu lista sallituista rooleista mutta listaan voi lisätä rooleja konfiguraation kautta. Tässä on yritetty tasapainoilla työmäärän ja DX:n välillä.

## How to install

* Make sure your instance is up and running on correct branch.
  * `feature/AU-695-allowed-roles`
  * `make fresh`
* Run `make drush-cr`
* TMuokkaa local-settings.php tiedostoa ja lisää sinne `$config['grants_mandate.settings']['extra_access_roles'] = ['NIMKO'];` jolloin testiyrityksien valtuutusprosessi onnistuu.

Tämä muutos pitää tehdä tarvittaessa testipalvelimelle ja kaikkien kehittäjien koneille joten älä mergeä tätä ilman että kaikki ovat tietoisia muutos tarpeesta.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Kirjaudu sisään.
* [ ] Hanki valtuutus
* [ ] Mikäli oikeudet eivät riitä niin tulee virhe-ilmoitus
* [ ] Jos oikeudet ovat kunnossa prosessi etenee kuten ennenkin
Huomaa että testidatassa roolit eivät vastaa tuotantoa. 

[AU-695]: https://helsinkisolutionoffice.atlassian.net/browse/AU-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ