### PR TITLE
Load Select2 library in composer, autologout patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,8 @@
         "globalcitizen/php-iban": "^4.1",
         "league/uri": "^6.7",
         "nesbot/carbon": "^2.64",
+        "npm-asset/select2": "^4.0",
+        "oomphinc/composer-installers-extender": "^2.0",
         "ramsey/uuid": "^4.3"
     },
     "require-dev": {
@@ -99,7 +101,8 @@
             "composer/installers": true,
             "cweagans/composer-patches": true,
             "drupal/core-composer-scaffold": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "oomphinc/composer-installers-extender": true
         }
     },
     "extra": {
@@ -119,9 +122,7 @@
                 "Add service nodetype to sidebar.": "patches/add-service-type-sidebar.patch"
             },
             "drupal/autologout": {
-                "Secure cookies": "https://www.drupal.org/files/issues/2022-11-25/3308456-11.patch"
-            },
-            "drupal/autologout": {
+                "Secure cookies": "https://www.drupal.org/files/issues/2022-11-25/3308456-11.patch",
                 "Module fix": "patches/autologout-fix-configuration.patch"
             }
         },
@@ -142,7 +143,9 @@
                 "type:drupal-core"
             ],
             "public/libraries/{$name}": [
-                "type:drupal-library"
+                "type:drupal-library",
+                "type:bower-asset",
+                "type:npm-asset"
             ],
             "public/modules/contrib/{$name}": [
                 "type:drupal-module"
@@ -162,7 +165,8 @@
             "drush/Commands/{$name}": [
                 "type:drupal-drush"
             ]
-        }
+        },
+        "installer-types": ["bower-asset", "npm-asset"]
     },
     "repositories": [
         {
@@ -172,6 +176,10 @@
         {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
         }
     ],
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dedb88be856e11adcff99163ef3b35b3",
+    "content-hash": "a769022596006992529c8de4b0a7e330",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -12191,6 +12191,18 @@
             "time": "2022-12-05T10:56:20+00:00"
         },
         {
+            "name": "npm-asset/select2",
+            "version": "4.0.13",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz"
+            },
+            "type": "npm-asset",
+            "license": [
+                "MIT"
+            ]
+        },
+        {
             "name": "nyholm/dsn",
             "version": "2.0.1",
             "source": {
@@ -12250,6 +12262,63 @@
                 }
             ],
             "time": "2021-11-18T09:23:29+00:00"
+        },
+        {
+            "name": "oomphinc/composer-installers-extender",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/oomphinc/composer-installers-extender.git",
+                "reference": "cbf4b6f9a24153b785d09eee755b995ba87bd5f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/oomphinc/composer-installers-extender/zipball/cbf4b6f9a24153b785d09eee755b995ba87bd5f9",
+                "reference": "cbf4b6f9a24153b785d09eee755b995ba87bd5f9",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "composer/installers": "^1.0 || ^2.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "phpunit/phpunit": "^7.2",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "OomphInc\\ComposerInstallersExtender\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "OomphInc\\ComposerInstallersExtender\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Stephen Beemsterboer",
+                    "email": "stephen@oomphinc.com",
+                    "homepage": "https://github.com/balbuf"
+                },
+                {
+                    "name": "Nathan Dentzau",
+                    "email": "nate@oomphinc.com",
+                    "homepage": "http://oomph.is/ndentzau"
+                }
+            ],
+            "description": "Extend the composer/installers plugin to accept any arbitrary package type.",
+            "homepage": "http://www.oomphinc.com/",
+            "support": {
+                "issues": "https://github.com/oomphinc/composer-installers-extender/issues",
+                "source": "https://github.com/oomphinc/composer-installers-extender/tree/2.0.1"
+            },
+            "time": "2021-12-15T12:32:42+00:00"
         },
         {
             "name": "pear/archive_tar",

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -776,6 +776,10 @@ class AtvSchema {
     if (!array_key_exists('attachmentsInfo', $documentStructure)) {
       $documentStructure['attachmentsInfo'] = [];
     }
+
+    if (empty($documentStructure['attachmentsInfo'])) {
+      $documentStructure['attachmentsInfo']['attachmentsArray'] = [];
+    }
     return $documentStructure;
   }
 


### PR DESCRIPTION

<!-- What problem does this solve? -->

"Select2" library is not loaded correctly, causing the DOM to get stuck.

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/471887/b49ea724-9bb1-430b-b70f-a3241f420508)

The URL format "//dist" is interpreted as "http://dist", so the DOM tries to load the script from "http://dist" and causes it to hang because it can't find that URL.

The malformed URL is caused by "select2" contrib module, which can't find the "select2" js library.

## What was done
<!-- Describe what was done -->

* Loaded "select2" js library via composer (per the instructions here: https://www.drupal.org/project/select2 )
* Fixed duplicate "drupal/autologout" patch definitions in composer.json

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the "select2" lib is loaded correctly and it exists. 

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/471887/53e04859-2bf8-4524-9c4f-380a738d2b71)
