### PR TITLE
fix: AU-862: translate subvention types in confs

### DIFF
--- a/conf/cmi/language/fi/grants_metadata.settings.yml
+++ b/conf/cmi/language/fi/grants_metadata.settings.yml
@@ -9,7 +9,7 @@ third_party_options:
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
     unregistered_community: 'Rekisteröimätön yhdistys'
-    private_person: 'Private person'
+    private_person: Yksityishenkilö
   application_types:
     29:
       id: ECONOMICGRANTAPPLICATION
@@ -19,8 +19,8 @@ third_party_options:
         definitionId: grants_metadata_yleisavustushakemus
       labels:
         fi: 'Kaupunginhallituksen yleisavustushakemus'
-        en: 'City Board, general grant application'
-        sv: 'Ansökan om stadsstyrelsens allmänna understöd'
+        en: 'EN Kaupunginhallituksen yleisavustushakemus'
+        sv: 'SV Kaupunginhallituksen yleisavustushakemus'
     51:
       id: KASKOYLEIS
       code: KASKOYLEIS
@@ -46,31 +46,31 @@ third_party_options:
     CANCELLED: CANCELLED
     CLOSED: CLOSED
   subvention_types:
-    1: 'Operating grant'
-    2: 'Wage subsidy'
-    4: 'Project grant'
-    5: 'Rent subsidy'
-    6: 'General grant'
-    7: 'Education grant for unemployed'
-    8: 'Interests and installments'
-    9: Other
-    11: 'Transport subsidy'
+    1: Toiminta-avustus
+    2: Palkkausavustus
+    4: Projektiavustus
+    5: Vuokra-avustus
+    6: Yleisavustus
+    7: 'Työttömien koulutusavustus'
+    8: 'Korot ja lyhennykset'
+    9: Muu
+    11: Kuljetusavustus
     12: Leiriavustus
-    13: 'Exemption from payments compensation'
-    14: 'Extra grant'
-    15: 'Navigation map grant'
-    17: 'Grant for operations development'
-    29: 'Capacity buildning grant / The Helsinki Model'
-    31: 'Start grant'
-    32: 'Subsidy for use of space'
-    34: 'Basic art education'
+    13: Maksuvapauskompensaatio
+    14: Lisäavustus
+    15: Suunnistuskartta-avustus
+    17: 'Toiminnan kehittämisavustus'
+    29: 'Kehittämisavustukset / Helsingin malli'
+    31: Starttiavustus
+    32: Tilankäyttöavustus
+    34: 'Taiteen perusopetus'
     35: Varhaiskasvatus
     36: 'Vapaa sivistystyö'
-    37: 'Event grant'
-    38: 'Small grant'
-    39: 'Immigrant integration grant'
-    40: 'Culture and leisure: application for subsidy'
+    37: Tapahtuma-avustus
+    38: Pienavustus
+    39: Kotouttamisavustus
+    40: Harrastushaku
     41: Laitosavustus
-    42: 'Grant for other associations promoting physical activity'
-    43: 'Targeted sports grant'
-langcode: en
+    42: 'Muiden liikuntaa edistävien yhteisöjen avustus'
+    43: Kohdeavustus
+langcode: fi

--- a/conf/cmi/language/fi/grants_metadata.settings.yml
+++ b/conf/cmi/language/fi/grants_metadata.settings.yml
@@ -19,8 +19,8 @@ third_party_options:
         definitionId: grants_metadata_yleisavustushakemus
       labels:
         fi: 'Kaupunginhallituksen yleisavustushakemus'
-        en: 'EN Kaupunginhallituksen yleisavustushakemus'
-        sv: 'SV Kaupunginhallituksen yleisavustushakemus'
+        en: 'City Board, general grant application'
+        sv: 'Ansökan om stadsstyrelsens allmänna understöd'
     51:
       id: KASKOYLEIS
       code: KASKOYLEIS

--- a/conf/cmi/language/sv/grants_metadata.settings.yml
+++ b/conf/cmi/language/sv/grants_metadata.settings.yml
@@ -9,7 +9,7 @@ third_party_options:
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
     unregistered_community: 'Rekisteröimätön yhdistys'
-    private_person: 'Private person'
+    private_person: Privatperson
   application_types:
     29:
       id: ECONOMICGRANTAPPLICATION
@@ -19,8 +19,8 @@ third_party_options:
         definitionId: grants_metadata_yleisavustushakemus
       labels:
         fi: 'Kaupunginhallituksen yleisavustushakemus'
-        en: 'City Board, general grant application'
-        sv: 'Ansökan om stadsstyrelsens allmänna understöd'
+        en: 'EN Kaupunginhallituksen yleisavustushakemus'
+        sv: 'SV Kaupunginhallituksen yleisavustushakemus'
     51:
       id: KASKOYLEIS
       code: KASKOYLEIS
@@ -46,31 +46,31 @@ third_party_options:
     CANCELLED: CANCELLED
     CLOSED: CLOSED
   subvention_types:
-    1: 'Operating grant'
-    2: 'Wage subsidy'
-    4: 'Project grant'
-    5: 'Rent subsidy'
-    6: 'General grant'
-    7: 'Education grant for unemployed'
-    8: 'Interests and installments'
-    9: Other
-    11: 'Transport subsidy'
-    12: Leiriavustus
-    13: 'Exemption from payments compensation'
-    14: 'Extra grant'
-    15: 'Navigation map grant'
-    17: 'Grant for operations development'
-    29: 'Capacity buildning grant / The Helsinki Model'
-    31: 'Start grant'
-    32: 'Subsidy for use of space'
-    34: 'Basic art education'
-    35: Varhaiskasvatus
-    36: 'Vapaa sivistystyö'
-    37: 'Event grant'
-    38: 'Small grant'
-    39: 'Immigrant integration grant'
-    40: 'Culture and leisure: application for subsidy'
-    41: Laitosavustus
-    42: 'Grant for other associations promoting physical activity'
-    43: 'Targeted sports grant'
-langcode: en
+    1: Verksamhetsunderstöd
+    2: Löneunderstöd
+    4: Projektunderstöd
+    5: Hyresunderstöd
+    6: 'Allmänt understöd'
+    7: 'Utbildningsbidrag för arbetslösa'
+    8: 'Räntor och amorteringar'
+    9: Annan
+    11: Transportunderstöd
+    12: Lägerunderstöd
+    13: 'Kompensation för avgiftsfrihet'
+    14: 'Extra understöd'
+    15: 'Understöd för orienteringskarta'
+    17: 'Understöd för verksamhetsutveckling'
+    29: 'Utveclingsunderstöd / Helsingforsmodellen'
+    31: 'Sportunderstöd'
+    32: 'Understöd för lokaler'
+    34: 'Grundläggande konstundervisning'
+    35: Småbarnspedagogik
+    36: 'Fri bildning'
+    37: Evenemangsbidrag
+    38: 'Små bidrag'
+    39: 'Bidrag för integrationsarbete'
+    40: 'Kultur och fritid: ansökan om understöd'
+    41: Anläggningsunderstöd
+    42: 'Understöd till andra föreningar som främjar idrott och motion'
+    43: 'Riktat understöd för idrott och motion'
+langcode: sv

--- a/conf/cmi/language/sv/grants_metadata.settings.yml
+++ b/conf/cmi/language/sv/grants_metadata.settings.yml
@@ -19,8 +19,8 @@ third_party_options:
         definitionId: grants_metadata_yleisavustushakemus
       labels:
         fi: 'Kaupunginhallituksen yleisavustushakemus'
-        en: 'EN Kaupunginhallituksen yleisavustushakemus'
-        sv: 'SV Kaupunginhallituksen yleisavustushakemus'
+        en: 'City Board, general grant application'
+        sv: 'Ansökan om stadsstyrelsens allmänna understöd'
     51:
       id: KASKOYLEIS
       code: KASKOYLEIS


### PR DESCRIPTION
# [AU-862](https://helsinkisolutionoffice.atlassian.net/browse/AU-862)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Translate subvention types in confs

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-862-avustuslajien-kaannokset`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as end user and go fill an application
* [ ] Check page 2 in every language
* [ ] Subvention types should be translated

![image](https://user-images.githubusercontent.com/26737690/232706848-42f70236-17c5-4478-bb68-bd8f1998b581.png)


[AU-862]: https://helsinkisolutionoffice.atlassian.net/browse/AU-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ