### PR TITLE
AU-856: Add check to javascript alter to prevent errors

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -182,7 +182,10 @@ function grants_handler_entity_type_alter(array &$entity_types) {
  * Path to the new form alert javascripts.
  */
 function grants_handler_js_alter(&$javascript) {
-  $javascript[\Drupal::service('extension.list.module')->getPath('webform') . '/js/webform.form.unsaved.js']['data'] = \Drupal::service('extension.list.module')->getPath('grants_handler') . '/js/webform.form.unsaved.js';
+  $key = \Drupal::service('extension.list.module')->getPath('webform') . '/js/webform.form.unsaved.js';
+  if (isset($javascript[$key])) {
+    $javascript[$key]['data'] = \Drupal::service('extension.list.module')->getPath('grants_handler') . '/js/webform.form.unsaved.js';
+  }
 }
 
 /**


### PR DESCRIPTION
# [AU-856](https://helsinkisolutionoffice.atlassian.net/browse/AU-856)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Add sanity check to prevent errors when javascript is being altered.

**You can test this before checking out**

Clear caches, after 2 page loads the errors will appear, this is due Drupal building javascript assets to cache etc. As we don't check if the key exists, we are adding barebone array with missing data.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-856-fix-php-warnings-undefined-group`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [  ] Clear drupal caches and visit the site, no errors should appear on page loads 
* [ ] Modified webform.form.unsaved.js should work as expected.


## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-856]: https://helsinkisolutionoffice.atlassian.net/browse/AU-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ