### PR TITLE
AU-770: Add update hook to remove delete module configs

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.install
+++ b/public/modules/custom/grants_handler/grants_handler.install
@@ -300,3 +300,20 @@ function grants_handler_update_9006(&$sandbox) {
   }
 
 }
+
+/**
+ * Remove configs of deleted modules.
+ */
+function grants_handler_update_9007(&$sandbox) {
+
+  $deletedModules = [
+    'helfi_proxy',
+    'jst_clock',
+    'jst_timer',
+    'jsstimer',
+  ];
+
+  foreach ($deletedModules as $module) {
+    \Drupal::keyValue("system.schema")->delete($module);
+  }
+}


### PR DESCRIPTION
# [AU-770](https://helsinkisolutionoffice.atlassian.net/browse/AU-770)
<!-- What problem does this solve? -->

## What was done

Update hook to remove configs of deleted modules

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-770-remove-deleted-module-configs`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `make shell` & `drush php-eval "print_r(\Drupal::keyValue('system.schema')->get('jst_timer'));"` should not return anything

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-770]: https://helsinkisolutionoffice.atlassian.net/browse/AU-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ