### PR TITLE
fix: AU-950: fix accessible tooltips

### DIFF
--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -618,7 +618,7 @@ elements: |-
       laajempi_hankekuvaus:
         '#type': textarea
         '#title': 'Laajempi hankekuvaus'
-        '#description': 'Kerro hankkeesta tiiviisti. Esim. miksi, mit&auml;, kenelle, miten ja mitk&auml; ovat tavoitteet.'
+        '#help': 'Kerro hankkeesta tiiviisti. Esim. miksi, mit&auml;, kenelle, miten ja mitk&auml; ovat tavoitteet.'
   5_toiminnan_lahtokohdat:
     '#type': webform_wizard_page
     '#title': '5. Toiminnan lähtökohdat'

--- a/public/themes/custom/hdbt_subtheme/templates/webform/webform-element-help.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/webform/webform-element-help.html.twig
@@ -15,5 +15,5 @@
 #}
 {% spaceless %}
 {{ attach_library('webform/webform.element.help') }}
-<span{{ attributes }}><span aria-hidden="true" class="hel-icon hel-icon--info-circle hel-icon--size-s"></span></span>
+<span{{ attributes }} aria-describedby="tippy-1"><span aria-hidden="true" class="hel-icon hel-icon--info-circle hel-icon--size-s"></span></span>
 {% endspaceless %}


### PR DESCRIPTION
# [AU-950](https://helsinkisolutionoffice.atlassian.net/browse/AU-950)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed the tooltip to point at the correct element

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-950-tooltip-a11y-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to a form
* [ ] See that the tooltip element has a aria-describedby attribute pointing to "tippy-1" element.
* [ ] When hovering on the tooltip element and the tooltip appearing, see that the ID of the appearing element is "tippy-1"
* [ ] Check that code follows our standards


[AU-950]: https://helsinkisolutionoffice.atlassian.net/browse/AU-950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ