### PR TITLE
fix: AU-1083: remove parenthesis if no role

### DIFF
--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -110,7 +110,7 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
 
     foreach ($persons as $delta => $official) {
       $deltaString = (string) $delta;
-      $juu = $official;
+
       if ($official['role'] != '0') {
         $optionSelection = $official['name'] . ' (' . $officialRole[$official['role']] . ')';
       }

--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -110,7 +110,8 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
 
     foreach ($persons as $delta => $official) {
       $deltaString = (string) $delta;
-      if (isset($official['role'])) {
+      $juu = $official;
+      if ($official['role'] != '0') {
         $optionSelection = $official['name'] . ' (' . $officialRole[$official['role']] . ')';
       }
       else {


### PR DESCRIPTION
# [AU-1083](https://helsinkisolutionoffice.atlassian.net/browse/AU-1083)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* remove parenthesis from contact person if no role

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1083-remove-parenthesis`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to application as unregistered community and choose responsible person, see that there are no parenthesis

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/85cd0b03-ec20-49b6-aedc-83706472e05d)

* [ ] Go to application as registered community and choose responsible person, see that there is a role

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/15b9ed5c-7629-4c55-acbd-bb51460c954b)


[AU-1083]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ