### PR TITLE
AU-994: Service channel link cache , missing attachment description

### DIFF
--- a/public/modules/custom/grants_handler/src/Form/MessageForm.php
+++ b/public/modules/custom/grants_handler/src/Form/MessageForm.php
@@ -149,6 +149,9 @@ class MessageForm extends FormBase {
         'file_validate_extensions' => ['doc docx gif jpg jpeg pdf png ppt pptx rtf txt xls xlsx zip'],
         'file_validate_size' => [$maxFileSizeInBytes],
       ],
+      '#description' => $this->t('Only one file.<br>Limit: 32 MB.<br>
+Allowed file types: doc, docx, gif, jpg, jpeg, pdf, png, ppt, pptx,
+rtf, txt, xls, xlsx, zip.'),
       '#element_validate' => ['\Drupal\grants_handler\Form\MessageForm::validateUpload'],
       '#upload_location' => $upload_location,
       '#sanitize' => TRUE,

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -80,7 +80,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'communityInfo',
           'generalCommunityInfoArray',
           'staffPeopleFulltime',
-        ]) ->setSetting('valueCallback', [
+        ])->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
         ])
@@ -96,7 +96,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'communityInfo',
           'generalCommunityInfoArray',
           'staffPeopleFulltime',
-        ]) ->setSetting('valueCallback', [
+        ])->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
         ])
@@ -121,7 +121,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'communityInfo',
           'generalCommunityInfoArray',
           'staffPeopleVoluntary',
-        ]) ->setSetting('valueCallback', [
+        ])->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
         ])
@@ -137,7 +137,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'communityInfo',
           'generalCommunityInfoArray',
           'staffManyearsFulltime',
-        ]) ->setSetting('valueCallback', [
+        ])->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
         ])
@@ -153,7 +153,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'communityInfo',
           'generalCommunityInfoArray',
           'staffManyearsParttime',
-        ]) ->setSetting('valueCallback', [
+        ])->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
         ])

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -478,7 +478,7 @@ function hdbt_subtheme_preprocess_tpr_service_channel(array &$variables) {
   $typeName = $node ? $node->bundle() : NULL;
 
   if ($typeName === 'service') {
-
+    $variables['#cache']['max-age'] = 0;
     $webform = $node->get('field_webform')->target_id;
 
     if (!isset($variables['content']['links']) || !$webform) {


### PR DESCRIPTION
# [AU-994](https://helsinkisolutionoffice.atlassian.net/browse/AU-994)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-994-tpr-link-fix?`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Comment out $settings['cache] configs in your `local.settings.php`
* [ ] Check that service pages service links are not cached for user (Unauthenticated should see login in and logged in either nothing or new application button).
* [ ] Messages attachment field has a description about 1 file limit and size + extensions



[AU-994]: https://helsinkisolutionoffice.atlassian.net/browse/AU-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ