### PR TITLE
feat: AU-539 Redirect after logout

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -122,6 +122,7 @@ module:
   node: 0
   oembed_providers: 0
   openid_connect: 0
+  openid_connect_logout_redirect: 0
   options: 0
   paragraphs_asymmetric_translation_widgets: 0
   path: 0

--- a/public/modules/custom/grants_handler/src/EventSubscriber/RedirectAfterLogoutSubscriber.php
+++ b/public/modules/custom/grants_handler/src/EventSubscriber/RedirectAfterLogoutSubscriber.php
@@ -25,8 +25,8 @@ class RedirectAfterLogoutSubscriber implements EventSubscriberInterface {
    *   Event.
    */
   public function checkRedirection(UserLogoutEvent $event) {
-    $response = new RedirectResponse('/');
-    $response->send();
+    $redirect_service = \Drupal::service('openid_connect_logout_redirect.redirect');
+    return $redirect_service->getLogoutRedirectUrl();
   }
 
   /**

--- a/public/modules/custom/grants_handler/src/EventSubscriber/RedirectAfterLogoutSubscriber.php
+++ b/public/modules/custom/grants_handler/src/EventSubscriber/RedirectAfterLogoutSubscriber.php
@@ -4,7 +4,6 @@ namespace Drupal\grants_handler\EventSubscriber;
 
 use Drupal\grants_handler\Event\UserLogoutEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * RedirectAfterLogoutSubscriber event subscriber.

--- a/public/modules/custom/openid_connect_logout_redirect/openid_connect_logout_redirect.info.yml
+++ b/public/modules/custom/openid_connect_logout_redirect/openid_connect_logout_redirect.info.yml
@@ -1,0 +1,8 @@
+name: openid_connect_logout_redirect
+type: module
+description: Implement oidc logout redirection
+package: Helfi
+core: 8.x
+core_version_requirement: ^8 || ^9
+dependencies:
+  - openid_connect

--- a/public/modules/custom/openid_connect_logout_redirect/openid_connect_logout_redirect.services.yml
+++ b/public/modules/custom/openid_connect_logout_redirect/openid_connect_logout_redirect.services.yml
@@ -1,0 +1,7 @@
+services:
+  openid_connect_logout_redirect.redirect:
+    class: 'Drupal\openid_connect_logout_redirect\Service\RedirectService'
+    arguments:
+      - '@request_stack'
+      - '@language_manager'
+      - '@module_handler'

--- a/public/modules/custom/openid_connect_logout_redirect/src/Service/RedirectService.php
+++ b/public/modules/custom/openid_connect_logout_redirect/src/Service/RedirectService.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\openid_connect_logout_redirect\Service;
+
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Http\RequestStack;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * RedirectService to handle saving and retriving logout redirection.
+ */
+class RedirectService {
+
+  const COOKIE_NAME = 'service_logout_redirect';
+  const DEFAULT_URL = 'https://hel.fi/';
+
+  /**
+   * The language manager object.
+   *
+   * @var \Drupal\Core\Language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * The request stack.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * RedirectService constructor.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   Request stack.
+   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   *   Language manager.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   Module handler.
+   */
+  public function __construct(
+    RequestStack $request_stack,
+    LanguageManagerInterface $language_manager,
+    ModuleHandlerInterface $module_handler,
+    ) {
+    $this->requestStack = $request_stack;
+    $this->languageManager = $language_manager;
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * Gets logout url from cookie.
+   *
+   * @return \Drupal\Core\Routing\TrustedRedirectResponse
+   *   Redirect response.
+   */
+  public function getLogoutRedirectUrl() {
+    $dest = $this->requestStack->getCurrentRequest()->get('dest');
+
+    $this->moduleHandler->invokeAll('openid_logout_redirect_alter_url', [&$dest]);
+
+    if (empty($dest)) {
+        $dest = $this->getDefaultUrl();
+    }
+
+    $response = new TrustedRedirectResponse($dest);
+    return $response;
+  }
+
+  /**
+   * Returns default url with a current language.
+   *
+   * @return string
+   *   Default url with language selection
+   */
+  private function getDefaultUrl(): string {
+    return self::DEFAULT_URL . $this->languageManager->getCurrentLanguage()->getId();
+  }
+
+}

--- a/public/modules/custom/openid_connect_logout_redirect/src/Service/RedirectService.php
+++ b/public/modules/custom/openid_connect_logout_redirect/src/Service/RedirectService.php
@@ -2,13 +2,10 @@
 
 namespace Drupal\openid_connect_logout_redirect\Service;
 
-use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
-use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * RedirectService to handle saving and retriving logout redirection.
@@ -71,7 +68,7 @@ class RedirectService {
     $this->moduleHandler->invokeAll('openid_logout_redirect_alter_url', [&$dest]);
 
     if (empty($dest)) {
-        $dest = $this->getDefaultUrl();
+      $dest = $this->getDefaultUrl();
     }
 
     $response = new TrustedRedirectResponse($dest);


### PR DESCRIPTION
# [AU-539](https://helsinkisolutionoffice.atlassian.net/browse/AU-539)
<!-- What problem does this solve? -->

Logout now applies also to tunnistamo in addition to Drupal.

## What was done
<!-- Describe what was done -->
I copied some magic by oskari and applied it in existing event subscriber.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-539-redirect-logout`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login with tunnistamo
* [ ] Logout in drupal, you end up in tunnistamo logout


[AU-539]: https://helsinkisolutionoffice.atlassian.net/browse/AU-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ