### PR TITLE
fix: AU-795: Changed asiointirooli-block's link to 'switch mandate' in every role

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-asiointirooli-block.html.twig
+++ b/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-asiointirooli-block.html.twig
@@ -1,5 +1,5 @@
 {% set name = companyName ? companyName : 'Private person'|t({}, {'context': 'Asiointirooli block'}) %}
-{% set link = companyName ? logOut : switchRole %}
+{% set link = switchRole %}
 
 <div class="asiointirooli-block">
   <div class="container">


### PR DESCRIPTION
# [AU-795](https://helsinkisolutionoffice.atlassian.net/browse/AU-795)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed asiointirooli-block's link to switch mandate in every role

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-795-asiointirooli-block`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as end user and check that this link is always "Vaihda asiointiroolia"

![image](https://user-images.githubusercontent.com/26737690/234220094-98aea25b-d015-4cb6-b870-1efd74b17ebf.png)



[AU-795]: https://helsinkisolutionoffice.atlassian.net/browse/AU-795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ