### PR TITLE
fiX: AU-691: Omat tiedot edit translations and texts

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
@@ -667,7 +667,7 @@ class GrantsProfileForm extends FormBase {
 
       $form['addressWrapper'][$delta]['address'] = [
         '#type' => 'fieldset',
-        '#title' => $this->t('Address'),
+        '#title' => $this->t('Community address'),
       ];
       $form['addressWrapper'][$delta]['address']['street'] = [
         '#type' => 'textfield',
@@ -681,7 +681,7 @@ class GrantsProfileForm extends FormBase {
       ];
       $form['addressWrapper'][$delta]['address']['city'] = [
         '#type' => 'textfield',
-        '#title' => $this->t('City/town'),
+        '#title' => $this->t('Post', [], ['context' => 'Profile Address']),
         '#default_value' => $address['city'],
       ];
       $form['addressWrapper'][$delta]['address']['country'] = [
@@ -727,7 +727,7 @@ class GrantsProfileForm extends FormBase {
           ],
           'city' => [
             '#type' => 'textfield',
-            '#title' => $this->t('City/town'),
+            '#title' => $this->t('Post', [], ['context' => 'Profile Address']),
           ],
           'country' => [
             '#type' => 'textfield',
@@ -975,7 +975,7 @@ class GrantsProfileForm extends FormBase {
       $form['bankAccountWrapper'][$delta]['bank'] = [
 
         '#type' => 'fieldset',
-        '#title' => $this->t('Community Bank Account'),
+        '#title' => $this->t('Community bank account'),
         'bankAccount' => [
           '#type' => 'textfield',
           '#title' => $this->t('Finnish bank account number in IBAN format'),
@@ -994,9 +994,7 @@ class GrantsProfileForm extends FormBase {
         ],
         'confirmationFile' => [
           '#type' => 'managed_file',
-          '#title' => $this->t("Attach a certificate of account access:
-        bank's notification of the account owner or a copy of
-        a bank statement."),
+          '#title' => $this->t("Attach a certificate of account access: bank's notification of the account owner or a copy of a bank statement."),
           '#multiple' => FALSE,
         // '#required' => TRUE,
           '#uri_scheme' => 'private',
@@ -1039,7 +1037,7 @@ rtf, txt, xls, xlsx, zip.'),
 
       $form['bankAccountWrapper'][count($bankAccountValues) + 1]['bank'] = [
         '#type' => 'fieldset',
-        '#title' => $this->t('Community Bank Account'),
+        '#title' => $this->t('Community bank account'),
         'bankAccount' => [
           '#type' => 'textfield',
           '#title' => $this->t('Finnish bank account number in IBAN format'),

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
@@ -681,7 +681,7 @@ class GrantsProfileForm extends FormBase {
       ];
       $form['addressWrapper'][$delta]['address']['city'] = [
         '#type' => 'textfield',
-        '#title' => $this->t('Post', [], ['context' => 'Profile Address']),
+        '#title' => $this->t('City/town', [], ['context' => 'Profile Address']),
         '#default_value' => $address['city'],
       ];
       $form['addressWrapper'][$delta]['address']['country'] = [
@@ -727,7 +727,7 @@ class GrantsProfileForm extends FormBase {
           ],
           'city' => [
             '#type' => 'textfield',
-            '#title' => $this->t('Post', [], ['context' => 'Profile Address']),
+            '#title' => $this->t('City/town', [], ['context' => 'Profile Address']),
           ],
           'country' => [
             '#type' => 'textfield',

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -420,7 +420,7 @@ msgid "Bank account & verification attachment deleted."
 msgstr "Tilinumero ja vahvistusliite poistettiin."
 
 msgctxt "Profile Address"
-msgid "Post"
+msgid "City/town"
 msgstr "Toimipaikka"
 
 msgid "Community address"

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -85,9 +85,6 @@ msgstr "Katuosoite"
 msgid "Street address"
 msgstr "Katuosoite"
 
-msgid "City/town"
-msgstr "Toimipaikka"
-
 msgid "Postal code"
 msgstr "Postinumero"
 
@@ -421,3 +418,25 @@ msgstr "Tilinumeron vahvistusliite poistettu hakemukselta."
 
 msgid "Bank account & verification attachment deleted."
 msgstr "Tilinumero ja vahvistusliite poistettiin."
+
+msgctxt "Profile Address"
+msgid "Post"
+msgstr "Toimipaikka"
+
+msgid "Community address"
+msgstr "Yhteisön osoite"
+
+msgid "Add address"
+msgstr "Lisää osoite"
+
+msgid "Community official"
+msgstr "Yhteisön vastuuhenkilö"
+
+msgid "Add official"
+msgstr "Lisää vastuuhenkilö"
+
+msgid "Community bank account"
+msgstr "Yhteisön pankkitili"
+
+msgid "Add bank account"
+msgstr "Lisää pankkitili"

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -60,9 +60,6 @@ msgstr "Gatuadress"
 msgid "Postal code"
 msgstr "Postnummer"
 
-msgid "City/town"
-msgstr "Verksamhetsställe"
-
 msgid "Country"
 msgstr "Land"
 
@@ -167,8 +164,8 @@ msgid "Bank account & verification attachment deleted."
 msgstr "Bankkonto & verifieringsbilaga raderade."
 
 msgctxt "Profile Address"
-msgid "Post"
-msgstr "Posta"
+msgid "City/town"
+msgstr "Verksamhetsställe"
 
 msgid "Community address"
 msgstr "Gemenskapsadress"

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -165,3 +165,25 @@ msgstr "Bilaga för verifiering av bankkonto raderad."
 
 msgid "Bank account & verification attachment deleted."
 msgstr "Bankkonto & verifieringsbilaga raderade."
+
+msgctxt "Profile Address"
+msgid "Post"
+msgstr "Posta"
+
+msgid "Community address"
+msgstr "Gemenskapsadress"
+
+msgid "Add address"
+msgstr "Lägg till adress"
+
+msgid "Community official"
+msgstr "Gemenskapstjänsteman"
+
+msgid "Add official"
+msgstr "Lägg till tjänsteman"
+
+msgid "Community bank account"
+msgstr "Gemenskapens bankkonto"
+
+msgid "Add bank account"
+msgstr "Lägg till bankkonto"


### PR DESCRIPTION
# [AU-691](https://helsinkisolutionoffice.atlassian.net/browse/AU-691)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix translations for Omat tiedot edit

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-691-omat-tiedot-tekstit`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR has been visually reviewed by a designer (Heikki)



[AU-691]: https://helsinkisolutionoffice.atlassian.net/browse/AU-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ