### PR TITLE
AU-865: Make business purpose editable

### DIFF
--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -341,7 +341,7 @@ elements: |-
       '#type': webform_section
       '#title': 'Toiminnan kuvaus'
       business_purpose:
-        '#type': textfield
+        '#type': textarea
         '#title': 'Toiminnan kuvaus'
         '#help': 'Tieto haetaan omat tiedot -osiosta'
       community_practices_business:
@@ -350,7 +350,7 @@ elements: |-
         '#options':
           1: Kyllä
           0: Ei
-        '#required': true
+        '#required': false
         '#options_display': side_by_side
         '#options_description_display': help
     ensimmainen_otsikko:

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -416,7 +416,7 @@ elements: |-
       '#type': webform_section
       '#title': 'Toiminnan kuvaus'
       business_purpose:
-        '#type': textfield
+        '#type': textarea
         '#title': 'Toiminnan kuvaus'
         '#help': 'Tieto haetaan omat tiedot -osiosta'
       community_practices_business:
@@ -427,7 +427,7 @@ elements: |-
           0: Ei
         '#options_display': side_by_side
         '#options_description_display': help
-        '#required': true
+        '#required': false
     ensimmainen_otsikko:
       '#type': webform_section
       '#title': Jäsenmaksut

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -652,15 +652,6 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
     $form['#attached']['drupalSettings']['grants_handler']['formData'] = $formData;
     $form['#attached']['drupalSettings']['grants_handler']['submissionId'] = $formData["application_number"] ?? '';
 
-    if (isset($grantsProfile["businessPurpose"]) && $grantsProfile["businessPurpose"]) {
-      _grants_handler_imported_handler($form["elements"]["3_yhteison_tiedot"]["business_info"]["business_purpose"], $grantsProfile["businessPurpose"], FALSE);
-    }
-    else {
-      _grants_handler_missing_data($form["elements"]["3_yhteison_tiedot"]["business_info"]["business_purpose"],
-        t('You need a description of the community purpose for the application.'), t('Add description of purpose'),
-        t('to My Services > My Information so it can be used on the application.'));
-    }
-
     if (isset($form["elements"]["1_hakijan_tiedot"]["tilinumero"]["account_number"]["#default_value"])) {
       $form["elements"]["1_hakijan_tiedot"]["tilinumero"]["account_number_select"]["#default_value"] = $form["elements"]["1_hakijan_tiedot"]["tilinumero"]["account_number"]["#default_value"];
     }

--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1038,6 +1038,7 @@ class ApplicationHandler {
     }
 
     $selectedCompany = $this->grantsProfileService->getSelectedRoleData();
+    $companyData = $this->grantsProfileService->getGrantsProfileContent($selectedCompany);
 
     // If we've given data to work with, clear it for copying.
     if (empty($submissionData)) {
@@ -1054,6 +1055,7 @@ class ApplicationHandler {
     $submissionData['applicant_type'] = $this->grantsProfileService->getApplicantType();
     $submissionData['status'] = self::getApplicationStatuses()['DRAFT'];
     $submissionData['company_number'] = $selectedCompany['identifier'];
+    $submissionData['businessPurpose'] = $companyData['businessPurpose'] ?? '';
 
     try {
       // Merge sender details to new stuff.

--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1055,7 +1055,7 @@ class ApplicationHandler {
     $submissionData['applicant_type'] = $this->grantsProfileService->getApplicantType();
     $submissionData['status'] = self::getApplicationStatuses()['DRAFT'];
     $submissionData['company_number'] = $selectedCompany['identifier'];
-    $submissionData['businessPurpose'] = $companyData['businessPurpose'] ?? '';
+    $submissionData['business_purpose'] = $companyData['businessPurpose'] ?? '';
 
     try {
       // Merge sender details to new stuff.


### PR DESCRIPTION
# [AU-865](https://helsinkisolutionoffice.atlassian.net/browse/AU-865)
<!-- What problem does this solve? -->

## What was done

Business purpose not required and is now editable. Prefill with profile data if found.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-865-businesspurpose-prefill-and-editable`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Yleisavustus applications page 3. the business purpose field should be editable and prefilled, if the profile business purpose filled.



[AU-865]: https://helsinkisolutionoffice.atlassian.net/browse/AU-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ