### PR TITLE
AU-1072: Fix multivalue fields error displays

### DIFF
--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -52,6 +52,8 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
+    _grants_handler_process_multivalue_errors($element, $form_state);
+
     $fieldKeys = array_keys(self::getFieldNames());
 
     $fieldsInUse = [];

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -48,13 +48,11 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
    */
   public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form): array {
 
-
-    $storage = $form_state->getStorage();
-    $errors = $storage['errors'];
-
     $element['#tree'] = TRUE;
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
+
+    _grants_handler_process_multivalue_errors($element, $form_state);
 
     $fieldKeys = array_keys(self::getFieldNames());
 

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherCost.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherCost.php
@@ -52,6 +52,8 @@ class GrantsBudgetOtherCost extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
+    _grants_handler_process_multivalue_errors($element, $form_state);
+
     if (isset($dataForElement['costGroupName'])) {
       $element['costGroupName']['#value'] = $dataForElement['costGroupName'];
     }

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherIncome.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherIncome.php
@@ -52,6 +52,8 @@ class GrantsBudgetOtherIncome extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
+    _grants_handler_process_multivalue_errors($element, $form_state);
+
     if (isset($dataForElement['incomeGroupName'])) {
       $element['incomeGroupName']['#value'] = $dataForElement['incomeGroupName'];
     }

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -9,6 +9,7 @@ use Drupal\webform\Entity\Webform;
 use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Drupal\block_content\Entity\BlockContent;
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
@@ -1718,4 +1719,30 @@ function grants_handler_language_switch_links_alter(array &$links) {
     }
   }
 
+}
+
+/**
+ * Checks if composite element if multi value and handles errors.
+ *
+ * @param array $element
+ *   The element array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ */
+function _grants_handler_process_multivalue_errors(&$element, $form_state) {
+  $storage = $form_state->getStorage();
+  $errors = $storage['errors'];
+
+  $componentErrors = $errors[$element['#webform_key']] ?? [];
+
+  preg_match_all("/\[([^\]]*)\]/", $element['#name'], $matches);
+
+  $relevantErrors = NestedArray::getValue($componentErrors, $matches[1]);
+
+  if ($relevantErrors) {
+    foreach ($relevantErrors as $key => $error) {
+      $element[$key]['#attributes']['class'][] = $error['class'];
+      $element[$key]['#attributes']['error_label'] = $error['label'];
+    }
+  }
 }

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -609,13 +609,20 @@ class GrantsHandler extends WebformHandlerBase {
         // These variables separate the array keys in them.
         $errorName = strtok($errorKey, ']');
         $errorSelectValue = substr($errorKey, strpos($errorKey, '[') + 1);
+        $valuePath = explode('][', $errorKey);
+        $isMultiValue = in_array('_item_', $valuePath);
+
         if (isset($form['elements'][$pageName][$errorName])) {
           $form['elements'][$pageName][$errorName]['#attributes']['class'][] = 'has-error';
         }
         else {
           foreach ($form['elements'][$pageName] as $fieldName => $element) {
             if (!str_starts_with($fieldName, '#')) {
-              if (isset($form['elements'][$pageName][$fieldName][$errorName]['#webform_composite_elements'][$errorSelectValue])) {
+              if ($isMultiValue) {
+                NestedArray::setValue($errors, [...$valuePath, 'class'], 'has-errors');
+                NestedArray::setValue($errors, [...$valuePath, 'label'], $error);
+              }
+              elseif (isset($form['elements'][$pageName][$fieldName][$errorName]['#webform_composite_elements'][$errorSelectValue])) {
                 $errors[$errorName]['class'] = 'has-errors';
                 $errors[$errorName]['label'] = $error;
               }


### PR DESCRIPTION
# [AU-1072](https://helsinkisolutionoffice.atlassian.net/browse/AU-1072)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Handle composite multi values errors little bit better

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1072-multivalue-errors`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any KUVA application and in budget page add letters to 1 or more fields.
* [ ] From the top navigation select the budget page once again, so we will trigger validation.
* [ ] Check that errors are working correctly
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/e75bb4e8-eddc-48c6-817d-9250aa6b5a1f)



[AU-1072]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ