### PR TITLE
AU-867: fix: AU-877: Fix delete button visibility to be only on draft…

### DIFF
--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -154,7 +154,11 @@ class GrantsAttachments extends WebformCompositeBase {
           $element["description"]["#attributes"] = ['readonly' => 'readonly'];
         }
 
-        if (isset($dataForElement['fileType']) && $dataForElement['fileType'] != '45') {
+        if (
+          isset($dataForElement['fileType'])
+          && $dataForElement['fileType'] != '45'
+          && (isset($submissionData['status']) && $submissionData['status'] === 'DRAFT')
+        ) {
           $element['deleteItem'] = [
             '#type' => 'submit',
             '#name' => 'delete_' . $arrayKey,


### PR DESCRIPTION
# [AU-867](https://helsinkisolutionoffice.atlassian.net/browse/AU-867)
<!-- What problem does this solve? -->

## What was done

Hide attachment delete buttons, if submission is not a draft.



## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-867-delete-button-visibility-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Submit a submission and check that there is no more delete attachment buttons available afterwards.




[AU-867]: https://helsinkisolutionoffice.atlassian.net/browse/AU-867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ