### PR TITLE
fix: AU-XX remove hardcoded notifications from forms

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
+++ b/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
@@ -140,7 +140,7 @@ class ApplicantInfoService {
   /**
    * Extact data.
    *
-   * @param ApplicantInfoDefinition $property
+   * @param \Drupal\grants_applicant_info\TypedData\Definition\ApplicantInfoDefinition $property
    *   Property.
    * @param array $content
    *   Doc content.

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -674,7 +674,6 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
                 ($element_contents['#type'] === 'community_address_composite' ||
                   $element_contents['#type'] === 'community_officials_composite' ||
                   $element_contents['#type'] === 'bank_account_composite' ||
-                  $element_contents['#type'] === 'bank_account_composite' ||
                   $element_key === 'community_purpose'
                 )
               ) {

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -657,10 +657,45 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
           '#label' => t('Fields marked with an asterisk * are required, that need to be filled before saving.'),
         ],
     ];
+    foreach ($form['elements'] as $page_name => $page_contents) {
+      $page_prefetched = FALSE;
+      $page_required = FALSE;
+      if ($page_name === 'actions') {
+        break;
+      }
+      foreach ($form['elements'][$page_name] as $section_key => $section_contents) {
+        if (!strstr($section_key, '#') && is_array($section_contents)) {
+          foreach ($section_contents as $element_key => $element_contents) {
+            if (!strstr($element_key, '#') && is_array($element_contents)) {
+              if (array_key_exists('#required', $element_contents) && $element_contents['#required'] === TRUE) {
+                $page_required = TRUE;
+              }
+              if (array_key_exists('#type', $element_contents) &&
+                ($element_contents['#type'] === 'community_address_composite' ||
+                  $element_contents['#type'] === 'community_officials_composite' ||
+                  $element_contents['#type'] === 'bank_account_composite' ||
+                  $element_contents['#type'] === 'bank_account_composite' ||
+                  $element_key === 'community_purpose'
+                )
+              ) {
+                $page_prefetched = TRUE;
+              }
+              if ($page_required && $page_prefetched) {
+                break 2;
+              }
+            }
+          }
+        }
+      }
+      if (!$isClosed && $page_required) {
+        $form['elements'][$page_name] = array_merge($required_fields_info_element, $form['elements'][$page_name]);
+      }
+      if (!$isClosed && $page_prefetched) {
+        $form['elements'][$page_name] = array_merge($infoelement, $form['elements'][$page_name]);
+      }
+    }
 
     if (!$isClosed && array_key_exists('1_hakijan_tiedot', $form['elements']) && is_array($form['elements']['1_hakijan_tiedot'])) {
-      $form['elements']['1_hakijan_tiedot'] = array_merge($required_fields_info_element, $form['elements']['1_hakijan_tiedot']);
-      $form['elements']['1_hakijan_tiedot'] = array_merge($infoelement, $form['elements']['1_hakijan_tiedot']);
 
       if (isset($grantsProfile["companyName"])) {
         _grants_handler_imported_handler($form["elements"]["1_hakijan_tiedot"]["yhteiso_jolle_haetaan_avustusta"]["community_official_name"], $grantsProfile["companyName"]);
@@ -706,16 +741,6 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
         _grants_handler_imported_handler($form["elements"]["1_hakijan_tiedot"]["verkkosivut"]["homepage"], $grantsProfile["companyHomePage"], FALSE);
       }
 
-    }
-    if (!$isClosed && array_key_exists('2_avustustiedot', $form['elements']) && is_array($form['elements']['2_avustustiedot'])) {
-      $form['elements']['2_avustustiedot'] = array_merge($required_fields_info_element, $form['elements']['2_avustustiedot']);
-    }
-    if (!$isClosed && array_key_exists('3_yhteison_tiedot', $form['elements']) && is_array($form['elements']['3_yhteison_tiedot'])) {
-      $form['elements']['3_yhteison_tiedot'] = array_merge($required_fields_info_element, $form['elements']['3_yhteison_tiedot']);
-      $form['elements']['3_yhteison_tiedot'] = array_merge($infoelement, $form['elements']['3_yhteison_tiedot']);
-    }
-    if (!$isClosed && array_key_exists('lisatiedot_ja_liitteet', $form['elements']) && is_array($form['elements']['lisatiedot_ja_liitteet'])) {
-      $form['elements']['lisatiedot_ja_liitteet'] = array_merge($required_fields_info_element, $form['elements']['lisatiedot_ja_liitteet']);
     }
 
   }


### PR DESCRIPTION
# AU-XX
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removes page-specific hardcoded notifications and replaces them with dynamic ones.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-899-kuva-projektihakemus-webform-hardcodes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works (notifications of the "this page has required fields" and "this page has pre-fetched fields" sort on correct pages)
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review