### PR TITLE
AU-1089: Get budget compensation value from subventions

### DIFF
--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -50,6 +50,15 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
+    $fieldKeys = array_keys(self::getFieldNames());
+
+    foreach ($fieldKeys as $fieldKey) {
+      $keyToCheck = '#' . $fieldKey . '__access';
+      if (isset($element[$keyToCheck]) && $element[$keyToCheck] === FALSE) {
+        unset($element[$fieldKey]);
+      }
+    }
+
     if (isset($dataForElement['costGroupName'])) {
       $element['costGroupName']['#value'] = $dataForElement['costGroupName'];
     }

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -82,6 +82,13 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
         '#min' => 0,
         '#step' => '.01',
       ];
+
+      if ($key === 'compensation') {
+        $elements[$key]['#disabled'] = TRUE;
+        $elements[$key]['#process'][] = [
+          self::class, 'getCompensationValue',
+        ];
+      }
     }
 
     $elements['incomeGroupName'] = [
@@ -92,6 +99,31 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
       '#wrapper_attributes' => ['class' => 'js-form-wrapper'],
     ];
     return $elements;
+  }
+
+  /**
+   * Get value for compensation field from subventions.
+   */
+  public static function getCompensationValue(&$element, FormStateInterface $form_state, &$complete_form) {
+
+    $subventions = $form_state->getValue('subventions');
+
+    $total = 0;
+    foreach ($subventions as $key => $subvention) {
+      if ($key === 'items' || !isset($subvention['amount'])) {
+        continue;
+      }
+
+      $trimmedString = str_replace([' ', '€'], '', $subvention['amount']);
+      $trimmedString = str_replace(',', '.', $trimmedString);
+      $floatVal = floatval($trimmedString);
+      $total += $floatVal;
+    }
+
+    $element['#value'] = $total;
+    $form_state->setValueForElement($element, $total);
+
+    return $element;
   }
 
   /**

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -54,6 +54,15 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
+    $fieldKeys = array_keys(self::getFieldNames());
+
+    foreach ($fieldKeys as $fieldKey) {
+      $keyToCheck = '#' . $fieldKey . '__access';
+      if (isset($element[$keyToCheck]) && $element[$keyToCheck] === FALSE) {
+        unset($element[$fieldKey]);
+      }
+    }
+
     if (isset($dataForElement['incomeGroupName'])) {
       $element['incomeGroupName']['#value'] = $dataForElement['incomeGroupName'];
     }

--- a/public/modules/custom/grants_budget_components/src/Plugin/WebformElement/GrantsBudgetBase.php
+++ b/public/modules/custom/grants_budget_components/src/Plugin/WebformElement/GrantsBudgetBase.php
@@ -4,6 +4,8 @@ namespace Drupal\grants_budget_components\Plugin\WebformElement;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
+use Drupal\Core\Render\Element as RenderElement;
+use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Base component for budget webform elements.
@@ -63,6 +65,36 @@ class GrantsBudgetBase extends WebformCompositeBase {
       'budgetForProjectAndDevelopment' => t('Budget for project and development', [], $tOpts),
       'budgetForOperatingAndArtsTeaching' => t('Budget for operating and arts teaching'),
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatHtmlItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []): array|string {
+    $format = $this->getItemFormat($element);
+    $items = [];
+    $composite_elements = $this->getInitializedCompositeElement($element);
+    foreach (RenderElement::children($composite_elements) as $composite_key) {
+
+      if (in_array($composite_key, ['incomeGroupName', 'costGroupName'])) {
+        continue;
+      }
+
+      $composite_element = $composite_elements[$composite_key];
+      $composite_title = (isset($composite_element['#title']) && $format !== 'raw') ? $composite_element['#title'] : $composite_key;
+      $composite_value = $this->formatCompositeHtml($element, $webform_submission, ['composite_key' => $composite_key] + $options);
+      if ($composite_value !== '') {
+        $items[$composite_key] = [
+          '#type' => 'inline_template',
+          '#template' => '<b>{{ title }}:</b> {{ value }}',
+          '#context' => [
+            'title' => $composite_title,
+            'value' => $composite_value,
+          ],
+        ];
+      }
+    }
+    return $items;
   }
 
 }


### PR DESCRIPTION
# [AU-1089](https://helsinkisolutionoffice.atlassian.net/browse/AU-1089)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Get compensation budget value from subvention values.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1089-budget-compensations-field-automatic-value`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any kuva application and add some values to subventions
* [ ] Go to budget page and check that the compensation field is disabled and has the sum of subventions
* [ ] Modify subventions values again and go straight to preview page and check that compensation field updates.



[AU-1089]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ