### PR TITLE
Rename conf file with space in name

### DIFF
--- a/conf/cmi/block.block.menuitemsforprofile.yml
+++ b/conf/cmi/block.block.menuitemsforprofile.yml
@@ -1,0 +1,20 @@
+uuid: 657a194f-7ccc-442d-a09e-c20c6502cc9f
+langcode: fi
+status: true
+dependencies:
+  module:
+    - grants_profile
+  theme:
+    - helfi_grant_applications
+id: menuitemsforprofile
+theme: helfi_grant_applications
+region: header_branding
+weight: -7
+provider: null
+plugin: grants_profile_menuitem
+settings:
+  id: grants_profile_menuitem
+  label: 'Menu Items For Profile'
+  label_display: '0'
+  provider: grants_profile
+visibility: {  }


### PR DESCRIPTION
<!-- What problem does this solve? -->

There's a config file that ends in space " " character. You can see the file here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/9ae53112f10be88271716499a82ef0456679b123/conf/cmi/block.block.menuitemsforprofile.yml%20

Github trims the filename in the page, you can see in the url above that it has "%20", so a space character at the end.

This causes errors in our Azure pipelines (thanks Windows).

## What was done
<!-- Describe what was done -->

* The file was renamed without the space character

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check in your local filesystem if that file in question has the space at the end or not.
