### PR TITLE
fix: AU-XX: Make some changes to viestintasivut

### DIFF
--- a/conf/cmi/language/en/views.view.application_search.yml
+++ b/conf/cmi/language/en/views.view.application_search.yml
@@ -3,3 +3,26 @@ display:
     display_options:
       menu:
         title: 'Application search'
+  default:
+    display_options:
+      title: 'Search for application'
+      exposed_form:
+        options:
+          submit_button: Search
+      filters:
+        combine:
+          expose:
+            label: Keyword
+            placeholder: 'Search by name or keyword'
+        field_avustuslaji_target_id_entityreference_filter:
+          expose:
+            label: 'What kind of activity are you applying grant for?'
+        field_hakijatyyppi_value:
+          expose:
+            label: Applicant
+        field_application_open_value:
+          group_info:
+            label: 'Show only the grants that can be applied for'
+      footer:
+        result:
+          content: '<strong>@total</strong> results'

--- a/conf/cmi/language/sv/views.view.application_search.yml
+++ b/conf/cmi/language/sv/views.view.application_search.yml
@@ -4,3 +4,30 @@ display:
     display_options:
       menu:
         title: 'Sök understöd'
+  default:
+    display_options:
+      title: 'Sök understöd'
+      exposed_form:
+        options:
+          submit_button: Sök
+      filters:
+        combine:
+          expose:
+            label: Nyckelord
+            placeholder: 'Sök på namn eller sökterm, till exempel verksamhetsunderstöd'
+        field_avustuslaji_target_id_entityreference_filter:
+          expose:
+            label: 'Vilken typ av verksamhet ansöker du om understöd?'
+        field_hakijatyyppi_value:
+          expose:
+            label: Sökande
+        field_application_open_value:
+          group_info:
+            label: 'Visa endast de undersök som kan sökas'
+      pager:
+        options:
+          expose:
+            items_per_page_options_all_label: '- Alla -'
+      footer:
+        result:
+          content: '<strong>@total</strong> sökresultat'

--- a/conf/cmi/views.view.application_search.yml
+++ b/conf/cmi/views.view.application_search.yml
@@ -1046,6 +1046,48 @@ display:
                 title: 'Application not open'
                 operator: '='
                 value: '0'
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -17,8 +17,8 @@ third_party_settings:
       48: '48'
       64: '64'
     applicationTargetGroup: '21'
-    applicationOpen: '2022-10-03T11:08:26'
-    applicationClose: '2023-06-14T11:19:00'
+    applicationOpen: '2023-04-03T08:00:00'
+    applicationClose: '2023-10-06T16:00:00'
     applicationContinuous: 0
     disableCopying: 0
 weight: 0

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -18,3 +18,8 @@ msgstr "Saknade eller ofullständig information"
 msgid "Error in page"
 msgstr "Fel på sidan"
 
+msgid "Filter search"
+msgstr "Begränsa din sökning"
+
+msgid "Search for application"
+msgstr "Sök understöd"


### PR DESCRIPTION
# [AU-XX](https://helsinkisolutionoffice.atlassian.net/browse/AU-XX)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Translated application search
* Added application search a criteria that shows only current language items
* Changed kasko application period 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-viestintasivut2`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that Etsi avustusta is properly translated in en and sv
* [ ] Check that KASKO application period is from 3.4.2023 08.00 to 6.10.2023 16.00 and lmk why the clock is wrong on frontend

