### PR TITLE
fix: AU-870: move messages block higher

### DIFF
--- a/conf/cmi/block.block.grantsapplicationsfrontpageinfoblock.yml
+++ b/conf/cmi/block.block.grantsapplicationsfrontpageinfoblock.yml
@@ -10,7 +10,7 @@ dependencies:
 id: grantsapplicationsfrontpageinfoblock
 theme: hdbt_subtheme
 region: content
-weight: -16
+weight: -15
 provider: null
 plugin: grants_frontpage_info_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_messages.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: hdbt_subtheme_messages
 theme: hdbt_subtheme
 region: content
-weight: -15
+weight: -16
 provider: null
 plugin: system_messages_block
 settings:


### PR DESCRIPTION
# [AU-870](https://helsinkisolutionoffice.atlassian.net/browse/AU-870)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moves Status messages -block higher

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-870-messages-block`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that Status messages appear on top of big yellow block in front page

[AU-870]: https://helsinkisolutionoffice.atlassian.net/browse/AU-870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ