### PR TITLE
fix: AU-820: Update ATV.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5588,16 +5588,16 @@
         },
         {
             "name": "drupal/helfi_atv",
-            "version": "0.9.4",
+            "version": "0.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv.git",
-                "reference": "0ce9c0bfcb16331c038952f01f42c88d09770f9e"
+                "reference": "6246f0e3bca12c6c185020cded19cbc54be5419b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/0ce9c0bfcb16331c038952f01f42c88d09770f9e",
-                "reference": "0ce9c0bfcb16331c038952f01f42c88d09770f9e",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/6246f0e3bca12c6c185020cded19cbc54be5419b",
+                "reference": "6246f0e3bca12c6c185020cded19cbc54be5419b",
                 "shasum": ""
             },
             "require": {
@@ -5614,10 +5614,10 @@
             ],
             "description": "ATV integration module",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/0.9.4",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/0.9.5",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/issues"
             },
-            "time": "2023-03-21T05:33:47+00:00"
+            "time": "2023-03-24T10:45:12+00:00"
         },
         {
             "name": "drupal/helfi_audit_log",

--- a/composer.lock
+++ b/composer.lock
@@ -5738,16 +5738,16 @@
         },
         {
             "name": "drupal/helfi_gdpr_api",
-            "version": "0.9.3",
+            "version": "0.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-gdpr-api.git",
-                "reference": "263207c07ac16ec9103849548f354cacdd000695"
+                "reference": "3c24e47c9693ff5337ebb50bcf6b83bb643b42c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-gdpr-api/zipball/263207c07ac16ec9103849548f354cacdd000695",
-                "reference": "263207c07ac16ec9103849548f354cacdd000695",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-gdpr-api/zipball/3c24e47c9693ff5337ebb50bcf6b83bb643b42c9",
+                "reference": "3c24e47c9693ff5337ebb50bcf6b83bb643b42c9",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -5760,10 +5760,10 @@
                 "GPL-2.0-or-later"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-gdpr-api/tree/0.9.3",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-gdpr-api/tree/0.9.4",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-gdpr-api/issues"
             },
-            "time": "2023-03-16T07:36:17+00:00"
+            "time": "2023-03-24T12:21:19+00:00"
         },
         {
             "name": "drupal/helfi_hauki",


### PR DESCRIPTION
# [AU-820](https://helsinkisolutionoffice.atlassian.net/browse/AU-820)
<!-- What problem does this solve? -->

GDPR calls to ATV were authenticated incorrectly with JWT token, when they need to be authenticated with Apikey.

## What was done
<!-- Describe what was done -->

* ATV module was updated to 0.9.5 which uses apikey.


## Other PRs
<!-- For example an related PR in another repository -->

* [Link to other PR
](https://github.com/City-of-Helsinki/drupal-module-helfi-atv/pull/9)

[AU-820]: https://helsinkisolutionoffice.atlassian.net/browse/AU-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ