### PR TITLE
AU-1022 Handle dummy boolean fields in webform

### DIFF
--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -192,10 +192,18 @@ elements: |-
         '#type': textarea
         '#title': 'Tulevat vuodet joiden ajalle monivuotista avustusta on haettu tai myönnetty'
         '#help': 'T&auml;yt&auml; vuodet vain t&auml;st&auml; eteenp&auml;in haettavan avustuskauden osalta. &Auml;l&auml; kirjaa saman tai aikaisemman avustuskauden aikaisempia vuosia.'
+        '#states':
+          visible:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
       erittely_kullekin_vuodelle_haettavasta_avustussummasta_:
         '#type': textarea
         '#title': 'Erittely kullekin vuodelle haettavasta avustussummasta.'
         '#help': 'Kirjoita vuosikohtaisesti muotoon: vuosi: avustussumma.'
+        '#states':
+          visible:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
       ensisijainen_taiteen_ala:
         '#type': select
         '#title': 'Ensisijainen taiteen ala'

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -323,14 +323,6 @@ function grants_handler_webform_element_alter(array &$element, FormStateInterfac
     // Get data from webform.
     $webformData = $webformSubmission->getData();
 
-    if (isset($element['#webform_key']) && $element['#webform_key'] == 'olemme_saaneet_muita_avustuksia') {
-      if (empty($webformData["myonnetty_avustus"])) {
-        $element['#default_value'] = 'Ei';
-      }
-      else {
-        $element['#default_value'] = 'Kyllä';
-      }
-    }
     if (isset($element['#webform_key']) && $element['#webform_key'] == 'olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta') {
       if (empty($webformData["haettu_avustus_tieto"])) {
         $element['#default_value'] = 'Ei';
@@ -1620,7 +1612,6 @@ function grants_handler_preprocess_webform_submission_information(array &$variab
     '#theme' => 'webform_submission_attachment_list',
     '#submission' => $submission,
   ];
-
 }
 
 /**

--- a/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
@@ -123,7 +123,6 @@ class ApplicationController extends ControllerBase {
   public function access(AccountInterface $account, string $webform, string $webform_submission): AccessResultInterface {
     $webformObject = Webform::load($webform);
     $webform_submissionObject = WebformSubmission::load($webform_submission);
-
     if ($webformObject == NULL || $webform_submissionObject == NULL) {
       return AccessResult::forbidden('No submission found');
     }

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -1130,4 +1130,36 @@ class AtvSchema {
     return $values;
   }
 
+  /**
+   * Extracts data from ATV document compensation field.
+   *
+   * @param Drupal\Core\TypedData\DataDefinitionInterface $definition
+   *   Field with relation settings.
+   * @param array $content
+   *   ATV data.
+   *
+   * @return array
+   *   Assocative array with fields.
+   */
+  public function returnRelations(DataDefinitionInterface $definition, array $content): array {
+    $relations = $definition->getSetting('relations');
+    $pathArray = $definition->getSetting('jsonPath');
+    $elementName = array_pop($pathArray);
+    $value = $this->getValueFromDocument($content, $pathArray, $elementName, $definition);
+    switch ($relations['type']) {
+      case 'truthy':
+        $relatedValue = $value ? 1 : 0;
+        break;
+
+      default:
+        throw new \Exception('Unknown relation type.');
+    }
+
+    $retval = [
+      $relations['master'] => $value,
+      $relations['slave'] => $relatedValue,
+    ];
+    return $retval;
+  }
+
 }

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -584,7 +584,13 @@ class AtvSchema {
                     // Backup label.
                     $label = $itemValueDefinition->getLabel();
                     if (isset($webformMainElement['#webform_composite_elements'][$itemName]['#title'])) {
-                      $label = $webformMainElement['#webform_composite_elements'][$itemName]['#title']->render();
+                      $titleElement = $webformMainElement['#webform_composite_elements'][$itemName]['#title'];
+                      if (is_string($titleElement)) {
+                        $label = $titleElement;
+                      }
+                      else {
+                        $label = $titleElement->render();
+                      }
                     }
                     $element = [
                       'weight' => $weight,

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -1156,12 +1156,12 @@ class AtvSchema {
   /**
    * Extracts data from ATV document compensation field.
    *
-   * @param \Drupal\Core\TypedData\DataDefinitionInterface $definition
-   *   Field with relation settings.
+   * @param Drupal\Core\TypedData\DataDefinitionInterface $definition
+   *   Field definition.
    * @param array $content
    *   ATV data.
    * @param array $arguments
-   *   Aguments for method.
+   *   Arguments for method.
    *
    * @return array
    *   Assocative array with fields.
@@ -1169,19 +1169,27 @@ class AtvSchema {
    * @throws \Exception
    */
   public function returnRelations(DataDefinitionInterface $definition, array $content, array $arguments): array {
+    /*
+     * Fields in relations array:
+     * master: Field name in ATV
+     * slave: Field that exists in webform and is calculated based on master.
+     * type: Type of the slave field.
+     */
     $relations = $arguments['relations'];
     $pathArray = $definition->getSetting('jsonPath');
     $elementName = array_pop($pathArray);
+    // Pick up the value for the master field.
     $value = $this->getValueFromDocument($content, $pathArray, $elementName, $definition);
     $relatedValue = match ($relations['type']) {
-      'truthy' => $value ? 1 : 0,
+      // We use values 1 and 0 for boolean fields in webform.
+      'boolean' => $value ? 1 : 0,
       default => throw new \Exception('Unknown relation type.'),
     };
-
-    return [
+    $retval = [
       $relations['master'] => $value,
       $relations['slave'] => $relatedValue,
     ];
+    return $retval;
   }
 
 }

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -1156,33 +1156,32 @@ class AtvSchema {
   /**
    * Extracts data from ATV document compensation field.
    *
-   * @param Drupal\Core\TypedData\DataDefinitionInterface $definition
+   * @param \Drupal\Core\TypedData\DataDefinitionInterface $definition
    *   Field with relation settings.
    * @param array $content
    *   ATV data.
+   * @param array $arguments
+   *   Aguments for method.
    *
    * @return array
    *   Assocative array with fields.
+   *
+   * @throws \Exception
    */
   public function returnRelations(DataDefinitionInterface $definition, array $content, array $arguments): array {
     $relations = $arguments['relations'];
     $pathArray = $definition->getSetting('jsonPath');
     $elementName = array_pop($pathArray);
     $value = $this->getValueFromDocument($content, $pathArray, $elementName, $definition);
-    switch ($relations['type']) {
-      case 'truthy':
-        $relatedValue = $value ? 1 : 0;
-        break;
+    $relatedValue = match ($relations['type']) {
+      'truthy' => $value ? 1 : 0,
+      default => throw new \Exception('Unknown relation type.'),
+    };
 
-      default:
-        throw new \Exception('Unknown relation type.');
-    }
-
-    $retval = [
+    return [
       $relations['master'] => $value,
       $relations['slave'] => $relatedValue,
     ];
-    return $retval;
   }
 
 }

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -110,7 +110,8 @@ class AtvSchema {
       $webformDataExtractor = $definition->getSetting('webformDataExtracter');
 
       if ($webformDataExtractor) {
-        $extractedValues = self::getWebformDataFromContent($webformDataExtractor, $documentData, $definition);
+        $arguments = $webformDataExtractor['arguments'] ?? [];
+        $extractedValues = self::getWebformDataFromContent($webformDataExtractor, $documentData, $definition, $arguments);
         if (isset($webformDataExtractor['mergeResults']) && $webformDataExtractor['mergeResults']) {
           $typedDataValues = array_merge($typedDataValues, $extractedValues);
         }
@@ -1050,6 +1051,8 @@ class AtvSchema {
    *   Content.
    * @param \Drupal\Core\TypedData\DataDefinitionInterface $definition
    *   Definition.
+   * @param array $arguments
+   *   Possible arguments for value callback.
    *
    * @return array
    *   Full item callback array.
@@ -1057,19 +1060,20 @@ class AtvSchema {
   public function getWebformDataFromContent(
     array $fullItemValueCallback,
     array $content,
-    DataDefinitionInterface $definition
+    DataDefinitionInterface $definition,
+    array $arguments
   ): mixed {
     $fieldValues = [];
     if ($fullItemValueCallback['service']) {
       $fullItemValueService = \Drupal::service($fullItemValueCallback['service']);
       $funcName = $fullItemValueCallback['method'];
 
-      $fieldValues = $fullItemValueService->$funcName($definition, $content);
+      $fieldValues = $fullItemValueService->$funcName($definition, $content, $arguments);
     }
     else {
       if ($fullItemValueCallback['class']) {
         $funcName = $fullItemValueCallback['method'];
-        $fieldValues = $fullItemValueCallback['class']::$funcName($definition, $content);
+        $fieldValues = $fullItemValueCallback['class']::$funcName($definition, $content, $arguments);
       }
     }
     return $fieldValues;
@@ -1147,8 +1151,8 @@ class AtvSchema {
    * @return array
    *   Assocative array with fields.
    */
-  public function returnRelations(DataDefinitionInterface $definition, array $content): array {
-    $relations = $definition->getSetting('relations');
+  public function returnRelations(DataDefinitionInterface $definition, array $content, array $arguments): array {
+    $relations = $arguments['relations'];
     $pathArray = $definition->getSetting('jsonPath');
     $elementName = array_pop($pathArray);
     $value = $this->getValueFromDocument($content, $pathArray, $elementName, $definition);

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -249,7 +249,7 @@ trait ApplicationDefinitionTrait {
           'relations' => [
             'master' => 'myonnetty_avustus',
             'slave' => 'olemme_saaneet_muita_avustuksia',
-            'type' => 'truthy',
+            'type' => 'boolean',
           ],
         ],
       ]);

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -215,7 +215,19 @@ trait ApplicationDefinitionTrait {
         'otherCompensationsInfo',
         'otherCompensationsArray',
       ])
-      ->setSetting('requiredInJson', TRUE);
+      ->setSetting('requiredInJson', TRUE)
+      ->setSetting('webformDataExtracter', [
+        'service' => 'grants_metadata.atv_schema',
+        'method' => 'returnRelations',
+        'mergeResults' => TRUE,
+        'arguments' => [
+          'relations' => [
+            'master' => 'myonnetty_avustus',
+            'slave' => 'olemme_saaneet_muita_avustuksia',
+            'type' => 'truthy',
+          ],
+        ],
+      ]);
 
     $info['haettu_avustus_tieto'] = ListDataDefinition::create('grants_metadata_other_compensation')
       ->setLabel('Haettu avustus')

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -46,6 +46,16 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
           'compensationInfo',
           'generalInfoArray',
           'yearsForMultiYearApplication',
+        ])
+        ->setSetting('relations', [
+          'slave' => 'kyseessa_on_monivuotinen_avustus',
+          'master' => 'tulevat_vuodet_joiden_ajalle_monivuotista_avustusta_on_haettu_ta',
+          'type' => 'truthy',
+        ])
+        ->setSetting('webformDataExtracter', [
+          'service' => 'grants_metadata.atv_schema',
+          'method' => 'returnRelations',
+          'mergeResults' => TRUE,
         ]);
 
       $info['erittely_kullekin_vuodelle_haettavasta_avustussummasta_'] = DataDefinition::create('string')

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -47,15 +47,17 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
           'generalInfoArray',
           'yearsForMultiYearApplication',
         ])
-        ->setSetting('relations', [
-          'slave' => 'kyseessa_on_monivuotinen_avustus',
-          'master' => 'tulevat_vuodet_joiden_ajalle_monivuotista_avustusta_on_haettu_ta',
-          'type' => 'truthy',
-        ])
         ->setSetting('webformDataExtracter', [
           'service' => 'grants_metadata.atv_schema',
           'method' => 'returnRelations',
           'mergeResults' => TRUE,
+          'arguments' => [
+            'relations' => [
+              'slave' => 'kyseessa_on_monivuotinen_avustus',
+              'master' => 'tulevat_vuodet_joiden_ajalle_monivuotista_avustusta_on_haettu_ta',
+              'type' => 'truthy',
+            ],
+          ],
         ]);
 
       $info['erittely_kullekin_vuodelle_haettavasta_avustussummasta_'] = DataDefinition::create('string')

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -55,7 +55,7 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
             'relations' => [
               'slave' => 'kyseessa_on_monivuotinen_avustus',
               'master' => 'tulevat_vuodet_joiden_ajalle_monivuotista_avustusta_on_haettu_ta',
-              'type' => 'truthy',
+              'type' => 'boolean',
             ],
           ],
         ]);


### PR DESCRIPTION
# [AU-1022](https://helsinkisolutionoffice.atlassian.net/browse/AU-1022)
<!-- What problem does this solve? -->

Anna arvo webformin boolean kentille perustuen toiseen kenttään. Tämä on tarpeen koska formilla on kenttiä joita ei talleteta ATV:hen.

## What was done
<!-- Describe what was done -->

Määritä webformextracter metodi ja tee siihen liittyen sopivat määrittelyt

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1022-radiobuttons`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Kirjaudu sisään ja mene https://hel-fi-drupal-grant-applications.docker.so/fi/form/kuva-toiminta

Lomakkeen sivulla 2 paina kyllä Kyseessä on monivuotinen avustus radiobuttonille ja täytä kenttä  "Tulevat vuodet joiden ajalle monivuotista avustusta on haettu tai myönnetty".

Tallenna keskeneräisenä

Palaa lomakkeelle ja varmista että radiobutton on kyllä asennossa ja mainitussa kentässä on oikea arvo

Tyhjennä kenttä ja tallenna keskeneräisenä.

Palaa lomakkeelle ja radiobutton on ei asennossa.

Katselmoi koodia ajatuksella. Ovatko nimet hyviä, tätä logiikkaa on tarkoitus käyttää jatkossa useammassa paikassa.

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1022]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ