### PR TITLE
fix: AU-1004: fix Unregistered community in mandate

### DIFF
--- a/public/modules/custom/grants_mandate/grants_mandate.libraries.yml
+++ b/public/modules/custom/grants_mandate/grants_mandate.libraries.yml
@@ -1,0 +1,7 @@
+# Disable Unregistered community -submit button
+disable-mandate-submit:
+  version: 1.x
+  js:
+    js/disable-mandate-submit.js: { }
+  dependencies:
+    - core/drupalSettings

--- a/public/modules/custom/grants_mandate/js/disable-mandate-submit.js
+++ b/public/modules/custom/grants_mandate/js/disable-mandate-submit.js
@@ -3,12 +3,21 @@
     attach: function (context, settings) {
       $('#edit-submit--2').prop('disabled', true);
 
-      $('select').on('change', function() {
-        if ($(this).find('option:selected').text() == 'Valitse') {
-          $('#edit-submit--2').prop('disabled', true);
+      $('#edit-unregistered-community-selection').change(function() {
+        var selectedValue = $(this).val();
+        var submitButton = $('#edit-submit--2');
+
+        if (selectedValue === '0') {
+          submitButton.prop('disabled', true);
         }
         else {
-          $('#edit-submit--2').prop('disabled', false);
+          submitButton.prop('disabled', false);
+        }
+
+        if (selectedValue === 'new') {
+          submitButton.html('<span class="hds-button__label">' + Drupal.t('Add new Unregistered community') + '</span>');
+        } else {
+          submitButton.html('<span class="hds-button__label">' + Drupal.t('Select Unregistered community role') + '</span>');
         }
      });
     }

--- a/public/modules/custom/grants_mandate/js/disable-mandate-submit.js
+++ b/public/modules/custom/grants_mandate/js/disable-mandate-submit.js
@@ -1,0 +1,16 @@
+(function ($, Drupal, drupalSettings) {
+  Drupal.behaviors.GrantsHandlerMandateSubmitBehavior = {
+    attach: function (context, settings) {
+      $('#edit-submit--2').prop('disabled', true);
+
+      $('select').on('change', function() {
+        if ($(this).find('option:selected').text() == 'Valitse') {
+          $('#edit-submit--2').prop('disabled', true);
+        }
+        else {
+          $('#edit-submit--2').prop('disabled', false);
+        }
+     });
+    }
+  };
+})(jQuery, Drupal, drupalSettings);

--- a/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
+++ b/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
@@ -99,7 +99,7 @@ class ApplicantMandateForm extends FormBase {
     ]);
 
     $form['info'] = [
-      '#markup' => '<p>' . $this->t('Choose the applicant role you want to use for the application') . '</p>',
+      '#markup' => '<p>' . $this->t('Before proceeding to the grant application, you should choose an applicant role. You can continue applying as an individual or switch to applying on behalf of the community. When you choose to apply on behalf of a registered community, you will be transferred to Suomi.fi business authorization.') . '</p>',
     ];
     $form['actions'] = [
       '#type' => 'actions',
@@ -114,7 +114,7 @@ class ApplicantMandateForm extends FormBase {
       '#theme' => 'select_applicant_role',
       '#icon' => 'company',
       '#role' => $this->t('Registered community'),
-      '#role_description' => $this->t('This is a short description of the applicant role.'),
+      '#role_description' => $this->t('Registered community is, for example, a company, non-profit organization, organization or association'),
     ];
     $form['actions']['registered_community']['submit'] = [
       '#type' => 'submit',
@@ -131,13 +131,13 @@ class ApplicantMandateForm extends FormBase {
       '#theme' => 'select_applicant_role',
       '#icon' => 'group',
       '#role' => $this->t('Unregistered community'),
-      '#role_description' => $this->t('This is a short description of the applicant role.'),
+      '#role_description' => $this->t('Apply for grant on behalf of your unregistered community'),
     ];
 
     $form['actions']['unregistered_community']['unregistered_community_selection'] = [
       '#type' => 'select',
       '#options' => $profileOptions,
-      '#empty_option' => 'Valitse',
+      '#empty_option' => $this->t('Choose'),
       '#empty_value' => '0',
     ];
 
@@ -161,7 +161,7 @@ class ApplicantMandateForm extends FormBase {
       '#theme' => 'select_applicant_role',
       '#icon' => 'user',
       '#role' => $this->t('Private person'),
-      '#role_description' => $this->t('This is a short description of the applicant role.'),
+      '#role_description' => $this->t('Apply for grant as a private person'),
     ];
     $form['actions']['private_person']['submit'] = [
       '#name' => 'private_person',

--- a/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
+++ b/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\grants_mandate\Form;
 
 use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;
@@ -111,7 +112,7 @@ class ApplicantMandateForm extends FormBase {
     ];
     $form['actions']['registered_community']['info'] = [
       '#theme' => 'select_applicant_role',
-      '#icon' => 'group',
+      '#icon' => 'company',
       '#role' => $this->t('Registered community'),
       '#role_description' => $this->t('This is a short description of the applicant role.'),
     ];
@@ -136,12 +137,19 @@ class ApplicantMandateForm extends FormBase {
     $form['actions']['unregistered_community']['unregistered_community_selection'] = [
       '#type' => 'select',
       '#options' => $profileOptions,
+      '#empty_option' => 'Valitse',
+      '#empty_value' => '0',
     ];
 
     $form['actions']['unregistered_community']['submit'] = [
       '#type' => 'submit',
       '#name' => 'unregistered_community',
       '#value' => $this->t('Select Unregistered community role'),
+      '#attached' => [
+        'library' => [
+          'grants_mandate/disable-mandate-submit',
+        ],
+      ],
     ];
     $form['actions']['private_person'] = [
       '#type' => 'container',
@@ -151,7 +159,7 @@ class ApplicantMandateForm extends FormBase {
     ];
     $form['actions']['private_person']['info'] = [
       '#theme' => 'select_applicant_role',
-      '#icon' => 'group',
+      '#icon' => 'user',
       '#role' => $this->t('Private person'),
       '#role_description' => $this->t('This is a short description of the applicant role.'),
     ];

--- a/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
+++ b/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
@@ -3,7 +3,6 @@
 namespace Drupal\grants_mandate\Form;
 
 use Drupal\Core\Form\FormBase;
-use Drupal\Core\Form\FormHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Url;

--- a/public/modules/custom/grants_mandate/templates/select-applicant-role.html.twig
+++ b/public/modules/custom/grants_mandate/templates/select-applicant-role.html.twig
@@ -1,4 +1,4 @@
-<span aria-hidden="true" class="hel-icon hel-icon--{{ icon}} hel-icon--size-m"></span>
+<span aria-hidden="true" class="hds-icon hds-icon--{{ icon}} hds-icon--size-m"></span>
 <h2 class="hds-card__heading-m heading-m" role="heading" aria-level="2">{{ role }}</h2>
 <div class="hds-card__text">
   {{ role_description }}

--- a/public/modules/custom/grants_mandate/translations/sv.po
+++ b/public/modules/custom/grants_mandate/translations/sv.po
@@ -1,4 +1,4 @@
-# Finnish translation of City of Helsinki Grants Mandate Module
+# Swedish translation of City of Helsinki Grants Mandate Module
 #
 msgid ""
 msgstr ""
@@ -13,52 +13,52 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgid "Select applicant type"
-msgstr "Valitse hakijarooli"
+msgstr "Välj sökandetyp"
 
 msgid "Registered community"
-msgstr "Rekisteröity yhteisö"
+msgstr "Registrerad gemenskap"
 
 msgid "Unregistered community"
-msgstr "Rekisteröimätön yhteisö"
+msgstr "Oregistrerad gemenskap"
 
 msgid "Private person"
-msgstr "Yksityishenkilö"
+msgstr "Privatperson"
 
 msgid "Choose"
-msgstr "Valitse"
+msgstr "Välja"
 
 msgid "Select role & authorize mandate"
-msgstr "Valitse käyttäjärooli & hyväksy valtuutus"
+msgstr "Välj roll & auktorisera mandat"
 
 msgid "Code exchange error. @error: @error_desc. State: @state, Error URI: @error_uri"
-msgstr "Koodin vaihtovirhe. @error: @error_desc. Tila: @state, Virhe URI: @error_uri"
+msgstr "Kodbytesfel. @error: @error_desc. Status: @state, Fel URI: @error_uri"
 
 msgid "Choose the applicant role you want to use for the application"
-msgstr "Valitse asiointirooli, jota haluat käyttää hakemuksella"
+msgstr "Välj den sökande roll du vill använda för ansökan"
 
 msgid "This is a short description of the applicant role."
-msgstr "Lyhyt kuvaus hakijaroolista."
+msgstr "Detta är en kort beskrivning av den sökande rollen."
 
 msgid "Select Applicant Type"
-msgstr "Valitse asiointiroolin tyyppi"
+msgstr "Välj sökandetyp"
 
 msgid "You must have company & authorisation set before applying."
-msgstr "Sinulla pitää olla yhteisö ja valtuutus valittuna ennen hakemuksen jättämistä."
+msgstr "Du måste ha företag & behörighet inställt innan du ansöker."
 
 msgid "Mandate process was interrupted or there was an error. Please try again."
-msgstr "Valtuutusprosessi keskeytyi, yritä uudelleen."
+msgstr "Medgivandeprocessen avbröts eller så uppstod ett fel. Var god försök igen."
 
 msgid "Your mandate does not allow you to use this service."
-msgstr "Valtuutuksesi ei sallin sinun käyttää tätä palvelua."
+msgstr "Ditt medgivande tillåter dig inte att använda denna tjänst."
 
 msgid "Before proceeding to the grant application, you should choose an applicant role. You can continue applying as an individual or switch to applying on behalf of the community. When you choose to apply on behalf of a registered community, you will be transferred to Suomi.fi business authorization."
-msgstr "Ennen kuin siirryt avustushakemukselle, sinun tulee valita asiointirooli. Voit jatkaa asiointia yksityishenkilönä tai vaihtaa yhteisön puolesta asiointiin. Valitessasi rekisteröidyn yhteisön puolesta asioinnin, sinut siirretään suomi.fi yritysvaltuutukseen."
+msgstr "Innan du går vidare till bidragsansökan bör du välja en sökanderoll. Du kan fortsätta att ansöka som privatperson eller byta till att ansöka på uppdrag av gemenskapen. När du väljer att ansöka på uppdrag av en registrerad gemenskap kommer du att överföras till Suomi.fi företagsauktorisering."
 
 msgid "Registered community is, for example, a company, non-profit organization, organization or association"
-msgstr "Rekisteröity yhdistys on esimerkiksi yritys, voittoa tavoittelematon organisaatio, järjestö tai yhdistys"
+msgstr "Registrerad gemenskap är till exempel ett företag, ideell organisation, organisation eller förening"
 
 msgid "Apply for grant on behalf of your unregistered community"
-msgstr "Hae avustusta rekisteröimättömän yhteisösi puolesta"
+msgstr "Ansök om bidrag på uppdrag av din oregistrerade grupp"
 
 msgid "Apply for grant as a private person"
-msgstr "Hae avustusta yksityishenkilönä"
+msgstr "Ansök om bidrag som privatperson"


### PR DESCRIPTION
# [AU-1004](https://helsinkisolutionoffice.atlassian.net/browse/AU-1004)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Disabled submit-button in unregistered community if nothing is selected
* Change button text according to select value

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1004-select-unregistered`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login and go to mandate
* [ ] Check that Unregistered community submit-button is disabled
* [ ] Check that submit-button is enabled after you select a community 

[AU-1004]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ