### PR TITLE
fix: AU-1049: translate status strings

### DIFF
--- a/conf/cmi/grants_handler.settings.yml
+++ b/conf/cmi/grants_handler.settings.yml
@@ -24,14 +24,14 @@ statusStrings:
     DONE: Käsitelty
     REJECTED: Hylätty
     DELETED: Poistettu
-    CANCELED: Keskeytetty
-    CANCELLED: Keskeytetty
-    CLOSED: Suljettu
+    CANCELED: Peruttu
+    CANCELLED: Peruttu
+    CLOSED: Ratkaistu
   sv:
     DRAFT: Draft
     SENT: Sent
     SUBMITTED: Submitted
-    RECEIVED: Received
+    RECEIVED: Mottagits
     PENDING: Pending
     PROCESSING: Processing
     READY: Ready

--- a/public/modules/custom/grants_handler/config/install/grants_handler.settings.yml
+++ b/public/modules/custom/grants_handler/config/install/grants_handler.settings.yml
@@ -24,9 +24,9 @@ statusStrings:
     DONE: Käsitelty
     REJECTED: Hylätty
     DELETED: Poistettu
-    CANCELED: Keskeytetty
-    CANCELLED: Keskeytetty
-    CLOSED: Suljettu
+    CANCELED: Peruttu
+    CANCELLED: Peruttu
+    CLOSED: Ratkaistu
   sv:
     DRAFT: Draft
     SENT: Sent


### PR DESCRIPTION
# [AU-1049](https://helsinkisolutionoffice.atlassian.net/browse/AU-1049)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Translated status strings

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1049-translate-status`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Send an application and ask to set it closed or cancelled, check that translations are correct


[AU-1049]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ