### PR TITLE
fix: AU-792: Add subscriber to handle guzzle errors

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.services.yml
+++ b/public/modules/custom/grants_handler/grants_handler.services.yml
@@ -82,3 +82,9 @@ services:
     arguments: ['@messenger']
     tags:
       - { name: event_subscriber }
+
+  grants_handler.handle_http_errors:
+    class: Drupal\grants_handler\EventSubscriber\GuzzleHttpErrorExceptionSubscriber
+    arguments: ['@messenger']
+    tags:
+      - { name: event_subscriber }

--- a/public/modules/custom/grants_handler/src/EventSubscriber/GuzzleHttpErrorExceptionSubscriber.php
+++ b/public/modules/custom/grants_handler/src/EventSubscriber/GuzzleHttpErrorExceptionSubscriber.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\grants_handler\EventSubscriber;
+
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Url;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Grants Handler event subscriber.
+ */
+class GuzzleHttpErrorExceptionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs event subscriber.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
+   */
+  public function __construct(MessengerInterface $messenger) {
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * Kernel response event handler.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   *   Response event.
+   */
+  public function onException(ExceptionEvent $event) {
+    $ex = $event->getThrowable();
+    $exceptionClass = get_class($ex);
+    if (str_starts_with($exceptionClass, 'GuzzleHttp\Exception')) {
+      $this->messenger->addError(t('Your request was not fulfilled due to network error.'));
+      // Redirect back to same page because could cause infinite loop.
+      $url = Url::fromRoute('<front>');
+      $response = new RedirectResponse($url->toString());
+      $event->setResponse($response);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      KernelEvents::EXCEPTION => ['onException'],
+    ];
+  }
+
+}

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -367,3 +367,6 @@ msgstr "1 uusi viesti"
 
 msgid "@count new messages"
 msgstr "@count uutta viestiä"
+
+msgid "Your request was not fulfilled due to network error."
+msgstr: "Pyyntösi keskeytyi verkkovirheen takia."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -33,3 +33,6 @@ msgstr "1 nytt meddelande"
 
 msgid "@count new messages"
 msgstr "@count nya meddelanden"
+
+msgid "Your request was not fulfilled due to network error."
+msgstr: "Your request was not fulfilled due to network error."


### PR DESCRIPTION
# [AU-792](https://helsinkisolutionoffice.atlassian.net/browse/AU-792)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add event handler to catch guzzle errors

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-792-http-errors`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Modify atv address in settings.php to be non existent
* [ ] Login and get mandate. Try to go to [Oma asiointi](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi). 
* [ ] Instead of white error page you go to front page with error message visible

Technically this works well. Practical issue that error message is not on top of the front page.


[AU-792]: https://helsinkisolutionoffice.atlassian.net/browse/AU-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ