### PR TITLE
fix: AU-747: Remove redirect to compilation page in case of an error.

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -769,18 +769,12 @@ class ApplicationHandler {
    *
    * @param array $submittedFormData
    *   Form data.
-   * @param string $definitionClass
-   *   Class name of the definition class.
-   * @param string $definitionKey
-   *   Name of the definition.
    *
    * @return \Drupal\Core\TypedData\TypedDataInterface
    *   Typed data with values set.
    */
   public function webformToTypedData(
-    array $submittedFormData,
-    string $definitionClass = '',
-    string $definitionKey = ''
+    array $submittedFormData
   ): TypedDataInterface {
 
     $dataDefinitionKeys = self::getDataDefinitionClass($submittedFormData['application_type']);
@@ -1039,7 +1033,7 @@ class ApplicationHandler {
     string $applicationNumber
   ): bool {
 
-    /** @var \Drupal\Core\TypedData\TypedDataInterface $applicationData */
+    /** @var \Drupal\helfi_atv\AtvDocument $appDocument */
     $appDocument = $this->atvSchema->typedDataToDocumentContent($applicationData);
     $myJSON = Json::encode($appDocument);
 
@@ -1104,7 +1098,6 @@ class ApplicationHandler {
       $this->logger->error('Error saving application: %msg', ['%msg' => $e->getMessage()]);
       return FALSE;
     }
-    return FALSE;
   }
 
   /**

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1068,10 +1068,7 @@ class GrantsHandler extends WebformHandlerBase {
       );
 
       $applicationData = $this->applicationHandler->webformToTypedData(
-        $this->submittedFormData,
-        '\Drupal\grants_metadata\TypedData\Definition\YleisavustusHakemusDefinition',
-        'grants_metadata_yleisavustushakemus'
-      );
+        $this->submittedFormData);
 
       $applicationUploadStatus = $this->applicationHandler->handleApplicationUploadViaIntegration(
         $applicationData,
@@ -1101,29 +1098,29 @@ class GrantsHandler extends WebformHandlerBase {
       }
       else {
         $this->messenger()
-          ->addERror(
+          ->addError(
             $this->t(
-              'Grant application (<span id="saved-application-number">@number</span>) saving failed. Please contact support.',
+              'Grant application (@number) saving failed. Error has been logged.',
               [
                 '@number' => $this->applicationNumber,
               ]
             )
           );
       }
-      $form_state->setRedirect(
-        'grants_handler.completion',
-        ['submission_id' => $this->applicationNumber],
-        [
-          'attributes' => [
-            'data-drupal-selector' => 'application-saved-successfully-link',
-          ],
-        ]
-      );
     }
     catch (\Exception $e) {
       $this->getLogger('grants_handler')
         ->error('Error: %error', ['%error' => $e->getMessage()]);
 
+      $this->messenger()
+        ->addError(
+          $this->t(
+            'Grant application (@number) saving failed. Error has been logged.',
+            [
+              '@number' => $this->applicationNumber,
+            ]
+          )
+        );
     }
   }
 

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -386,3 +386,6 @@ msgstr "Hakemuksella on tallentamattomia muutoksia."
 msgid "Press OK to leave this page or Cancel to stay."
 msgstr "Paina OK poistuaksesi sivulta tai Peruuta jatkaaksesi."
 
+msgid "Grant application (@number) saving failed. Error has been logged."
+msgstr "Hakemustunnuksen @number tallennus epäonnistui. Virhe on kirjattu."
+

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -36,3 +36,6 @@ msgstr "@count nya meddelanden"
 
 msgid "Your request was not fulfilled due to network error."
 msgstr "Your request was not fulfilled due to network error."
+
+msgid "Grant application (@number) saving failed. Error has been logged."
+msgstr "Det gick inte att spara applikations-ID @nummer. Ett fel har loggats."


### PR DESCRIPTION
# [AU-747](https://helsinkisolutionoffice.atlassian.net/browse/AU-747)
<!-- What problem does this solve? -->

User was redirected to compilation page even in rare case that integration fails to respond with 200 status.

Now user is left on the form with the values and they are shown an error message. Only succesful saves redirect to completion.

## What was done
<!-- Describe what was done -->

* Remove catch-all redirect
* Add error messages + translations.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-747-application-errors-page`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Leave VPN OFF
* [ ] Edit existing application that is already in Avus2 -> status >= RECEIVED
* [ ] Try to save application
* [ ] See that you stay on the form with error message & things are logged.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)



[AU-747]: https://helsinkisolutionoffice.atlassian.net/browse/AU-747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ