### PR TITLE
fix: AU- 848: Show only messages that are received from kasittelyjarjestelma in Oma asiointi -block

### DIFF
--- a/conf/cmi/language/fi/views.view.frontpage_news.yml
+++ b/conf/cmi/language/fi/views.view.frontpage_news.yml
@@ -2,3 +2,6 @@ display:
   latest_news:
     display_options:
       use_more_text: 'Katso kaikki ajankohtaiset'
+  main_news:
+    display_options:
+      title: Pääuutiset

--- a/conf/cmi/language/fi/views.view.news_archive.yml
+++ b/conf/cmi/language/fi/views.view.news_archive.yml
@@ -2,15 +2,6 @@ display:
   default:
     display_options:
       title: 'Ajankohtaista avustuksista'
-  feed_1:
-    display_options:
-      filters:
-        field_news_groups_target_id:
-          group_info:
-            description: ''
-        field_news_item_tags_target_id:
-          group_info:
-            description: ''
   page_1:
     display_options:
       menu:

--- a/conf/cmi/language/sv/views.view.frontpage_news.yml
+++ b/conf/cmi/language/sv/views.view.frontpage_news.yml
@@ -2,3 +2,6 @@ display:
   latest_news:
     display_options:
       use_more_text: 'Visa alla'
+  main_news:
+    display_options:
+      title: Nyheter

--- a/conf/cmi/language/sv/views.view.news_archive.yml
+++ b/conf/cmi/language/sv/views.view.news_archive.yml
@@ -1,14 +1,9 @@
 display:
-  feed_1:
-    display_options:
-      filters:
-        field_news_groups_target_id:
-          group_info:
-            description: ''
-        field_news_item_tags_target_id:
-          group_info:
-            description: ''
   page_1:
     display_options:
       menu:
         title: Aktuell
+  default:
+    display_options:
+      title: Nyheter
+label: Nyheter

--- a/conf/cmi/views.view.frontpage_news.yml
+++ b/conf/cmi/views.view.frontpage_news.yml
@@ -600,7 +600,7 @@ display:
     display_plugin: block
     position: 2
     display_options:
-      title: Pääuutiset
+      title: 'Main news'
       fields:
         published_at:
           id: published_at

--- a/conf/cmi/views.view.news_archive.yml
+++ b/conf/cmi/views.view.news_archive.yml
@@ -26,7 +26,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Uutiset
+      title: News
       fields:
         title:
           id: title

--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
@@ -196,7 +196,7 @@ class OmaAsiointiBlock extends BlockBase implements ContainerFactoryPluginInterf
 
     $receivedMsgs = [];
 
-    // Show only messages that are received from kasittelyjarjestelma
+    // Show only messages that are received from kasittelyjarjestelma.
     foreach ($messages as $message) {
       if ($message['sentBy'] === 'Avustusten kasittelyjarjestelma') {
         array_push($receivedMsgs, $message);

--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/OmaAsiointiBlock.php
@@ -194,6 +194,15 @@ class OmaAsiointiBlock extends BlockBase implements ContainerFactoryPluginInterf
     catch (\Exception $e) {
     }
 
+    $receivedMsgs = [];
+
+    // Show only messages that are received from kasittelyjarjestelma
+    foreach ($messages as $message) {
+      if ($message['sentBy'] === 'Avustusten kasittelyjarjestelma') {
+        array_push($receivedMsgs, $message);
+      }
+    }
+
     $lang = \Drupal::languageManager()->getCurrentLanguage();
     krsort($submissions);
     krsort($messages);
@@ -201,8 +210,8 @@ class OmaAsiointiBlock extends BlockBase implements ContainerFactoryPluginInterf
     $allMessagesLink = Link::createFromRoute($this->t('See all messages'), 'grants_oma_asiointi.front');
     $build = [
       '#theme' => 'grants_oma_asiointi_block',
-      '#allMessages' => $messages,
-      '#messages' => array_slice($messages, 0, 2),
+      '#allMessages' => $receivedMsgs,
+      '#messages' => array_slice($receivedMsgs, 0, 2),
       '#allSubmissions' => $submissions,
       '#submissions' => array_slice($submissions, 0, 2),
       '#userProfileData' => $helsinkiProfileData['myProfile'],


### PR DESCRIPTION
# [AU-848](https://helsinkisolutionoffice.atlassian.net/browse/AU-848)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Show only messages that are received from kasittelyjarjestelma in Oma asiointi -block
* Also translations to news page in this PR

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-848-uudet-viestit`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that in Oma asiointi -block you see only RECEIVED messages, not your own


[AU-848]: https://helsinkisolutionoffice.atlassian.net/browse/AU-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ