### PR TITLE
fix: AU-864: hide user links from login form

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -432,8 +432,11 @@ function hdbt_subtheme_form_alter(&$form, FormStateInterface $form_state, $form_
   }
 }
 
+/**
+ * Implements hook_preprocess_block__user_login_block().
+ */
 function hdbt_subtheme_preprocess_block__user_login_block(&$variables, $hook) {
-  $variables['content']['user_links'] = null;
+  $variables['content']['user_links'] = NULL;
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -432,6 +432,10 @@ function hdbt_subtheme_form_alter(&$form, FormStateInterface $form_state, $form_
   }
 }
 
+function hdbt_subtheme_preprocess_block__user_login_block(&$variables, $hook) {
+  $variables['content']['user_links'] = null;
+}
+
 /**
  * Implements template_preprocess_paragraph().
  */


### PR DESCRIPTION
# [AU-864](https://helsinkisolutionoffice.atlassian.net/browse/AU-864)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Hide user links from login form

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-864-hide-user-links`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Stay logged out and go to https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi
* [ ] Check that you dont see links for creating an account or getting a password

![image](https://user-images.githubusercontent.com/26737690/231730488-f12fb462-3494-4267-9081-32c289226089.png)



[AU-864]: https://helsinkisolutionoffice.atlassian.net/browse/AU-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ