### PR TITLE
fix: AU-1087: Disable premise type from kuva proj and keha

### DIFF
--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -660,6 +660,7 @@ elements: |-
         '#multiple__sorting': false
         '#multiple__add': false
         '#multiple__add_more_input': false
+        '#premiseType__access': false
         '#premiseAddress__access': false
         '#location__access': false
         '#streetAddress__access': false

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -477,7 +477,7 @@ elements: |-
       '#title': 'Yleisölle avoin toiminta Helsingissä toteutetaan'
       tila:
         '#type': premises_composite
-        '#title': 'Tilat'
+        '#title': Tilat
         '#multiple': true
         '#title_display': before
         '#multiple__min_items': 0
@@ -485,6 +485,7 @@ elements: |-
         '#multiple__sorting': false
         '#multiple__add': false
         '#multiple__add_more_input': false
+        '#premiseType__access': false
         '#premiseAddress__access': false
         '#location__access': false
         '#streetAddress__access': false


### PR DESCRIPTION
# [AU-1087](https://helsinkisolutionoffice.atlassian.net/browse/AU-1087)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Disable premise type on KUVA PROJ & KEHA, as these won't use those fields.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1087-disable-premisetype`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check KUVA PROJ & KEHA applications, that the premises component doesn't have a type dropdown any more (KUVA TOIMINTA should have one).


## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1087]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ