### PR TITLE
fix: AU-1019: remove dot from frontpage info block title & change site name

### DIFF
--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -8,7 +8,7 @@ slogan: ''
 page:
   403: ''
   404: ''
-  front: /node/45
+  front: /avustukset
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -2,13 +2,13 @@ _core:
   default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI
 langcode: fi
 uuid: c7259448-db95-43bf-9851-b51cf95b0159
-name: 'Hel.fi Avustusasiointi'
+name: Avustusasiointi
 mail: noreply@hel.fi
 slogan: ''
 page:
   403: ''
   404: ''
-  front: /avustukset
+  front: /node/45
 admin_compact_mode: false
 weight_select_max: 100
 default_langcode: en

--- a/public/modules/custom/grants_frontpage_info_block/templates/block--grants-frontpage-info-block.html.twig
+++ b/public/modules/custom/grants_frontpage_info_block/templates/block--grants-frontpage-info-block.html.twig
@@ -10,7 +10,7 @@
       <div class="banner__content-wrapper">
         <div class="banner__content">
           <h2 class="banner__title" id="kaupungin-sivut-uudistuvat">
-            {{ "The transition to the new grants service will take place in stages during 2023."|t }}
+            {{ "The transition to the new grants service will take place in stages during 2023"|t }}
           </h2>
           <div class="banner__desc">
             <p>{{ "Grant forms are being worked on for the new transaction at a fast pace! Despite this, some applications are still filled out in the old transaction service. We list all the applications found on this site in the list below."|t }}</p>

--- a/public/modules/custom/grants_frontpage_info_block/translations/fi.po
+++ b/public/modules/custom/grants_frontpage_info_block/translations/fi.po
@@ -3,8 +3,8 @@
 msgid ""
 msgstr ""
 
-msgid "The transition to the new grants service will take place in stages during 2023."
-msgstr "Uuteen avustusasiointiin siirtyminen tapahtuu vaiheittain vuoden 2023 aikana."
+msgid "The transition to the new grants service will take place in stages during 2023"
+msgstr "Uuteen avustusasiointiin siirtyminen tapahtuu vaiheittain vuoden 2023 aikana"
 
 msgid "Grant forms are being worked on for the new transaction at a fast pace! Despite this, some applications are still filled out in the old transaction service. We list all the applications found on this site in the list below."
 msgstr "Avustuslomakkeita työstetään uuteen asiointiin kovaa vauhtia! Tästä huolimatta osa hakemuksista täytetään vielä vanhassa asiointipalvelussa. Listaamme kaikki tältä sivustolta löytyvät hakemukset alla olevaan listaan."

--- a/public/modules/custom/grants_frontpage_info_block/translations/sv.po
+++ b/public/modules/custom/grants_frontpage_info_block/translations/sv.po
@@ -3,8 +3,8 @@
 msgid ""
 msgstr ""
 
-msgid "The transition to the new grants service will take place in stages during 2023."
-msgstr "Övergången till den nya bidragstjänsten kommer att ske stegvis under 2023."
+msgid "The transition to the new grants service will take place in stages during 2023"
+msgstr "Övergången till den nya bidragstjänsten kommer att ske stegvis under 2023"
 
 msgid "Grant forms are being worked on for the new transaction at a fast pace! Despite this, some applications are still filled out in the old transaction service. We list all the applications found on this site in the list below."
 msgstr "Anslagsformulär arbetar i snabb takt för den nya transaktionen! Trots detta är vissa ansökningar fortfarande ifyllda i den gamla transaktionstjänsten. Vi listar alla ansökningar som finns på denna sida i listan nedan."


### PR DESCRIPTION
# [AU-1019](https://helsinkisolutionoffice.atlassian.net/browse/AU-1019)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove dot from frontpage info block title
* Change site name to Avustusasiointi

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/1019-etusivu`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that title is Avustusasiointi
* [ ] Check that front page info block title has no dot


[AU-1019]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ