### PR TITLE
AU-858: Display grant attachment validation errors inline

### DIFF
--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -64,6 +64,12 @@ class GrantsAttachments extends WebformCompositeBase {
       $arrayKey .=  '_' . $element['#parents'][2];
     }
 
+    if (isset($storage['errors'][$arrayKey])) {
+      $errors = $storage['errors'][$arrayKey];
+      $element['#attributes']['class'][] = $errors['label'];
+      $element['#attributes']['error_label'] = $errors['label'];
+    }
+
     // Attachment has been deleted, show default componenet state.
     if (isset($storage['deleted_attachments'][$arrayKey]) && $storage['deleted_attachments'][$arrayKey]) {
       unset($element['attachmentName']);


### PR DESCRIPTION
# [AU-858](https://helsinkisolutionoffice.atlassian.net/browse/AU-858)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Display attachment validation errors inline.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-858-grant-attachment-inline-error`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Do not fill attachment file field or checkboxes - Go to attachment pages again, check that errors are inline



[AU-858]: https://helsinkisolutionoffice.atlassian.net/browse/AU-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ