### PR TITLE
AU-1026: Redirect to profile form if missing

### DIFF
--- a/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
+++ b/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
@@ -193,8 +193,14 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
       return new RedirectResponse($redirectUrl->toString());
     }
 
-    // Redirect user to grants profile page.
-    $redirectUrl = Url::fromRoute('grants_oma_asiointi.front');
+    $selectedRoleData = $this->grantsProfileService->getSelectedRoleData();
+
+    // Load grants profile.
+    $grantsProfile = $this->grantsProfileService->getGrantsProfile($selectedRoleData, TRUE);
+
+    // Redirect user based on if the user has a profile
+    $redirectUrl = $grantsProfile ? Url::fromRoute('grants_oma_asiointi.front') : Url::fromRoute('grants_profile.edit');
+
     return new RedirectResponse($redirectUrl->toString());
   }
 

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -341,11 +341,11 @@ class GrantsProfileService {
         $newProfile = $this->saveGrantsProfile($grantsProfileContent);
       }
       else {
-        $newProfile = NULL;
+        $newProfile = FALSE;
       }
     }
     catch (\Throwable $e) {
-      $newProfile = NULL;
+      $newProfile = FALSE;
       // If no company data is found, we cannot continue.
       $this->messenger
         ->addError($this->t('Community details not found in registries. Please contact customer service'));


### PR DESCRIPTION
# [AU-1026](https://helsinkisolutionoffice.atlassian.net/browse/AU-1026)
<!-- What problem does this solve? -->

Users should be redirected to create profile forms if missing.

## What was done
<!-- Describe what was done -->

Added check and redirect if user is missing a profile for registered community.

Unregistered communities and personal profiles already redirect automatically.

Also fixed a bug where function `createNewProfile` returned `NULL`, even though the function declaration said it should return `bool`.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as a registered community, without profile
* [ ] User should be redirected to profile edit form
