### PR TITLE
AU-847: Allow language switcher to work on edit application pages

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -60,7 +60,7 @@ module:
   grants_budget_components: 0
   grants_front_banner: 0
   grants_frontpage_info_block: 0
-  grants_handler: 0
+  grants_handler: 1
   grants_healtz: 0
   grants_industries: 0
   grants_mandate: 0

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -5,6 +5,7 @@
  * Provides an example of a webform handler.
  */
 
+use Drupal\webform\Entity\Webform;
 use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Drupal\block_content\Entity\BlockContent;
@@ -1597,4 +1598,36 @@ function grants_handler_preprocess_fieldset(&$variables) {
   if (isset($variables['element']['#attributes']['error_label'])) {
     $variables['errors'] = $variables['element']['#attributes']['error_label'];
   }
+}
+
+/**
+ * Implements hook_language_switch_links_alter().
+ */
+function grants_handler_language_switch_links_alter(array &$links) {
+  $route_match = Drupal::routeMatch();
+  if (!$route_match) {
+    return;
+  }
+
+  $route_name = $route_match->getRouteName();
+
+  if ($route_name === 'grants_handler.edit_application') {
+    $webform_key = $route_match->getParameter('webform');
+    $webform = Webform::load($webform_key);
+
+    if (!$webform) {
+      return;
+    }
+
+    // If we have translations for webform, override
+    // untranslated as original hbdt doesn't take account into dynamic routes.
+    $translations = array_keys($webform->getTranslationLanguages());
+
+    foreach ($translations as $translation) {
+      if ($links[$translation]) {
+        $links[$translation]['#untranslated'] = FALSE;
+      }
+    }
+  }
+
 }

--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -968,6 +968,7 @@ class ApplicationHandler {
       'applicationnumber' => $applicationNumber,
       'applicant_type' => $selectedCompany['type'],
       'applicant_id' => $selectedCompany['identifier'],
+      'application_language' => \Drupal::languageManager()->getCurrentLanguage()->getId(),
     ]);
 
     $typeData = $this->webformToTypedData($submissionData);

--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\grants_handler\Plugin\WebformElement;
 
-use Drupal\grants_profile\Form\GrantsProfileFormRegisteredCommunity;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\webform\WebformSubmissionInterface;
 


### PR DESCRIPTION
# [AU-847](https://helsinkisolutionoffice.atlassian.net/browse/AU-847)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Hook to make language switch links work on edit application pages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-847-application-edit-page-language-switch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->


[AU-847]: https://helsinkisolutionoffice.atlassian.net/browse/AU-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ