### PR TITLE
fix: AU-935: add translations to front banner

### DIFF
--- a/public/modules/custom/grants_front_banner/templates/grants-front-banner.html.twig
+++ b/public/modules/custom/grants_front_banner/templates/grants-front-banner.html.twig
@@ -5,9 +5,9 @@
   {% set banner_style = 'component--banner-secondary'%}
   {% set banner_icon = 'alert-circle' %}
 {% elseif loggedin %}
-  {% set title = "Ovathan omat tietosi ajan tasalla?"|t %}
-  {% set description = "Avustusasiointiin tallennetut käyttäjätiedot tuodaan suoraan lomakkeille, kun haet uusia avustuksia. Muista tarkistaa aika ajoin omat käyttäjätietosi, jotta hakemuslomakkeilla on ajantasaiset tiedot."|t %}
-  {% set link = 'Siirry päivittämään omat tietosi'|t({}, {'context': 'Login to grants'}) %}
+  {% set title = "Please make sure that your information is up to date!"|t %}
+  {% set description = "The user information saved in the grant process will be imported directly to the application when you apply for new grants. Remember to check your information from time to time so that the information in the application form is up to date."|t %}
+  {% set link = 'Go to update your information'|t({}, {'context': 'Login to grants'}) %}
   {% set banner_style = 'component--banner-secondary'%}
   {% set banner_icon = 'alert-circle' %}
 {% else %}

--- a/public/modules/custom/grants_front_banner/translations/fi.po
+++ b/public/modules/custom/grants_front_banner/translations/fi.po
@@ -22,3 +22,13 @@ msgstr "Huomaathan, että avustuksen hakemista varten omien tietojen täytyy oll
 msgctxt "Login to grants"
 msgid "Go to fill in your personal information"
 msgstr "Siirry täydentämään omat tietosi"
+
+msgid "Please make sure that your information is up to date!"
+msgstr "Ovathan omat tietosi ajan tasalla?"
+
+msgid "The user information saved in the grant process will be imported directly to the application when you apply for new grants. Remember to check your information from time to time so that the information in the application form is up to date."
+msgstr "Avustusasiointiin tallennetut käyttäjätiedot tuodaan suoraan lomakkeille, kun haet uusia avustuksia. Muista tarkistaa aika ajoin omat käyttäjätietosi, jotta hakemuslomakkeilla on ajantasaiset tiedot."
+
+msgctxt "Login to grants"
+msgid "Go to update your information"
+msgstr "Siirry päivittämään omat tietosi"

--- a/public/modules/custom/grants_front_banner/translations/sv.po
+++ b/public/modules/custom/grants_front_banner/translations/sv.po
@@ -22,3 +22,13 @@ msgstr "Vänligen notera att du inte kan ansöka om understöd innan du fyllt i 
 msgctxt "Login to grants"
 msgid "Go to fill in your personal information"
 msgstr "Börja fylla i dina uppgifter."
+
+msgid "Please make sure that your information is up to date!"
+msgstr "Är dina uppgifter uppdaterade?"
+
+msgid "The user information saved in the grant process will be imported directly to the application when you apply for new grants. Remember to check your information from time to time so that the information in the application form is up to date."
+msgstr "De användaruppgifter som sparats i e-tjänsten hämtas direkt till blanketter när du ansöker om nya understöd. Kom ihåg att kontrollera dina användaruppgifter då och då så att uppgifterna på ansökningsblanketterna är uppdaterade."
+
+msgctxt "Login to grants"
+msgid "Go to update your information"
+msgstr "Gå och uppdatera dina uppgifter"


### PR DESCRIPTION
# [AU-935](https://helsinkisolutionoffice.atlassian.net/browse/AU-935)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added missing translation to front banner

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-935-translate-frontbanner`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as end user
* [ ] Go to front page and check that "Ovathan omat tietosi ajan tasalla?" is translated to every language


[AU-935]: https://helsinkisolutionoffice.atlassian.net/browse/AU-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ