### PR TITLE
fix: AU-843: Fix account confirmation errors

### DIFF
--- a/public/modules/custom/grants_profile/grants_profile.services.yml
+++ b/public/modules/custom/grants_profile/grants_profile.services.yml
@@ -12,5 +12,6 @@ services:
         '@helfi_helsinki_profiili.userdata',
         '@grants_metadata.atv_schema',
         '@helfi_yjdh.client',
-        '@logger.factory'
+        '@logger.factory',
+        '@helfi_audit_log.audit_log'
     ]

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileForm.php
@@ -95,6 +95,7 @@ class GrantsProfileForm extends FormBase {
     // Load grants profile.
     try {
       $grantsProfile = $grantsProfileService->getGrantsProfile($selectedCompany, TRUE);
+      $grantsProfileService->clearAttachments($grantsProfile);
     }
     catch (GuzzleException $e) {
       $grantsProfile = NULL;
@@ -247,6 +248,12 @@ class GrantsProfileForm extends FormBase {
       else {
         \Drupal::messenger()
           ->addError('Attachment deletion failed, error has been logged. Please contact customer support');
+
+        // Remove item from items.
+        unset($fieldValue[$deltaToRemove]);
+        $formState->setValue($fieldName, $fieldValue);
+        $formState->setRebuild();
+
       }
     }
     else {
@@ -1052,7 +1059,7 @@ rtf, txt, xls, xlsx, zip.'),
           ],
           '#ajax' => [
             'callback' => '::addmoreCallback',
-            'wrapper' => 'officials-wrapper',
+            'wrapper' => 'bankaccount-wrapper',
           ],
         ],
       ];

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -13,6 +13,7 @@ use Drupal\grants_metadata\AtvSchema;
 use Drupal\helfi_atv\AtvDocument;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvService;
+use Drupal\helfi_audit_log\AuditLogService;
 use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
 use Drupal\helfi_yjdh\Exception\YjdhException;
 use Drupal\helfi_yjdh\YjdhClient;
@@ -78,6 +79,13 @@ class GrantsProfileService {
   protected LoggerChannelFactory|LoggerChannelInterface|LoggerChannel $logger;
 
   /**
+   * Audit logger.
+   *
+   * @var \Drupal\helfi_audit_log\AuditLogService
+   */
+  protected AuditLogService $auditLogService;
+
+  /**
    * Constructs a GrantsProfileService object.
    *
    * @param \Drupal\helfi_atv\AtvService $helfi_atv
@@ -94,6 +102,8 @@ class GrantsProfileService {
    *   Access to yjdh data.
    * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
    *   Logger service.
+   * @param \Drupal\helfi_audit_log\AuditLogService $auditLogService
+   *   Audit log.
    */
   public function __construct(
     AtvService $helfi_atv,
@@ -102,7 +112,8 @@ class GrantsProfileService {
     HelsinkiProfiiliUserData $helsinkiProfiiliUserData,
     AtvSchema $atv_schema,
     YjdhClient $yjdhClient,
-    LoggerChannelFactory $loggerFactory
+    LoggerChannelFactory $loggerFactory,
+    AuditLogService $auditLogService
   ) {
     $this->atvService = $helfi_atv;
     $this->requestStack = $requestStack;
@@ -111,6 +122,7 @@ class GrantsProfileService {
     $this->atvSchema = $atv_schema;
     $this->yjdhClient = $yjdhClient;
     $this->logger = $loggerFactory->get('helfi_atv');
+    $this->auditLogService = $auditLogService;
   }
 
   /**
@@ -119,7 +131,7 @@ class GrantsProfileService {
    * @param array $data
    *   Data for the new profile document.
    *
-   * @return Drupal\helfi_atv\AtvDocument
+   * @return \Drupal\helfi_atv\AtvDocument
    *   New profile
    */
   public function newProfile(array $data): AtvDocument {
@@ -719,6 +731,7 @@ class GrantsProfileService {
     // Get profile document from ATV.
     try {
       $profileDocument = $this->getGrantsProfileFromAtv($businessId, $refetch);
+
       if ($profileDocument) {
         $this->setToCache($businessId, $profileDocument);
         return $profileDocument;
@@ -763,7 +776,6 @@ class GrantsProfileService {
     if (empty($searchDocuments)) {
       return FALSE;
     }
-    // @todo merge profiles if multiple is saved for some reason.
     return reset($searchDocuments);
   }
 
@@ -788,6 +800,8 @@ class GrantsProfileService {
    *
    * @return bool
    *   Success.
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function setSelectedCompany(array $companyData): bool {
     return $this->setToCache('selected_company', $companyData);
@@ -904,7 +918,57 @@ class GrantsProfileService {
       $session->set($key, $grantsProfile);
       return TRUE;
     }
+  }
 
+  /**
+   * Clean up any attachments from profile.
+   *
+   * Sometimes deleting of attachment fails and document is left with some
+   * attachments that are not in any bank accounts.
+   * These need to be cleared out.
+   *
+   * @param \Drupal\helfi_atv\AtvDocument $grantsProfile
+   *   Profile to be cleared.
+   */
+  public function clearAttachments(AtvDocument &$grantsProfile): void {
+
+    $profileContent = $grantsProfile->getContent();
+    foreach ($grantsProfile->getAttachments() as $key => $attachment) {
+      $bankAccountAttachment = array_filter($profileContent['bankAccounts'], function ($item) use ($attachment) {
+        return $item['confirmationFile'] === $attachment['filename'];
+      });
+
+      if (empty($bankAccountAttachment)) {
+        try {
+          $this->atvService->deleteAttachmentByUrl($attachment['href']);
+
+          $message = [
+            "operation" => "GRANTS_APPLICATION_ATTACHMENT_DELETE",
+            "status" => "SUCCESS",
+            "target" => [
+              "id" => $grantsProfile->getId(),
+              "type" => $grantsProfile->getType(),
+              "name" => $grantsProfile->getTransactionId(),
+            ],
+          ];
+
+          unset($grantsProfile['attachments'][$key]);
+
+        }
+        catch (\Throwable $e) {
+          $message = [
+            "operation" => "GRANTS_APPLICATION_ATTACHMENT_DELETE",
+            "status" => "FAILURE",
+            "target" => [
+              "id" => $grantsProfile->getId(),
+              "type" => $grantsProfile->getType(),
+              "name" => $grantsProfile->getTransactionId(),
+            ],
+          ];
+        }
+        $this->auditLogService->dispatchEvent($message);
+      }
+    }
   }
 
 }

--- a/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/NotEmptyValue.php
+++ b/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/NotEmptyValue.php
@@ -17,4 +17,11 @@ class NotEmptyValue extends Constraint {
 
   const IS_BLANK_ERROR = 'This value should not be blank.';
 
+  /**
+   * The message that will be shown if the value is not unique.
+   *
+   * @var string
+   */
+  public string $message = '%value is not valid url';
+
 }

--- a/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/NotEmptyValueValidator.php
+++ b/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/NotEmptyValueValidator.php
@@ -4,6 +4,7 @@ namespace Drupal\grants_profile\Plugin\Validation\Constraint;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
  * Validate empty values. Custom class to override default.


### PR DESCRIPTION
# [AU-843](https://helsinkisolutionoffice.atlassian.net/browse/AU-843)
# [AU-844](https://helsinkisolutionoffice.atlassian.net/browse/AU-844)
# [AU-845](https://helsinkisolutionoffice.atlassian.net/browse/AU-845)
<!-- What problem does this solve? -->

Some issues with bank account confirmation files + validations.

Sadly this will not fix every issue with profile form & validation, but usability is much better.

## What was done
<!-- Describe what was done -->

* Delete all attachments that are not used in bank accounts when accessing form. This ensures that no extra attachments are present.
* Make bank account validation better
* Delete files no matter when Delete button is created

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-843-pankkitili-vahvistus-virhe`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to profile page, and remove and add bank accounts & other fields and try to break things.
* [ ] Pay attention to bank accounts & validations. There may be some strange behavior still, but deleting any account that does not validate should be possible.
* [ ] Code follows yada yada..
