### PR TITLE
feat: AU-1000: Make GrantsHandler respect applicant type for all users.

### DIFF
--- a/public/modules/custom/grants_handler/src/EventSubscriber/CompanySelectExceptionSubscriber.php
+++ b/public/modules/custom/grants_handler/src/EventSubscriber/CompanySelectExceptionSubscriber.php
@@ -44,7 +44,9 @@ class CompanySelectExceptionSubscriber implements EventSubscriberInterface {
     $ex = $event->getThrowable();
     $exceptionClass = get_class($ex);
     if ($exceptionClass === 'Drupal\grants_mandate\CompanySelectException') {
-      $this->messenger->addError($this->t('You must have company & authorisation set before applying.'));
+      // @codingStandardsIgnoreStart
+      $this->messenger->addError($this->t($ex->getMessage()));
+      // @codingStandardsIgnoreEnd
 
       $url = Url::fromRoute('grants_mandate.mandateform');
       $response = new RedirectResponse($url->toString());

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -402,3 +402,9 @@ msgstr "Sinulla on oltava profiilissasi tallennettu tilinumero."
 
 msgid "You must have grants profile created."
 msgstr "Sinulla on oltava hakemusprofiili luotu."
+
+msgid "User does not have proper mandate."
+msgstr "Käyttäjällä ei ole sopivaa asiointiroolia."
+
+msgid "User role is not allowed to use this form."
+msgstr "Aktiivisella asiointiroolilla ei ole pääsyoikeutta lomakkeelle."

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -724,7 +724,7 @@ class GrantsProfileFormUnregisteredCommunity extends FormBase {
    *   Form.
    * @param \Drupal\Core\Form\FormStateInterface $formState
    *   Form state.
-   * @param array $officials
+   * @param array|null $officials
    *   Current officials.
    * @param string|null $newItem
    *   Name of new item.
@@ -732,7 +732,7 @@ class GrantsProfileFormUnregisteredCommunity extends FormBase {
   public function addOfficialBits(
     array &$form,
     FormStateInterface $formState,
-    array $officials,
+    ?array $officials,
     ?string $newItem
   ) {
     $form['officialWrapper'] = [


### PR DESCRIPTION
# [AU-1000](https://helsinkisolutionoffice.atlassian.net/browse/AU-1000)
# [AU-882](https://helsinkisolutionoffice.atlassian.net/browse/AU-882)

<!-- What problem does this solve? -->

Grants handler did not force user applicant roles and the one selected on form. Now this is enforced, and only users with proper applicant roles can access given form.

## What was done
<!-- Describe what was done -->

* Add check to GrantsHandler to require matching applicant roles.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1000-grantshandler-roles`
  * `make fresh` / `drush deploy` inside container
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Check that some form has only one role selected
* Select different role for user
* Try accessing the form that has not the user active role selected
* See that you're redirected to mandate form with an error message.



[AU-1000]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-882]: https://helsinkisolutionoffice.atlassian.net/browse/AU-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ