### PR TITLE
fix: AU-873 & AU-876: fix Grants Admin -rights and make Bottom content -field translatable

### DIFF
--- a/conf/cmi/field.field.node.service.field_bottom_content.yml
+++ b/conf/cmi/field.field.node.service.field_bottom_content.yml
@@ -18,7 +18,7 @@ bundle: service
 label: 'Bottom content'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
@@ -70,6 +70,9 @@ settings:
       from_library:
         weight: 49
         enabled: false
+      front_banner:
+        weight: 53
+        enabled: false
       front_page_latest_news:
         weight: 50
         enabled: false
@@ -97,6 +100,9 @@ settings:
       news_list:
         weight: 58
         enabled: false
+      oma_asiointi:
+        weight: 63
+        enabled: false
       paragraph_verkkolomake:
         weight: 59
         enabled: false
@@ -117,6 +123,9 @@ settings:
         enabled: false
       service_list:
         weight: 65
+        enabled: false
+      service_list_search:
+        weight: 71
         enabled: false
       sidebar_text:
         weight: 66

--- a/conf/cmi/user.role.grants_admin.yml
+++ b/conf/cmi/user.role.grants_admin.yml
@@ -74,6 +74,7 @@ permissions:
   - 'administer webform submission'
   - 'assign all roles'
   - 'break content lock'
+  - 'bypass node access'
   - 'change own username'
   - 'create address content'
   - 'create announcement content'


### PR DESCRIPTION
# [AU-873](https://helsinkisolutionoffice.atlassian.net/browse/AU-873)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix Grants Admin -rights and make Bottom content -field translatable

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-873-grants-admin`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as Grants Admin and check that you see all content, including unpublished
* [ ] Add content to Bottom content in Service page and check that you can add different content in different languages


[AU-873]: https://helsinkisolutionoffice.atlassian.net/browse/AU-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ