### PR TITLE
AU-1059: Add tooltips to budget component fields on KUVA PROJ&TOIM

### DIFF
--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -935,19 +935,22 @@ elements: |-
         '#multiple__add_more_input': false
         '#customerFees__access': false
         '#donations__access': false
+        '#otherCompensations__access': false
+        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#compensationFromCulturalAffairs__access': false
         '#otherCompensationFromCity__access': false
         '#otherCompensationType__access': false
-        '#totalIncome__access': false
         '#incomeWithoutCompensations__access': false
         '#plannedStateOperativeSubvention__access': false
+        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#financialFundingAndInterests__access': false
         '#plannedTotalIncome__access': false
         '#plannedTotalIncomeWithoutSubventions__access': false
         '#plannedShareOfIncomeWithoutSubventions__access': false
         '#stateOperativeSubvention__access': false
-        '#totalIncomeWithoutSubventions__access': false
         '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__access': false
     menot:
       '#type': webform_section
       '#title': 'Suunnitellut menot'
@@ -987,7 +990,6 @@ elements: |-
         '#services__access': false
         '#supplies__access': false
         '#useOfCustomerFeesTotal__access': false
-        '#totalCosts__access': false
         '#netCosts__access': false
         '#generalCosts__access': false
         '#permits__access': false
@@ -995,6 +997,8 @@ elements: |-
         '#security__access': false
         '#costsWithoutDeferredItems__access': false
         '#generalCostsTotal__access': false
+        '#showCosts__help': 'Teosten esittämisestä muuna kuin palkkana tai palkkiona maksettavat korvaukset.'
+        '#totalCosts__access': false
         '#allCostsTotal__access': false
         '#plannedTotalCosts__access': false
       budget_other_cost:

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -1029,7 +1029,7 @@ elements: |-
       '#title': 'Suunnitellut tulot'
       budget_static_income:
         '#type': grants_budget_income_static
-        '#title': 'Suunnitellut Tulot'
+        '#title': '<empty>'
         '#multiple': true
         '#incomeGroup': general
         '#multiple__min_items': 1
@@ -1044,6 +1044,8 @@ elements: |-
         '#otherCompensationFromCity__access': false
         '#otherCompensationType__access': false
         '#incomeWithoutCompensations__access': false
+        '#plannedStateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#ownFunding__access': false
         '#plannedTotalIncome__access': false
         '#plannedTotalIncomeWithoutSubventions__access': false
@@ -1057,7 +1059,7 @@ elements: |-
       '#title': 'Suunnitellut menot'
       suunnitellut_menot:
         '#type': grants_budget_cost_static
-        '#title': 'Suunnitellut menot'
+        '#title': '<empty>'
         '#multiple': true
         '#incomeGroup': general
         '#multiple__min_items': 1
@@ -1131,7 +1133,7 @@ elements: |-
       '#title_tag': h3
       toteutuneet_tulot_data:
         '#type': grants_budget_income_static
-        '#title': 'Toteutuneet tulot'
+        '#title': '<empty>'
         '#multiple': true
         '#incomeGroup': general
         '#multiple__min_items': 1
@@ -1143,9 +1145,11 @@ elements: |-
         '#customerFees__access': false
         '#donations__access': false
         '#entryFees__access': false
+        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#sponsorships__access': false
         '#sales__access': false
         '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationFromCity__help': 'Samaan toimitaan edelliselle päättyneelle tilivuodelle myönnetty avustus. '
         '#otherCompensationType__access': false
         '#incomeWithoutCompensations__access': false
         '#plannedStateOperativeSubvention__access': false
@@ -1155,8 +1159,10 @@ elements: |-
         '#plannedTotalIncome__access': false
         '#plannedTotalIncomeWithoutSubventions__access': false
         '#plannedShareOfIncomeWithoutSubventions__access': false
+        '#stateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
         '#shareOfIncomeWithoutSubventions__access': false
         '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__help': 'Kirjaa tähän kaikki tulot yhteensä, sisältäen myös jo aiemmissa kohdissa kirjatut avustukset.'
     toteutuneet_menot_osio:
       '#type': webform_section
       '#title': 'Toteutuneet menot'


### PR DESCRIPTION
# [AU-1059](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1059-budget-component-tooltips`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check KUVA Toim & Proj applications and check that the tooltips match excel / word doc




[AU-1059]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ