### PR TITLE
AU-756: Display blocks on login page

### DIFF
--- a/conf/cmi/block_content.type.login_page_info.yml
+++ b/conf/cmi/block_content.type.login_page_info.yml
@@ -1,0 +1,8 @@
+uuid: 7f984bb2-b0d9-4c14-b55e-7a91eac4bfa7
+langcode: fi
+status: true
+dependencies: {  }
+id: login_page_info
+label: 'Login page info'
+revision: 0
+description: ''

--- a/conf/cmi/core.entity_form_display.block_content.login_page_info.default.yml
+++ b/conf/cmi/core.entity_form_display.block_content.login_page_info.default.yml
@@ -1,0 +1,52 @@
+uuid: b03da204-bea8-44e1-b1ce-4852c874fee0
+langcode: fi
+status: true
+dependencies:
+  config:
+    - block_content.type.login_page_info
+    - field.field.block_content.login_page_info.body
+    - field.field.block_content.login_page_info.field_login_type
+  module:
+    - text
+id: block_content.login_page_info.default
+targetEntityType: block_content
+bundle: login_page_info
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 26
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  field_login_type:
+    type: options_select
+    weight: 27
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_view_display.block_content.login_page_info.default.yml
+++ b/conf/cmi/core.entity_view_display.block_content.login_page_info.default.yml
@@ -1,0 +1,25 @@
+uuid: 867b8e74-fe79-4b31-aa09-b77d39cd4d94
+langcode: fi
+status: true
+dependencies:
+  config:
+    - block_content.type.login_page_info
+    - field.field.block_content.login_page_info.body
+    - field.field.block_content.login_page_info.field_login_type
+  module:
+    - text
+id: block_content.login_page_info.default
+targetEntityType: block_content
+bundle: login_page_info
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_login_type: true
+  langcode: true

--- a/conf/cmi/field.field.block_content.login_page_info.body.yml
+++ b/conf/cmi/field.field.block_content.login_page_info.body.yml
@@ -1,0 +1,23 @@
+uuid: 929f6cfe-e507-4e30-9b35-3c4392db8f17
+langcode: fi
+status: true
+dependencies:
+  config:
+    - block_content.type.login_page_info
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.login_page_info.body
+field_name: body
+entity_type: block_content
+bundle: login_page_info
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+  required_summary: false
+field_type: text_with_summary

--- a/conf/cmi/field.field.block_content.login_page_info.field_login_type.yml
+++ b/conf/cmi/field.field.block_content.login_page_info.field_login_type.yml
@@ -1,0 +1,23 @@
+uuid: e2b7abad-4c90-4f0a-af35-03647b53dd7b
+langcode: fi
+status: true
+dependencies:
+  config:
+    - block_content.type.login_page_info
+    - field.storage.block_content.field_login_type
+  module:
+    - options
+id: block_content.login_page_info.field_login_type
+field_name: field_login_type
+entity_type: block_content
+bundle: login_page_info
+label: 'Login type'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: 'No authentication'
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/conf/cmi/field.field.block_content.login_page_info.field_login_type.yml
+++ b/conf/cmi/field.field.block_content.login_page_info.field_login_type.yml
@@ -12,12 +12,12 @@ field_name: field_login_type
 entity_type: block_content
 bundle: login_page_info
 label: 'Login type'
-description: ''
+description: 'Avustusasioinnissa tähän valitaan "No authentication".  Tämä koska meille ei ole eri kirjautumistyyppejä.'
 required: true
 translatable: false
 default_value:
   -
-    value: 'No authentication'
+    value: '0'
 default_value_callback: ''
 settings: {  }
 field_type: list_string

--- a/conf/cmi/field.storage.block_content.field_login_type.yml
+++ b/conf/cmi/field.storage.block_content.field_login_type.yml
@@ -1,0 +1,30 @@
+uuid: 459d4f27-1afa-498f-81da-993bfd128459
+langcode: fi
+status: true
+dependencies:
+  module:
+    - block_content
+    - options
+id: block_content.field_login_type
+field_name: field_login_type
+entity_type: block_content
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '0'
+      label: 'No authentication'
+    -
+      value: '1'
+      label: 'Weak authentication'
+    -
+      value: '2'
+      label: 'Strong authentication'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.block_content.login_page_info.yml
+++ b/conf/cmi/language.content_settings.block_content.login_page_info.yml
@@ -1,0 +1,16 @@
+uuid: bcb131db-ba65-484c-bcd4-63f30c042cd4
+langcode: fi
+status: true
+dependencies:
+  config:
+    - block_content.type.login_page_info
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: block_content.login_page_info
+target_entity_type_id: block_content
+target_bundle: login_page_info
+default_langcode: site_default
+language_alterable: false

--- a/public/modules/custom/grants_profile/grants_profile.module
+++ b/public/modules/custom/grants_profile/grants_profile.module
@@ -253,3 +253,24 @@ function grants_profile_block_view_profile_block_alter(array &$build, BlockPlugi
 function grants_profile_theme_registry_alter(&$theme_registry) {
   $theme_registry['profile_block']['variables']['extra_links'] = NULL;
 }
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function grants_profile_preprocess_page(&$vars) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+
+  // Check for user login or access denied pages.
+  if ($route_name === 'user.login' || $route_name === 'system.403' || $route_name === 'system.401') {
+    $block_ids = \Drupal::entityQuery('block_content')
+      ->condition('field_login_type', 0)
+      ->execute();
+
+    $blocks = \Drupal::entityTypeManager()->getStorage('block_content')->loadMultiple($block_ids);
+
+    foreach ($blocks as $b) {
+      $vars['page']['login_block'][] = \Drupal::entityTypeManager()
+        ->getViewBuilder('block_content')->view($b);
+    }
+  }
+}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/page--401.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/page--401.html.twig
@@ -1,0 +1,43 @@
+{% embed 'page.html.twig' %}
+  {% block page_content %}
+    {% embed '@hdbt/misc/container.twig' with {container_element: 'error-page-content'} %}
+      {% block container_content %}
+        <div class="error-page__text-container">
+          <h1 class="error-page__title">{{ error_number|default('401') }} - {{ 'You do not have permission to access this page'|t }}</h1>
+          <p class="error-page__description">{{ 'This page is available to registered users only. If you have the necessary permissions, you can sign in to see the content.'|t }}</p>
+
+          {% set link_title %}
+            {{ 'Go back to the hel.fi homepage'|t({}, {'context': 'Return to homepage link for error pages'}) }}
+          {% endset %}
+          {% set link_attributes = {
+            'class': [
+              'error-page__link',
+            ],
+          } %}
+          {{ link(link_title, error_page_home_link, link_attributes) }}
+
+          <br>
+
+          {% set feedback_link_title %}
+            {{ 'Give feedback'|t({}, {'context': 'Feedback link for error pages'}) }}
+          {% endset %}
+          {{ link(feedback_link_title, error_page_feedback_link, link_attributes) }}
+
+          {% if user_not_logged_in %}
+            <h2 class="error-page__login-title">{{ 'Log in'|t({}, {'context': 'Log in block title on error pages'}) }}</h2>
+          {% endif %}
+          {{ page.login_block }}
+          <div class="error-page__login-form">
+            {{ drupal_block('user_login_block') }}
+          </div>
+        </div>
+        <div class="error-page__illustration-container">
+          <img src="{{ theme_path }}/src/images/illustration_error_page_403_401.svg" alt="" class="error-page__illustration" width="379" height="566" />
+        </div>
+      {% endblock container_content %}
+    {% endembed %}
+  {% endblock page_content %}
+
+  {% block page_after_content %}
+  {% endblock page_after_content %}
+{% endembed %}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/page--user--login.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/page--user--login.html.twig
@@ -1,0 +1,23 @@
+{% embed 'page.html.twig' %}
+  {% block page_content %}
+    {% embed '@hdbt/misc/container.twig' with {container_element: 'user-login-page-content'} %}
+      {% block container_content %}
+        <div class="user-login__form-container">
+          <h1 class="user-login-page__title">{{ 'Log in'|t }}</h1>
+          <div class="user-login__text-container">
+            <div class="user-login-page__body">
+              {{ page.login_block }}
+            </div>
+            {{ page.content|without(page_title_block) }}
+          </div>
+        </div>
+        <div class="user-login-page__illustration-container">
+          <img src="/themes/contrib/hdbt/src/images/illustration_user_login_page.svg" alt="" class="user-login-page__illustration"/>
+        </div>
+      {% endblock container_content %}
+    {% endembed %}
+  {% endblock page_content %}
+
+  {% block page_after_content %}
+  {% endblock page_after_content %}
+{% endembed %}


### PR DESCRIPTION
# [AU-756](https://helsinkisolutionoffice.atlassian.net/browse/AU-756)
<!-- What problem does this solve? -->

Allows you to display blocks of content on login page(s).

Similar functionality to https://github.com/City-of-Helsinki/drupal-helfi-form-tool/pull/137

## What was done
<!-- Describe what was done -->

* Added new block type for login page content.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-756_Login_page_blocks`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as admin and new custom blocks of type "login info"
* [ ] Check that these new blocks are displayed on login page(s)



[AU-756]: https://helsinkisolutionoffice.atlassian.net/browse/AU-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ