### PR TITLE
fix: AU-1005: Add max width to number element

### DIFF
--- a/public/themes/custom/hdbt_subtheme/src/scss/components/webform/_form_elements.scss
+++ b/public/themes/custom/hdbt_subtheme/src/scss/components/webform/_form_elements.scss
@@ -64,6 +64,10 @@ $breakpoint-xl: 1248px;
 .hds-text-input {
   max-width: fit-content;
   width: 100%;
+
+  &.js-form-type-number {
+    max-width: 200px;
+  }
 }
 .webform-section-grid-wrapper {
   display: grid;


### PR DESCRIPTION
# [AU-1005](https://helsinkisolutionoffice.atlassian.net/browse/AU-1005)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add max width to number element

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1005-number-fields`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that number fields have the same width in budget component

[AU-1005]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ