### PR TITLE
fix: AU-1082: Remove unused duplicate application language field

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1201,9 +1201,6 @@ class ApplicationHandler {
       'language' => $this->languageManager->getCurrentLanguage()->getId(),
       'applicant_type' => $selectedCompany['type'],
       'applicant_id' => $selectedCompany['identifier'],
-      'application_language' => \Drupal::languageManager()
-        ->getCurrentLanguage()
-        ->getId(),
     ]);
 
     $typeData = $this->webformToTypedData($submissionData);


### PR DESCRIPTION
# [AU-1082](https://helsinkisolutionoffice.atlassian.net/browse/AU-1082)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Remove duplicate `application_language`, as there is already `language`

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1082-remove-duplicate-lang-field`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Applications should not save `application_language` field any more to atv.




[AU-1082]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ