### PR TITLE
fix: AU-1028: add translations to metadata

### DIFF
--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -253,16 +253,26 @@ function grants_metadata_form_alter(&$form, FormStateInterface $form_state, $for
       '#multiple' => TRUE,
     ];
 
+    $language =  \Drupal::languageManager()->getCurrentLanguage()->getId();
+
     // Load the taxonomy terms.
     $terms = \Drupal::entityTypeManager()
       ->getStorage('taxonomy_term')
       ->loadByProperties([
         'vid' => 'avustuslaji',
       ]);
+
+
     // Build options list.
     $termOptions = [];
     foreach ($terms as $term) {
-      $termOptions[$term->id()] = $term->label();
+      if ($term->hasTranslation($language)){
+        $translated_term = \Drupal::service('entity.repository')->getTranslationFromContext($term, $language);
+        $termOptions[$term->id()] = $translated_term->label();
+      }
+      else {
+        $termOptions[$term->id()] = $term->label();
+      }
     }
 
     $form['third_party_settings']['grants_metadata']['applicationTypeTerms'] = [
@@ -280,10 +290,17 @@ function grants_metadata_form_alter(&$form, FormStateInterface $form_state, $for
       ->loadByProperties([
         'vid' => 'target_group',
       ]);
+
     // Build options list.
     $termOptions = [];
     foreach ($terms as $term) {
-      $termOptions[$term->id()] = $term->label();
+      if ($term->hasTranslation($language)){
+        $translated_term = \Drupal::service('entity.repository')->getTranslationFromContext($term, $language);
+        $termOptions[$term->id()] = $translated_term->label();
+      }
+      else {
+        $termOptions[$term->id()] = $term->label();
+      }
     }
 
     $form['third_party_settings']['grants_metadata']['applicationTargetGroup'] = [


### PR DESCRIPTION
# [AU-1028](https://helsinkisolutionoffice.atlassian.net/browse/AU-1028)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Show translations in webform third party settings

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1028-third-party-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to webform settings and navigate to third party settings
* [ ] Check that you see Avustuslajis in correct language

[AU-1028]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ