### PR TITLE
feat: AU-993: Activity component that are normal fields

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -65,6 +65,7 @@ module:
   grants_mandate: 0
   grants_metadata: 0
   grants_oma_asiointi: 0
+  grants_premises: 0
   grants_profile: 0
   hal: 0
   hdbt_admin_editorial: 0

--- a/conf/cmi/field.field.node.service.field_hakijatyyppi.yml
+++ b/conf/cmi/field.field.node.service.field_hakijatyyppi.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: service
 label: Hakijatyyppi
 description: 'Kenttä on pakollinen, mutta päivitetään automaattisesti mikäli hakulomake on valittununa yllä. Jos ei hakulomaketta ole valittu, täytä kenttään oikea tieto jotta haut & listaukset toimivat oikein.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/conf/cmi/field.field.node.service.field_industry.yml
+++ b/conf/cmi/field.field.node.service.field_industry.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: service
 label: Industry
 description: 'Kenttä on pakollinen, mutta päivitetään automaattisesti mikäli hakulomake on valittununa yllä. Jos ei hakulomaketta ole valittu, täytä kenttään oikea tieto jotta haut & listaukset toimivat oikein.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/conf/cmi/field.field.node.service.field_target_group.yml
+++ b/conf/cmi/field.field.node.service.field_target_group.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: service
 label: 'Target group'
 description: 'Kenttä on pakollinen, mutta päivitetään automaattisesti mikäli hakulomake on valittununa yllä. Jos ei hakulomaketta ole valittu, täytä kenttään oikea tieto jotta haut & listaukset toimivat oikein.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/conf/cmi/field.storage.node.field_hakijatyyppi.yml
+++ b/conf/cmi/field.storage.node.field_hakijatyyppi.yml
@@ -23,7 +23,7 @@ settings:
   allowed_values_function: ''
 module: options
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -15,7 +15,7 @@ third_party_settings:
       private_person: private_person
     applicationTypeTerms:
       47: '47'
-    applicationOpen: '2022-10-03T11:08:26'
+    applicationOpen: '2022-10-02T11:08:26'
     applicationClose: '2023-06-14T11:19:00'
     applicationContinuous: 0
     applicationTargetGroup: '22'

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -424,9 +424,79 @@ elements: |-
       '#type': webform_section
       '#title': 'Arvio määristä'
       '#description': 'Sy&ouml;t&auml; tiedot koskien koko hanketta, johon avustusta haetaan. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.'
-      markup:
-        '#type': webform_markup
-        '#markup': 'T&auml;h&auml;n tulee Toiminta-osiolle custom composite.'
+      tapahtuma_tai_esityspaivien_maara_helsingissa:
+        '#type': number
+        '#title': 'Tapahtuma- tai esityspäivien määrä Helsingissä.'
+    esityksista:
+      '#type': webform_section
+      '#title': Esityksistä
+      kantaesitysten_maara:
+        '#type': number
+        '#title': 'Kantaesitysten määrä'
+      ensi_iltojen_maara_helsingissa:
+        '#type': number
+        '#title': 'Ensi-iltojen määrä Helsingissä'
+    yleisolle_avoin_toiminta:
+      '#type': webform_section
+      '#title': 'Yleisölle avoin toiminta'
+      postinumero:
+        '#type': textfield
+        '#title': Postinumero
+        '#input_mask': '99999[-9999]'
+      kyseessa_on_kaupungin_omistama_tila:
+        '#type': radios
+        '#title': 'Kyseessä on kaupungin omistama tila'
+        '#options': yes_no
+      tila:
+        '#type': premises_composite
+        '#title': Tila
+        '#multiple': true
+        '#premiseAddress__access': false
+        '#location__access': false
+        '#streetAddress__access': false
+        '#address__access': false
+        '#studentCount__access': false
+        '#specialStudents__access': false
+        '#groupCount__access': false
+        '#specialGroups__access': false
+        '#personnelCount__access': false
+        '#totalRent__access': false
+        '#rentTimeBegin__access': false
+        '#rentTimeEnd__access': false
+        '#free__access': false
+        '#isOthersUse__access': false
+        '#isOwnedByApplicant__access': false
+      ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara:
+        '#type': datetime
+        '#title': 'Ensimmäisen yleisölle avoimen tilaisuuden päivämäärä'
+        '#date_date_element': datepicker
+        '#date_date_format': d.m.Y
+        '#date_year_range': '2023:2010'
+        '#date_time_element': none
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
+        '#type': textfield
+        '#title': 'Festivaalin tai tapahtuman kohdalla tapahtuman päivämäärät'
+      hanke_alkaa:
+        '#type': datetime
+        '#title': 'Hanke alkaa'
+        '#date_date_element': datepicker
+        '#date_date_format': d.m.Y
+        '#date_year_range': '2023:2030'
+        '#date_time_element': none
+      hanke_loppuu:
+        '#type': datetime
+        '#title': 'Hanke loppuu'
+        '#date_date_element': datepicker
+        '#date_date_format': d.m.Y
+        '#date_year_range': '2023:2030'
+        '#date_time_element': none
+    hankekuvaus:
+      '#type': webform_section
+      '#title': Hankekuvaus
+      laajempi_hankekuvaus:
+        '#type': textarea
+        '#title': 'Laajempi hankekuvaus'
+        '#description': 'Kerro hankkeesta tiiviisti. Esim. miksi, mit&auml;, kenelle, miten ja mitk&auml; ovat tavoitteet.'
   5_toiminnan_lahtokohdat:
     '#type': webform_wizard_page
     '#title': '5. Toiminnan lähtökohdat'

--- a/public/modules/custom/grants_handler/src/EventSubscriber/CompanySelectExceptionSubscriber.php
+++ b/public/modules/custom/grants_handler/src/EventSubscriber/CompanySelectExceptionSubscriber.php
@@ -3,6 +3,7 @@
 namespace Drupal\grants_handler\EventSubscriber;
 
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -13,6 +14,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * Grants Handler event subscriber.
  */
 class CompanySelectExceptionSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
 
   /**
    * The messenger.

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -97,6 +97,39 @@ function grants_metadata_webform_presave(Webform $entity) {
   }
 }
 
+///**
+// * Implements hook_ENTITY_TYPE_presave().
+// */
+//function grants_metadata_node_presave(EntityInterface $entity) {
+//
+//  $bundle = $entity->bundle();
+//  if ($bundle == 'service') {
+//
+//    /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $referenceItem */
+//    $referenceItem = $entity->get('field_webform')->first();
+//    if ($referenceItem) {
+//      /** @var \Drupal\Core\Entity\Plugin\DataType\EntityReference $entityReference */
+//      $entityReference = $referenceItem->get('entity');
+//
+//      /** @var \Drupal\Core\Entity\Plugin\DataType\EntityAdapter $entityAdapter */
+//      $entityAdapter = $entityReference->getTarget();
+//
+//      /** @var \Drupal\Core\Entity\EntityInterface $referencedEntity */
+//      $referencedEntity = $entityAdapter->getValue();
+//
+//      // Get third party settings.
+//      $thirdPartySettings = $referencedEntity->getThirdPartySettings('grants_metadata');
+//
+//      // Get entity status.
+//      $status = $referencedEntity->isOpen();
+//
+//      // Update node values from 3rd party settings.
+//      grants_metadata_set_node_values($entity, $status, $thirdPartySettings);
+//    }
+//  }
+//
+//}
+
 /**
  * Add configurations from webform to given node.
  *
@@ -116,7 +149,7 @@ function grants_metadata_set_node_values(Node &$page, bool $status, mixed $third
   $page->set('field_application_open', $status);
   // Applicant types.
   if (!empty($thirdPartySettings["applicantTypes"])) {
-    $page->set('field_hakijatyyppi',$thirdPartySettings["applicantTypes"]);
+    $page->set('field_hakijatyyppi',array_values($thirdPartySettings["applicantTypes"]));
   }
   // Type terms.
   if (!empty($thirdPartySettings["applicationTypeTerms"])) {

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -5,7 +5,6 @@
  * Module hooks.
  */
 
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormStateInterface;
@@ -97,39 +96,6 @@ function grants_metadata_webform_presave(Webform $entity) {
   }
 }
 
-///**
-// * Implements hook_ENTITY_TYPE_presave().
-// */
-//function grants_metadata_node_presave(EntityInterface $entity) {
-//
-//  $bundle = $entity->bundle();
-//  if ($bundle == 'service') {
-//
-//    /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $referenceItem */
-//    $referenceItem = $entity->get('field_webform')->first();
-//    if ($referenceItem) {
-//      /** @var \Drupal\Core\Entity\Plugin\DataType\EntityReference $entityReference */
-//      $entityReference = $referenceItem->get('entity');
-//
-//      /** @var \Drupal\Core\Entity\Plugin\DataType\EntityAdapter $entityAdapter */
-//      $entityAdapter = $entityReference->getTarget();
-//
-//      /** @var \Drupal\Core\Entity\EntityInterface $referencedEntity */
-//      $referencedEntity = $entityAdapter->getValue();
-//
-//      // Get third party settings.
-//      $thirdPartySettings = $referencedEntity->getThirdPartySettings('grants_metadata');
-//
-//      // Get entity status.
-//      $status = $referencedEntity->isOpen();
-//
-//      // Update node values from 3rd party settings.
-//      grants_metadata_set_node_values($entity, $status, $thirdPartySettings);
-//    }
-//  }
-//
-//}
-
 /**
  * Add configurations from webform to given node.
  *
@@ -149,7 +115,7 @@ function grants_metadata_set_node_values(Node &$page, bool $status, mixed $third
   $page->set('field_application_open', $status);
   // Applicant types.
   if (!empty($thirdPartySettings["applicantTypes"])) {
-    $page->set('field_hakijatyyppi',array_values($thirdPartySettings["applicantTypes"]));
+    $page->set('field_hakijatyyppi', array_values($thirdPartySettings["applicantTypes"]));
   }
   // Type terms.
   if (!empty($thirdPartySettings["applicationTypeTerms"])) {

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -98,39 +98,6 @@ function grants_metadata_webform_presave(Webform $entity) {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_presave().
- */
-function grants_metadata_node_presave(EntityInterface $entity) {
-
-  $bundle = $entity->bundle();
-  if ($bundle == 'service') {
-
-    /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $referenceItem */
-    $referenceItem = $entity->get('field_webform')->first();
-    if ($referenceItem) {
-      /** @var \Drupal\Core\Entity\Plugin\DataType\EntityReference $entityReference */
-      $entityReference = $referenceItem->get('entity');
-
-      /** @var \Drupal\Core\Entity\Plugin\DataType\EntityAdapter $entityAdapter */
-      $entityAdapter = $entityReference->getTarget();
-
-      /** @var \Drupal\Core\Entity\EntityInterface $referencedEntity */
-      $referencedEntity = $entityAdapter->getValue();
-
-      // Get third party settings.
-      $thirdPartySettings = $referencedEntity->getThirdPartySettings('grants_metadata');
-
-      // Get entity status.
-      $status = $referencedEntity->isOpen();
-
-      // Update node values from 3rd party settings.
-      grants_metadata_set_node_values($entity, $status, $thirdPartySettings);
-    }
-  }
-
-}
-
-/**
  * Add configurations from webform to given node.
  *
  * @param \Drupal\node\Entity\Node $page
@@ -149,7 +116,7 @@ function grants_metadata_set_node_values(Node &$page, bool $status, mixed $third
   $page->set('field_application_open', $status);
   // Applicant types.
   if (!empty($thirdPartySettings["applicantTypes"])) {
-    $page->set('field_hakijatyyppi', $thirdPartySettings["applicantTypes"]);
+    $page->set('field_hakijatyyppi',$thirdPartySettings["applicantTypes"]);
   }
   // Type terms.
   if (!empty($thirdPartySettings["applicationTypeTerms"])) {

--- a/public/modules/custom/grants_metadata/grants_metadata.services.yml
+++ b/public/modules/custom/grants_metadata/grants_metadata.services.yml
@@ -2,3 +2,6 @@ services:
   grants_metadata.atv_schema:
     class: Drupal\grants_metadata\AtvSchema
     arguments: ['@typed_data_manager', '@logger.factory']
+
+  grants_metadata.converter:
+    class: Drupal\grants_metadata\GrantsConverterService

--- a/public/modules/custom/grants_metadata/src/GrantsConverterService.php
+++ b/public/modules/custom/grants_metadata/src/GrantsConverterService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\grants_metadata;
+
+/**
+ * Provide useful helper for converting values.
+ */
+class GrantsConverterService {
+
+  const DEFAULT_DATETIME_FORMAT = 'c';
+
+  /**
+   * Format dates to a given or default format.
+   *
+   * @param string $value
+   *   Input value.
+   * @param array $arguments
+   *   Arguments, dateFormat is used.
+   *
+   * @return string
+   *   Formatted datetime string.
+   */
+  public function convertDates(string $value, array $arguments): string {
+
+    try {
+      $dateObject = new \DateTime($value);
+      if (isset($arguments['dateFormat'])) {
+        $retval = $dateObject->format($arguments['dateFormat']);
+      }
+      else {
+        $retval = $dateObject->format(self::DEFAULT_DATETIME_FORMAT);
+      }
+
+    }
+    catch (\Exception $e) {
+      $retval = '';
+    }
+
+    return $retval;
+  }
+
+}

--- a/public/modules/custom/grants_metadata/src/Plugin/DataType/DataFormatTrait.php
+++ b/public/modules/custom/grants_metadata/src/Plugin/DataType/DataFormatTrait.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\grants_metadata\Plugin\DataType;
 
+use Drupal\grants_metadata\AtvSchema;
+
 /**
  * Trait to handle generic value settings for implementing data.
  */
@@ -18,6 +20,7 @@ trait DataFormatTrait {
 
       $defaultValue = $definition->getSetting('defaultValue');
       $valueCallback = $definition->getSetting('valueCallback');
+      $itemTypes = AtvSchema::getJsonTypeForDataType($definition);
 
       if (!is_array($values)) {
         $formattedData[$name] = NULL;
@@ -31,7 +34,7 @@ trait DataFormatTrait {
           }
 
           if ($valueCallback) {
-            $value = call_user_func($valueCallback, $value);
+            $value = AtvSchema::getItemValue($itemTypes, $value, $defaultValue, $valueCallback);
           }
           $formattedData[$name] = $value;
         }

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -180,6 +180,142 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'toiminta_yhteistyokumppanit',
         ]);
 
+      $info['tapahtuma_tai_esityspaivien_maara_helsingissa'] = DataDefinition::create('string')
+        ->setLabel('Tapahtuma- tai esityspäivien määrä Helsingissä.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'eventDaysCountHki',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'int',
+        ]);
+
+      $info['kantaesitysten_maara'] = DataDefinition::create('string')
+        ->setLabel('Kantaesitysten määrä.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'firstPublicPerformancesCount',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'int',
+        ]);
+
+      $info['ensi_iltojen_maara_helsingissa'] = DataDefinition::create('string')
+        ->setLabel('Ensi-iltojen määrä Helsingissä.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'premiereCountHki',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'int',
+        ]);
+
+      $info['postinumero'] = DataDefinition::create('string')
+        ->setLabel('Postinumero.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'firstPublicEventLocationPostCode',
+        ]);
+
+      $info['kyseessa_on_kaupungin_omistama_tila'] = DataDefinition::create('string')
+        ->setLabel('Kyseessä on kaupungin omistama tila.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'isOwnedByCity',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'bool',
+        ]);
+
+      $info['ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara'] = DataDefinition::create('string')
+        ->setLabel('Ensimmäisen yleisölle avoimen tilaisuuden päivämäärä.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'firstPublicOccasionDate',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'datetime',
+        ])
+        ->setSetting('valueCallback', [
+          'service' => 'grants_metadata.converter',
+          'method' => 'convertDates',
+          'arguments' => [
+            'dateFormat' => 'c',
+          ],
+        ]);
+      $info['hanke_alkaa'] = DataDefinition::create('string')
+        ->setLabel('Hanke alkaa.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'projectStartDate',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'datetime',
+        ])
+        ->setSetting('valueCallback', [
+          'service' => 'grants_metadata.converter',
+          'method' => 'convertDates',
+          'arguments' => [
+            'dateFormat' => 'c',
+          ],
+        ]);
+      $info['hanke_loppuu'] = DataDefinition::create('string')
+        ->setLabel('Hanke loppuu.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'projectEndDate',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'datetime',
+        ])
+        ->setSetting('valueCallback', [
+          'service' => 'grants_metadata.converter',
+          'method' => 'convertDates',
+          'arguments' => [
+            'dateFormat' => 'c',
+          ],
+        ]);
+
+      $info['festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat'] = DataDefinition::create('string')
+        ->setLabel('Tapahtuman tai festivaalin kohdalla tapahtuman päivämäärät.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'eventOrFestivalDates',
+        ]);
+      $info['laajempi_hankekuvaus'] = DataDefinition::create('string')
+        ->setLabel('Laajempi hankekuvaus.')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedActivityInfoArray',
+          'detailedProjectDescription',
+        ]);
+
     }
     return $this->propertyDefinitions;
   }

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -316,6 +316,23 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'detailedProjectDescription',
         ]);
 
+      $info['tila'] = ListDataDefinition::create('grants_premises')
+        ->setLabel('Tilat')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'activityInfo',
+          'plannedPremisesArray',
+        ])
+        ->setSetting('fullItemValueCallback', [
+          'service' => 'grants_premises.service',
+          'method' => 'processPremises',
+        ])
+        ->setSetting('fieldsForApplication', [
+          'premiseName',
+          'isOwnedByCity',
+          'postCode',
+        ]);
+
     }
     return $this->propertyDefinitions;
   }


### PR DESCRIPTION
# [AU-923](https://helsinkisolutionoffice.atlassian.net/browse/AU-923)
<!-- What problem does this solve? -->


So yeah. No point doing custom component for these since they are normal form fields.


## What was done
<!-- Describe what was done -->

* Added activity fields as normal fields.
* Created data mappers for them
* Updated schema mapper a bit to use services as value callbacks as well

## How to install

* Make sure your instance is up and running on correct branch.
  * `git feature/AU-993-activity-component`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Setup kuva service page to support forms: Select form and add node to menu
* [ ] Fill form
* [ ] Check that code follows our standards



[AU-923]: https://helsinkisolutionoffice.atlassian.net/browse/AU-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ