### PR TITLE
fix: AU-XX: fix application timezones

### DIFF
--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -157,13 +157,21 @@ function grants_metadata_set_node_values(Node &$page, bool $status, mixed $third
     $terms = Term::loadMultiple($tids);
     $page->set('field_avustuslaji', $terms);
   }
+  $applicationOpenStr = strtotime($thirdPartySettings["applicationOpen"]);
+  $applicationOpenDate = DrupalDateTime::createFromFormat('U', $applicationOpenStr, 'Europe/Helsinki');
+  $applicationOpenDateFormat = $applicationOpenDate->format('Y-m-d\TH:i:s');
+
+  $applicationCloseStr = strtotime($thirdPartySettings["applicationClose"]);
+  $applicationCloseDate = DrupalDateTime::createFromFormat('U', $applicationCloseStr, 'Europe/Helsinki');
+  $applicationCloseDateFormat = $applicationCloseDate->format('Y-m-d\TH:i:s');
+
   // If we have open time, assume that end time is added as well and
   // use them as is.
   if (!empty($thirdPartySettings["applicationOpen"])) {
     $page->set('field_application_period',
       [
-        'value' => $thirdPartySettings["applicationOpen"],
-        'end_value' => $thirdPartySettings["applicationClose"],
+        'value' => $applicationOpenDateFormat,
+        'end_value' => $applicationCloseDateFormat,
       ]);
   }
   // If application is set to be continuous, mark it to node as well.


### PR DESCRIPTION
# [AU-XX](https://helsinkisolutionoffice.atlassian.net/browse/AU-XX)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix application time zones to show correct time

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-timezones`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this Kasko application is open from 3.4.2023 8.00 to 6.10.2023 to 16.00
* [ ] If not correct right way, try saving the form again in https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/kasvatus_ja_koulutus_yleisavustu/settings
