### PR TITLE
fix: AU-1014: Add translations to preview warning

### DIFF
--- a/conf/cmi/language/fi/webform.settings.yml
+++ b/conf/cmi/language/fi/webform.settings.yml
@@ -4,6 +4,7 @@ settings:
   default_delete_button_label: Poista
   default_preview_next_button_label: Esikatselu
   default_preview_label: Esikatselu
+  default_preview_message: 'Hyväksy ehdot ja lähetä hakemus.'
   dialog_options:
     narrow:
       title: Kapea

--- a/conf/cmi/language/sv/webform.settings.yml
+++ b/conf/cmi/language/sv/webform.settings.yml
@@ -10,6 +10,7 @@ settings:
   default_wizard_toggle_hide_label: 'Piilota kaikki'
   default_preview_next_button_label: Förhandsgranska
   default_preview_label: Förhandsgranska
+  default_preview_message: 'Acceptera villkoren och skicka ansökan.'
   default_draft_button_label: 'Spara utkast'
   default_draft_saved_message: 'Formulär sparat. Du kan återvända till detta formulär senare och fortsätta inmatningen.'
   default_confirmation_message: 'Lisätty uusi lähetys lomakkeelle [webform:title].'


### PR DESCRIPTION
# [AU-1014](https://helsinkisolutionoffice.atlassian.net/browse/AU-1014)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added translations to application preview warning message

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1014-warning-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go fill an application and to to the preview page
* [ ] Check that you see the warning message in correct language

[AU-1014]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ