### PR TITLE
AU-1045: Fix premise radiobutton translations

### DIFF
--- a/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
@@ -33,6 +33,7 @@ class PremisesComposite extends WebformCompositeBase {
    */
   public static function getCompositeElements(array $element): array {
     $elements = [];
+    $tOpts = ['context' => 'grants_premises'];
 
     $elements['premiseName'] = [
       '#type' => 'textfield',
@@ -119,16 +120,16 @@ class PremisesComposite extends WebformCompositeBase {
     $elements['isOwnedByApplicant'] = [
       '#type' => 'radios',
       '#options' => [
-        'true' => t('Yes'),
-        'false' => t('No'),
+        1 => t('Yes', [], $tOpts),
+        0 => t('No', [], $tOpts),
       ],
       '#title' => t('Applicant owns property'),
     ];
     $elements['isOwnedByCity'] = [
       '#type' => 'radios',
       '#options' => [
-        TRUE => t('Yes'),
-        FALSE => t('No'),
+        1 => t('Yes', [], $tOpts),
+        0 => t('No', [], $tOpts),
       ],
       '#title' => t('City owns the property'),
     ];

--- a/public/modules/custom/grants_premises/translations/fi.po
+++ b/public/modules/custom/grants_premises/translations/fi.po
@@ -57,3 +57,10 @@ msgstr "Tilan nimi"
 msgid "Total Rent"
 msgstr "Kokonaisvuokra"
 
+msgctxt "grants_premises"
+msgid "Yes"
+msgstr "Kyllä"
+
+msgctxt "grants_premises"
+msgid "No"
+msgstr "Ei"

--- a/public/modules/custom/grants_premises/translations/sv.po
+++ b/public/modules/custom/grants_premises/translations/sv.po
@@ -57,5 +57,10 @@ msgstr "Tilan nimi"
 msgid "Total Rent"
 msgstr "Total Hyra"
 
+msgctxt "grants_premises"
+msgid "Yes"
+msgstr "Ja"
 
-
+msgctxt "grants_premises"
+msgid "No"
+msgstr "Nej"


### PR DESCRIPTION
# [AU-1045](https://helsinkisolutionoffice.atlassian.net/browse/AU-1045)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1045-premise-radio-translate`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that premise custom composite's radio buttons are translated.



[AU-1045]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ