### PR TITLE
fix: AU-850: Redirect user from user page to my service page

### DIFF
--- a/public/modules/custom/grants_profile/grants_profile.services.yml
+++ b/public/modules/custom/grants_profile/grants_profile.services.yml
@@ -14,3 +14,8 @@ services:
         '@helfi_yjdh.client',
         '@logger.factory'
     ]
+
+  grants_profile.route_subscriber:
+    class: Drupal\grants_profile\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/public/modules/custom/grants_profile/src/Controller/GrantsProfileController.php
+++ b/public/modules/custom/grants_profile/src/Controller/GrantsProfileController.php
@@ -364,4 +364,17 @@ class GrantsProfileController extends ControllerBase {
 
   }
 
+  /**
+   * Redirect to my service page.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Redirect to profile page.
+   */
+  public function redirectToMyServices(): RedirectResponse {
+    $showtProfileUrl = Url::fromRoute(
+      'grants_profile.show'
+    );
+    return new RedirectResponse($showtProfileUrl->toString());
+  }
+
 }

--- a/public/modules/custom/grants_profile/src/Routing/RouteSubscriber.php
+++ b/public/modules/custom/grants_profile/src/Routing/RouteSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\grants_profile\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Route subscriber to alter core user routes.
+ *
+ * @package Drupal\openid_connect_logout_redirect\Routing
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Reroute the user.page route.
+    if ($route = $collection->get('user.page')) {
+      $route->setDefault('_controller', '\Drupal\grants_profile\Controller\GrantsProfileController::redirectToMyServices');
+    }
+    // Reroute the entity.user.canonical.
+    if ($route = $collection->get('entity.user.canonical')) {
+      $route->setDefault('_controller', '\Drupal\grants_profile\Controller\GrantsProfileController::redirectToMyServices');
+    }
+  }
+
+}


### PR DESCRIPTION
# [AU-0000](https://helsinkisolutionoffice.atlassian.net/browse/AU-850)
<!-- What problem does this solve? -->

Users had a possibility to enter user page by accident e.g. clicking back button in the browser.

## What was done
<!-- Describe what was done -->

Alter relevant routes to redirect user to My Services page.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-850-user-page`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login
* [ ] Try to access user page by any means. You should always end up in my services page.