### PR TITLE
AU-878: Login redirect user to oma asiointi

### DIFF
--- a/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
+++ b/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
@@ -194,7 +194,7 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
     }
 
     // Redirect user to grants profile page.
-    $redirectUrl = Url::fromRoute('grants_profile.show');
+    $redirectUrl = Url::fromRoute('grants_oma_asiointi.front');
     return new RedirectResponse($redirectUrl->toString());
   }
 

--- a/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
+++ b/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
@@ -239,7 +239,7 @@ class ApplicantMandateForm extends FormBase {
           $this->grantsProfileService->setSelectedRoleData($selectedProfileData);
 
           // Redirect user to grants profile page.
-          $redirectUrl = Url::fromRoute('grants_profile.show');
+          $redirectUrl = Url::fromRoute('grants_oma_asiointi.front');
         }
 
         $redirect = new TrustedRedirectResponse($redirectUrl->toString());
@@ -257,7 +257,7 @@ class ApplicantMandateForm extends FormBase {
         $this->grantsProfileService->setSelectedRoleData($selectedProfileData);
 
         // Redirect user to grants profile page.
-        $redirectUrl = Url::fromRoute('grants_profile.show');
+        $redirectUrl = Url::fromRoute('grants_oma_asiointi.front');
         $redirect = new TrustedRedirectResponse($redirectUrl->toString());
         $form_state->setResponse($redirect);
 

--- a/test/resources/common.resource
+++ b/test/resources/common.resource
@@ -36,7 +36,7 @@ Do Company Login Process With Tunnistamo
     ELSE
       Go To Omat tiedot
     END
-    Logged In Company Page Should Be Open
+    Logged In Oma Asiointi Page Should Be Open
 
 Do Unregistered Community Login Process With Tunnistamo
     Go To Login Page
@@ -50,7 +50,7 @@ Do Unregistered Community Login Process With Tunnistamo
     ELSE
       Go To Omat tiedot
     END
-    Logged In Unregistered Community Page Should Be Open
+    Logged In Oma Asiointi Page Should Be Open
 
 Do Private Person Login Process With Tunnistamo
     Go To Login Page
@@ -64,7 +64,7 @@ Do Private Person Login Process With Tunnistamo
     ELSE
       Go To Omat tiedot
     END
-    Logged In Private Person Page Should Be Open
+    Logged In Oma Asiointi Page Should Be Open
 
 Go To Login Page
     Click          .profile__login-link
@@ -97,7 +97,7 @@ Do Company Selection
     Choose Company Profile With Tunnistamo
 
 Do Unregistered Community Selection
-    Select Options By    [data-drupal-selector="edit-unregistered-community-selection"]    index    1
+    Select Options By    [data-drupal-selector="edit-unregistered-community-selection"]    index    2
     Click             \#edit-unregistered-community .form-submit
 
 Do Private Person Selection
@@ -107,13 +107,5 @@ Choose Company Role
     Click             \#edit-registered-community .form-submit
     Wait For Condition    Title           ==    Suomi.fi-valtuudet
 
-Logged In Company Page Should Be Open
-    Get Title           ==    Näytä oma profiili | ${SITE_NAME}
-    Get Text          .grants-profile-company-name      *=    ${TUNNISTAMO_COMPANY_NAME}
-
-Logged In Unregistered Community Page Should Be Open
-    Get Title           ==    Näytä oma profiili | ${SITE_NAME}
-
-Logged In Private Person Page Should Be Open
-    Get Title           ==    Näytä oma profiili | ${SITE_NAME}
-    Get Text          h1      *=    ${TUNNISTAMO_PERSON_NAME}
+Logged In Oma Asiointi Page Should Be Open
+    Get Text          \#keskeneraiset-hakemukset      *=    Keskeneräiset hakemukset

--- a/test/resources/dev-env-variables.resource
+++ b/test/resources/dev-env-variables.resource
@@ -4,7 +4,7 @@ ${TUNNISTAMO_COMPANY_ID}              2036583-2
 ${TUNNISTAMO_COMPANY_NAME}            Maanrakennus Ari Eerola T:mi
 ${TUNNISTAMO_PERSON_NAME}             Nordea Demo
 ${SITE_NAME}                          Helsingin kaupunki
-${SITE_NAME_ALT}                      Hel.fi Avustusasiointi
+${SITE_NAME_ALT}                      Avustusasiointi
 ${APPLICATION_TITLE}                  Kaupunginhallituksen yleisavustushakemus
 ${APPLICATION_TITLE_ALT}              Kaupunginhallitus, yleisavustus
 ${INPUT_EMAIL}                        testi@test.fi

--- a/test/tests/02__profile.robot
+++ b/test/tests/02__profile.robot
@@ -17,6 +17,7 @@ Update Company Bank Account
     Open Browser To Home Page
     Accept Cookies Banner
     Do Company Login Process With Tunnistamo
+    Go To Profile Page
     Open Edit Form
     Add New Bank Account
     Open Edit Form
@@ -27,6 +28,7 @@ Update Company Website
     Open Browser To Home Page
     Accept Cookies Banner
     Do Company Login Process With Tunnistamo
+    Go To Profile Page
     Open Edit Form
     Change Company Website To Temporary
     Open Edit Form
@@ -41,6 +43,7 @@ Update Unregistered Company Bank Account
     Open Browser To Home Page
     Accept Cookies Banner
     Do Unregistered Community Login Process With Tunnistamo
+    Go To Profile Page
     Open Edit Form
     Add New Bank Account
     Open Edit Form
@@ -51,6 +54,7 @@ Update Unregistered Community Name
     Open Browser To Home Page
     Accept Cookies Banner
     Do Unregistered Community Login Process With Tunnistamo
+    Go To Profile Page
     Open Edit Form
     Change Company Name To Temporary
     Open Edit Form
@@ -65,6 +69,7 @@ Update Private Person Bank Account
     Open Browser To Home Page
     Accept Cookies Banner
     Do Private Person Login Process With Tunnistamo
+    Go To Profile Page
     Open Edit Form
     Add New Bank Account
     Open Edit Form
@@ -75,6 +80,7 @@ Update Private Person Address
     Open Browser To Home Page
     Accept Cookies Banner
     Do Private Person Login Process With Tunnistamo
+    Go To Profile Page
     Open Edit Form
     Change Address To Temporary
     Open Edit Form
@@ -85,6 +91,7 @@ Update Private Person Phone
     Open Browser To Home Page
     Accept Cookies Banner
     Do Private Person Login Process With Tunnistamo
+    Go To Profile Page
     Open Edit Form
     Change Phone To Temporary
     Open Edit Form
@@ -92,6 +99,11 @@ Update Private Person Phone
     [Teardown]    Close Browser
 
 *** Keywords ***
+
+Go To Profile Page
+    Click           a[data-drupal-link-system-path="oma-asiointi/hakuprofiili"]
+    Wait Until Network Is Idle
+    Get Title           ==    Näytä oma profiili | ${SITE_NAME}
 
 Open Edit Form
     Click           a[data-drupal-selector="profile-edit-link"]


### PR DESCRIPTION
# [AU-878](https://helsinkisolutionoffice.atlassian.net/browse/AU-878)
<!-- What problem does this solve? -->

Users should be redirected to oma asiointi on login

## What was done
<!-- Describe what was done -->

* Changed login redirects to point to oma asiointi
* Updated related tests

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login with any of the three role types
* [ ] All should redirect to oma asiointi on success



[AU-878]: https://helsinkisolutionoffice.atlassian.net/browse/AU-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ