### PR TITLE
AU-1033: Metadata to budget component generated data

### DIFF
--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -275,7 +275,7 @@ class GrantsBudgetComponentService {
   /**
    * Process budget components to ATV structure.
    */
-  public static function processBudgetInfo($property) {
+  public static function processBudgetInfo($property, $arguments) {
     $incomeStaticRow = [
       'incomeRowsArrayStatic' => [],
       'otherIncomeRowsArrayStatic' => [],
@@ -285,14 +285,23 @@ class GrantsBudgetComponentService {
       'otherCostRowsArrayStatic' => [],
     ];
 
-    foreach ($property as $p) {
-      $pDef = $p->getDataDefinition();
+    foreach ($property as $propertyKey => $property) {
+      $pDef = $property->getDataDefinition();
       $jsonPath = $pDef->getSetting('jsonPath');
       $pJsonPath = reset($jsonPath);
       $defaultValue = $pDef->getSetting('defaultValue');
       $valueCallback = $pDef->getSetting('fullItemValueCallback');
       $itemTypes = AtvSchema::getJsonTypeForDataType($pDef);
-      $itemValue = AtvSchema::getItemValue($itemTypes, $p, $defaultValue, $valueCallback);
+      $itemValue = AtvSchema::getItemValue($itemTypes, $property, $defaultValue, $valueCallback);
+
+      if (isset($arguments['webform'])) {
+        $processedValues = self::processMetaFields(
+          $property,
+          $propertyKey,
+          $itemValue,
+          $arguments['webform']
+        );
+      }
 
       switch ($pJsonPath) {
         case 'incomeRowsArrayStatic':
@@ -300,7 +309,7 @@ class GrantsBudgetComponentService {
         case 'incomeGroupName':
           if (is_array($itemValue)) {
             $original = $incomeStaticRow[$pJsonPath] ?? [];
-            $incomeStaticRow[$pJsonPath] = array_merge($original, $itemValue);
+            $incomeStaticRow[$pJsonPath] = array_merge($original, $processedValues);
           }
           else {
             $incomeStaticRow[$pJsonPath] = $itemValue;
@@ -312,7 +321,7 @@ class GrantsBudgetComponentService {
         case 'costGroupName':
           if (is_array($itemValue)) {
             $original = $costStaticRow[$pJsonPath] ?? [];
-            $costStaticRow[$pJsonPath] = array_merge($original, $itemValue);
+            $costStaticRow[$pJsonPath] = array_merge($original, $processedValues);
           }
           else {
             $costStaticRow[$pJsonPath] = $itemValue;
@@ -332,6 +341,60 @@ class GrantsBudgetComponentService {
     ];
 
     return $retval;
+
+  }
+
+  /**
+   * Add meta fields to budget component values.
+   */
+  private static function processMetaFields($propertyDefinition, $propertyKey, $values, $webform) {
+    if (!is_array($values) || count($values) == 0 || !$webform) {
+      return $values;
+    }
+
+    $webformMainElement = $webform->getElement($propertyKey);
+    $elements = $webform->getElementsDecodedAndFlattened();
+    $elementKeys = array_keys($elements);
+
+    $pages = $webform->getPages('edit');
+
+    $pageId = $webformMainElement['#webform_parents'][0];
+    $pageKeys = array_keys($pages);
+    $pageLabel = $pages[$pageId]['#title'];
+    $pageNumber = array_search($pageId, $pageKeys) + 1;
+
+    $sectionId = $webformMainElement['#webform_parents'][1];
+    $sectionLabel = $elements[$sectionId]['#title'];
+    $sectionWeight = array_search($sectionId, $elementKeys);
+
+    $page = [
+      'id' => $pageId,
+      'label' => $pageLabel,
+      'number' => $pageNumber,
+    ];
+
+    $section = [
+      'id' => $sectionId,
+      'label' => $sectionLabel,
+      'weight' => $sectionWeight,
+    ];
+
+    foreach ($values as &$value) {
+
+      $fieldId = $value['ID'];
+
+      $webformLabelElement = $webformMainElement['#webform_composite_elements'][$fieldId] ?? $webformMainElement['#webform_key'];
+      $label = $webformLabelElement['#title'] ?? $webformMainElement['#title'];
+
+      $element = [
+        'label' => $label,
+      ];
+
+      $value['meta'] = json_encode(AtvSchema::getMetaData($page, $section, $element));
+
+    }
+
+    return $values;
 
   }
 

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -523,6 +523,12 @@ class AtvSchema {
       else {
 
         if ($propertyStructureCallback) {
+
+          $addWebformToCallback = $propertyStructureCallback['webform'] ?? FALSE;
+          if ($addWebformToCallback) {
+            $propertyStructureCallback['arguments']['webform'] = $webform;
+          }
+
           $documentStructure = array_merge_recursive(
             $documentStructure,
             self::getFieldValuesFromFullItemCallback(

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaKehaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaKehaDefinition.php
@@ -332,6 +332,7 @@ class KuvaKehaDefinition extends ComplexDataDefinitionBase {
         ->setSetting('propertyStructureCallback', [
           'service' => 'grants_budget_components.service',
           'method' => 'processBudgetInfo',
+          'webform' => TRUE,
         ])
         ->setSetting('webformDataExtracter', [
           'service' => 'grants_budget_components.service',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -712,6 +712,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ->setSetting('propertyStructureCallback', [
           'service' => 'grants_budget_components.service',
           'method' => 'processBudgetInfo',
+          'webform' => TRUE,
         ])
         ->setSetting('webformDataExtracter', [
           'service' => 'grants_budget_components.service',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -667,6 +667,7 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
         ->setSetting('propertyStructureCallback', [
           'service' => 'grants_budget_components.service',
           'method' => 'processBudgetInfo',
+          'webform' => TRUE,
         ])
         ->setSetting('webformDataExtracter', [
           'service' => 'grants_budget_components.service',

--- a/tools/make/drupal.mk
+++ b/tools/make/drupal.mk
@@ -52,6 +52,11 @@ drush-cex: ## Export configuration
 	$(call step,Export configuration...\n)
 	$(call drush,cex -y)
 
+PHONY += drush-gwi
+drush-gwi: ## Export configuration
+	$(call step,Import forms...\n)
+	$(call drush,gwi -y)
+
 PHONY += drush-cim
 drush-cim: ## Import configuration
 	$(call step,Import configuration...\n)
@@ -111,7 +116,7 @@ new: ## Create a new empty Drupal installation from configuration
 
 PHONY += post-install
 post-install: ## Run post-install Drush actions
-	@$(MAKE) $(DRUPAL_POST_INSTALL_TARGETS) drush-uli
+	@$(MAKE) $(DRUPAL_POST_INSTALL_TARGETS) drush-uli drush-gwi
 
 PHONY += drush-disable-modules
 drush-disable-modules: ## Disable Drupal modules


### PR DESCRIPTION
# [AU-1033](https://helsinkisolutionoffice.atlassian.net/browse/AU-1033)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1033-budget-component-meta`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Edit / apply to application with budget components and save the application
* [ ] Check from ATV that metadata is saved to budget fields.


[AU-1033]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ