### PR TITLE
AU-866: Validate addresses and display errors

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -638,7 +638,7 @@ class GrantsProfileFormRegisteredCommunity extends FormBase {
 
     $addressValues = $formState->getValue('addressWrapper') ?? $addresses;
     unset($addressValues['actions']);
-    foreach ($addressValues as $delta => $address) {
+    foreach (array_values($addressValues) as $delta => $address) {
       if (array_key_exists('address', $address)) {
         $temp = $address['address'];
         unset($address['address']);
@@ -698,7 +698,7 @@ class GrantsProfileFormRegisteredCommunity extends FormBase {
 
     if ($newItem == 'addressWrapper') {
 
-      $form['addressWrapper'][count($addressValues) + 1] = [
+      $form['addressWrapper'][] = [
         'address' => [
           '#type' => 'fieldset',
           '#title' => $this->t('Community address'),

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -414,7 +414,7 @@ class GrantsProfileFormUnregisteredCommunity extends FormBase {
               $errorMesg = 'You must add one address';
             }
             else {
-              $propertyPath = 'addressWrapper][' . ($propertyPathArray[1] + 1) . '][address][' . $propertyPathArray[2];
+              $propertyPath = 'addressWrapper][' . $propertyPathArray[1] . '][address][' . $propertyPathArray[2];
             }
           }
           elseif ($propertyPathArray[0] == 'bankAccounts') {
@@ -585,7 +585,7 @@ class GrantsProfileFormUnregisteredCommunity extends FormBase {
 
     $addressValues = $formState->getValue('addressWrapper') ?? $addresses;
     unset($addressValues['actions']);
-    foreach ($addressValues as $delta => $address) {
+    foreach (array_values($addressValues) as $delta => $address) {
       if (array_key_exists('address', $address)) {
         $temp = $address['address'];
         unset($address['address']);
@@ -639,7 +639,7 @@ class GrantsProfileFormUnregisteredCommunity extends FormBase {
 
     if ($newItem == 'addressWrapper') {
 
-      $form['addressWrapper'][count($addressValues) + 1] = [
+      $form['addressWrapper'][] = [
         'address' => [
           '#type' => 'fieldset',
           '#title' => $this->t('Community address'),


### PR DESCRIPTION
# [AU-866](https://helsinkisolutionoffice.atlassian.net/browse/AU-866)
<!-- What problem does this solve? -->

Sometimes the validation are not shown correctly to the user. This is due to the delta values for multi value address fields can be wrong (for example, often the first item has delta of `1`, not `0`)

## What was done
<!-- Describe what was done -->

Makes the deltas for multi value address fields consistent.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Edit addresses for registered or unregistered communities
* [ ] Leave some of the address fields empty
* [ ] The error message(s) should identify the corresponding field, NOT display a generic error "This field should not be null"


[AU-866]: https://helsinkisolutionoffice.atlassian.net/browse/AU-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ