### PR TITLE
AU-867: Remove TPR link to current service page and replace with serv…

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -10,6 +10,7 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Component\Utility\Html;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
  * @file
@@ -444,5 +445,48 @@ function hdbt_subtheme_preprocess_paragraph(&$variables) {
     $grantsProfileService = \Drupal::service('grants_profile.service');
     $selectedCompany = $grantsProfileService->getSelectedCompany();
     $variables['company'] = $selectedCompany;
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function hdbt_subtheme_preprocess_tpr_service_channel(array &$variables) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $typeName = $node ? $node->bundle() : NULL;
+
+  if ($typeName === 'service') {
+
+    $webform = $node->get('field_webform')->target_id;
+
+    if (!isset($variables['content']['links']) || !$webform) {
+      return;
+    }
+
+    $items = $variables['content']['links']['#items'] ?? NULL;
+
+    if (!$items) {
+      return;
+    }
+
+    $current_url = Url::fromRoute('<current>');
+    $path = $current_url->toString();
+
+    foreach ($variables['content']['links']['#items']->getIterator() as $key => $item) {
+      $values = $item->getValue();
+      $item->setValue($values);
+      if (
+        strpos($values['uri'], $webform) !== FALSE ||
+        strpos($values['uri'], $path) !== FALSE
+      ) {
+        $items->removeItem($key);
+      }
+    }
+
+    $servicePageAuthBlock = \Drupal::service('plugin.manager.block')->createInstance('grants_handler_service_page_auth_block', []);
+    $blockLink = $servicePageAuthBlock->buildAsTprLink();
+    if ($blockLink) {
+      $items->appendItem($blockLink);
+    }
   }
 }


### PR DESCRIPTION
…ice auth block link

# [AU-867](https://helsinkisolutionoffice.atlassian.net/browse/AU-867)
<!-- What problem does this solve? -->

## What was done

Remove the TPR Service Channel link, if it's pointing to current service page / form. Display service auth block, if user is logged in

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-867-service-page-tpr-links`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that link is gone for unauthenticated user (MVP Form servicepage is pointing to old service, so it should be visible)
* [ ] As logged in user, you should see similar button as sidebar to get to the application form
* [ ] Language versions as always.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-867]: https://helsinkisolutionoffice.atlassian.net/browse/AU-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ