### PR TITLE
Fix: AU-XXX: Fix css selectors

### DIFF
--- a/public/modules/custom/grants_handler/js/webform-additions.js
+++ b/public/modules/custom/grants_handler/js/webform-additions.js
@@ -39,9 +39,9 @@
         // @codingStandardsIgnoreStart
         // set up data selectors for delta
         const nameTarget = `[data-drupal-selector='edit-community-officials-items-${elementDelta}-item-name']`
-        const roleTarget = `[data-drupal-selector='edit-community-officials-items-${elementDelta}-item-role'`
-        const emailTarget = `[data-drupal-selector='edit-community-officials-items-${elementDelta}-item-email'`
-        const phoneTarget = `[data-drupal-selector='edit-community-officials-items-${elementDelta}-item-phone'`
+        const roleTarget = `[data-drupal-selector='edit-community-officials-items-${elementDelta}-item-role']`
+        const emailTarget = `[data-drupal-selector='edit-community-officials-items-${elementDelta}-item-email']`
+        const phoneTarget = `[data-drupal-selector='edit-community-officials-items-${elementDelta}-item-phone']`
         // @codingStandardsIgnoreEnd
 
         // set values

--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
@@ -43,10 +43,11 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
 
     /** @var \Drupal\Core\StringTranslation\TranslatableMarkup $role */
     $role = $roles[(int) $value['role']];
+    $roleRender = $role ? $role->render() : '';
 
     return [
       $value['name'],
-      $role->render(),
+      $roleRender,
       $value['email'],
       $value['phone'],
     ];


### PR DESCRIPTION
* This thing was fixed

Missing bracket end to css selectors.

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-XXX-css-selector-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Toiminnasta vastaavat henkilöt select should not print JS errors on firefox.
