### PR TITLE
feat: AU-1034: Add support for bank account details for unreg community.

### DIFF
--- a/public/modules/custom/grants_handler/js/webform-additions.js
+++ b/public/modules/custom/grants_handler/js/webform-additions.js
@@ -8,12 +8,33 @@
 
       if (formData['status'] === 'DRAFT' && !$("#webform-button--delete-draft").length) {
         $('#edit-actions').append($('<a id="webform-button--delete-draft" class="webform-button--delete-draft hds-button hds-button--secondary" href="/hakemus/' + submissionId + '/clear">' +
-          '  <span class="hds-button__label">' + Drupal.t('Delete draft') + '</span>' +
-          '</a>'));
+            '  <span class="hds-button__label">' + Drupal.t('Delete draft') + '</span>' +
+            '</a>'));
       }
 
       $("#edit-bank-account-account-number-select").change(function () {
-        $("[data-drupal-selector='edit-bank-account-account-number']").val($(this).val())
+        // Get selected account from dropdown
+        const selectedNumber = $(this).val();
+        // Get bank account info on this selected account.
+        const selectedAccountArray = drupalSettings.grants_handler
+            .grantsProfile.bankAccounts
+            .filter(item => item.bankAccount === selectedNumber);
+        const selectedAccount = selectedAccountArray[0];
+
+        // Always set the number
+        $("[data-drupal-selector='edit-bank-account-account-number']").val(selectedAccount.bankAccount);
+
+        // Only set name & ssn if they're present in the profile.
+        if (selectedAccount.ownerName !== null) {
+          $("[data-drupal-selector='edit-bank-account-account-number-owner-name']")
+              .val(selectedAccount.ownerName);
+        }
+        if (selectedAccount.ownerSsn !== null) {
+          $("[data-drupal-selector='edit-bank-account-account-number-ssn']")
+              .val(selectedAccount.ownerSsn);
+        }
+
+
       });
       $("#edit-community-address-community-address-select").change(function () {
         const selectedDelta = $(this).val()
@@ -54,7 +75,7 @@
       // Managed file #states handling is a bit wonky,
       // so we need to manually handle checkbox disables in the
       // composite element
-      const checkBoxStateFn =  function () {
+      const checkBoxStateFn = function () {
         if (this.checked) {
           $(this).prop('disabled', false);
         }
@@ -75,7 +96,8 @@
         if (attachmentValue && attachmentValue !== '') {
           box1.prop('disabled', true)
           box2.prop('disabled', true)
-        } else if (attachment) {
+        }
+        else if (attachment) {
           box1.prop('disabled', false)
           box2.prop('disabled', false)
         }

--- a/public/modules/custom/grants_handler/src/Element/BankAccountComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/BankAccountComposite.php
@@ -49,6 +49,12 @@ class BankAccountComposite extends WebformCompositeBase {
     $elements['account_number'] = [
       '#type' => 'hidden',
     ];
+    $elements['account_number_owner_name'] = [
+      '#type' => 'hidden',
+    ];
+    $elements['account_number_ssn'] = [
+      '#type' => 'hidden',
+    ];
 
     return $elements;
   }

--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/BankAccountComposite.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/BankAccountComposite.php
@@ -40,6 +40,13 @@ class BankAccountComposite extends WebformCompositeBase {
     $value = $this->getValue($element, $webform_submission, $options);
     $lines = [];
     $lines[] = $value['account_number'];
+    if (isset($value['account_number_account_owner'])) {
+      $lines[] = $value['account_number_account_owner'];
+    }
+    if (isset($value['account_number_ssn'])) {
+      $lines[] = $value['account_number_ssn'];
+    }
+
     return $lines;
   }
 

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -320,6 +320,14 @@ class GrantsHandler extends WebformHandlerBase {
 
     if (isset($values['bank_account']) && $values['bank_account'] !== NULL) {
       $values['account_number'] = $values['bank_account']['account_number'];
+
+      if (isset($values['bank_account']['account_number_owner_name']) && !empty($values['bank_account']['account_number_owner_name'])) {
+        $values['account_number_owner_name'] = $values['bank_account']['account_number_owner_name'];
+      }
+      if (isset($values['bank_account']['account_number_ssn']) && !empty($values['bank_account']['account_number_ssn'])) {
+        $values['account_number_ssn'] = $values['bank_account']['account_number_ssn'];
+      }
+
       unset($values['bank_account']);
     }
 

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -130,6 +130,26 @@ trait ApplicationDefinitionTrait {
         ->setSetting('defaultValue', 'Suomi');
     }
 
+    if ($applicantType === 'unregistered_community') {
+      $info['account_number_owner_name'] = DataDefinition::create('string')
+        ->setLabel('accountNumber')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'bankAccountArray',
+          'accountOwnerName',
+        ])
+        ->addConstraint('NotBlank');
+
+      $info['account_number_ssn'] = DataDefinition::create('string')
+        ->setLabel('accountNumber')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'bankAccountArray',
+          'socialSecurityNumber',
+        ])
+        ->addConstraint('NotBlank');
+    }
+
     $info['application_type'] = DataDefinition::create('string')
       ->setRequired(TRUE)
       ->setLabel('Application type')


### PR DESCRIPTION
# [AU-1034](https://helsinkisolutionoffice.atlassian.net/browse/AU-1034)
<!-- What problem does this solve? -->

Unregistered community has 2 fields in bank account data that other users do not have: Owner name & SSN. This adds those only for unreg community.

## What was done
<!-- Describe what was done -->

* Add account specs to data definition
* Add details to bank account composite
* Make things work

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1034-account-details`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login and authorize unreg community
* [ ] Make sure this community has bank account & the details are saved.
* [ ] Create application with this unreg community
* [ ] See that account owner details are added to ATV document, like so:
![image](https://user-images.githubusercontent.com/892920/237042600-8cd1091d-846b-479a-aa0b-5f2ec1325b5c.png)



[AU-1034]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ