### PR TITLE
AU-860: Correctly delete latest attachment

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -851,7 +851,7 @@ rtf, txt, xls, xlsx, zip.'),
         return FALSE;
       });
 
-    $attachmentToDelete = reset($attachmentToDelete);
+    $attachmentToDelete = end($attachmentToDelete);
     $hrefToDelete = NULL;
 
     // If attachment is found.

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -1275,7 +1275,7 @@ rtf, txt, xls, xlsx, zip.'),
         return FALSE;
       });
 
-    $attachmentToDelete = reset($attachmentToDelete);
+    $attachmentToDelete = end($attachmentToDelete);
     $hrefToDelete = NULL;
 
     // If attachment is found.

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -1222,7 +1222,7 @@ rtf, txt, xls, xlsx, zip.'),
         return FALSE;
       });
 
-    $attachmentToDelete = reset($attachmentToDelete);
+    $attachmentToDelete = end($attachmentToDelete);
     $hrefToDelete = NULL;
 
     // If attachment is found.


### PR DESCRIPTION
# [AU-860](https://helsinkisolutionoffice.atlassian.net/browse/AU-860)
<!-- What problem does this solve? -->

Previously, when deleting a bank account attachment from ATV, the file it actually removed was not correct 100% of the time. This was caused by two issues:

1. The `delta` of the bank account wrapper was bugged, f.ex. sometimes starting with either 0 or 1. This was fixed in https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/365
2. The deletion method looks for the removed file via the uploaded file filename. If you upload several files with same name, the method deletes just the first one it encounters. This issue is fixed in this PR

## What was done
<!-- Describe what was done -->

* Fixed so that the last uploaded file with same name is deleted, not the first one.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login with any of the three profile types
* [ ] Upload a bank account confirmation attachment file in profile
* [ ] Delete the attachment file
* [ ] Check in ATV that correct file was deleted


[AU-860]: https://helsinkisolutionoffice.atlassian.net/browse/AU-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ