### PR TITLE
fix: AU-1103 & AU-1104: hakijan tiedot - text & attachment translations

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -4,30 +4,8 @@ elements: |
     '#title': '1. Applicant details'
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
-  yhteiso_jolle_haetaan_avustusta:
-    '#title': 'Community for which the grant is being applied for'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">The indicated information has been retrieved from the register of the Finnish Patent and Registration Office (PRH), and changing the information is only possible in the online service in question.</div>'
-  community_official_name:
-    '#title': 'Name of community'
-  company_number:
-    '#title': 'Business ID'
-  home:
-    '#title': Domicile
-  registration_date:
-    '#title': 'Date of registration'
-  perustamisvuosi:
-    '#title': 'Year of establishment'
-  founding_year:
-    '#title': 'Year of establishment'
-  yhteison_lyhenne:
-    '#title': 'Abbreviated name'
-  community_official_name_short:
-    '#title': 'Abbreviated name'
-  verkkosivut:
-    '#title': Website
-  homepage:
-    '#title': Website
   contact_person_email_section:
     '#title': Email
   contact_markup:
@@ -45,16 +23,24 @@ elements: |
     '#title': Address
   community_address:
     '#title': Address
+    '#description': 'Valitse osoite, osoitteita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
     '#community_address_select__title': 'Select the address'
   tilinumero:
     '#title': 'Account number'
   bank_account:
     '#title': 'Account number'
+    '#description': 'Valitse tilinumero, tilinumeroita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
     '#account_number_select__title': 'Select the account number'
     '#account_number__title': ''
+    '#account_number_owner_name__title': ''
+    '#account_number_ssn__title': ''
   toiminnasta_vastaavat_henkilot:
     '#title': 'Persons responsible for operations'
   community_officials:
+    '#description': 'Valitse toiminnasta vastaavat henkil&ouml;t, henki&ouml;it&auml; yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa henkil&ouml;it&auml; tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n henkil&ouml;iden tietoja omiin tietoihin.'
     '#title': 'Persons responsible within the community'
   2_avustustiedot:
     '#title': '2. Grant details'
@@ -64,25 +50,14 @@ elements: |
     '#title': 'Grant details'
   acting_year:
     '#title': 'Year for which I am applying for a grant'
-  avustuslajit:
-    '#title': 'Types of grant'
   subventions:
     '#title': Grants
-  kayttotarkoitus:
-    '#title': 'Purpose of use'
-  compensation_purpose:
-    '#title': 'Brief description of the purpose(s) of the grant(s) applied for'
-    '#help': 'Indicate the purpose for which the grant is applied for. If necessary, specify the different uses. Also tell us what is intended to be achieved with the grant and what goals are associated with the activities to be supported.'
-    '#counter_maximum_message': '%d/5000 characters remaining'
   muut_samaan_tarkoitukseen_myonnetyt_avustukset:
     '#title': 'Other grants received for the same purpose'
   info_muut_samaan_tarkoitukseen_myonnetty:
     '#text': "<p>Indicate here only the grants received from somewhere other than the City of Helsinki in the current and two previous tax years.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
   olemme_saaneet_muita_avustuksia:
     '#title': 'We have received other grants'
-    '#options':
-      Kyllä: 'Yes'
-      Ei: 'No'
   myonnetty_avustus:
     '#title': 'Received grant'
     '#multiple__add_more_button_label': 'Add new received grant'
@@ -94,90 +69,32 @@ elements: |
       purpose:
         '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
         '#counter_maximum_message': '%d/1000 characters remaining'
-  muut_samaan_tarkoitukseen_haetut_avustukset:
-    '#title': 'Other grants applied for to be used for the same purpose'
-  info_muut_samaan_tarkoitukseen_haettu:
-    '#text': "<p>Indicate here only the grants that have been applied for from somewhere other than the City of Helsinki and for which the decisions have not been made yet.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta:
-    '#title': 'We have applied for grants from somewhere other than the City of Helsinki'
-    '#options':
-      Kyllä: 'Yes'
-      Ei: 'No'
-  haettu_avustus_tieto:
-    '#title': 'Add new grant applied for'
-    '#multiple__add_more_button_label': 'Add new grant applied for'
-    '#element':
-      issuer_name:
-        '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
-      year:
-        '#pattern_error': 'Only numbers'
-      purpose:
-        '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
-        '#counter_maximum_message': '%d/1000 characters remaining'
-  kaupungilta_saadut_lainat_ja_takaukset:
-    '#title': 'Loans and guarantees received from the city'
-  kaupungilta_saadut_1:
-    '#markup': 'For loans received from the city, indicate the original loan amount, remaining loan amount, loan period, interest rate and purpose for which the loan was granted. For guarantees, indicate the monetary value and purpose.'
-  benefits_loans:
-    '#title': 'Description of loans and guarantees'
-    '#counter_maximum_message': '%d/500 characters remaining'
-  kaupungilta_saatu_tiloihin_liittyva_tuki:
-    '#title': 'Support from the city related to facilities'
-  tilate_1:
-    '#markup': 'Facilities that the city has given free of charge or rented to the applicant (name or address of the facility, rent amount &euro;/month)'
-  benefits_premises:
-    '#title': 'Description of the support related to facilities'
-    '#counter_maximum_message': '%d/500 characters remaining'
-  edellisen_avustuksen_kayttoselvitys:
-    '#title': 'Report on the use of the previous grant'
-  compensation_boolean_info:
-    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  compensation_boolean:
-    '#title': 'Report on the use of the grant I received in the previous year'
-  markup:
-    '#markup': 'Provide a report on the use of the grant received from the City of Helsinki. A report on the use of the grant must be drawn up for the grant concerning the previous accounting period. A report on the use should not be drawn up for the current accounting period. Providing the report on the use is a prerequisite for receiving the next grant. If no report on the use is provided, the grant will not be awarded or paid. A grant awarded may be recovered if the use of the previous grant has not been satisfactorily reported.'
-  compensation_explanation:
-    '#title': 'Report on the use of the grant'
-    '#help': 'The report on the use must briefly describe how the received grant has been used. The recipient must arrange its accounting in such a way that it is possible to monitor the use of the grant. For example, if a community has received a lease grant, the profit and loss account in the financial statements must show the grant in both income and expenses. Further information on the use of the grant can also be written in a separate appendix, which can be returned under Report on the use.'
-    '#counter_maximum_message': '%d/5000 characters remaining'
   3_yhteison_tiedot:
     '#title': '3. Activities of the community'
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
-  business_info:
-    '#title': 'Description of activities'
-  community_purpose:
-    '#title': 'Description of activities'
-    '#help': 'The description of activities is maintained in your data.'
-  community_practices_business:
-    '#title': 'Is the entity engaged in business?'
-    '#options':
-      1: 'Yes'
-      0: 'No'
-  ensimmainen_otsikko:
-    '#title': 'Membership fees'
-  fee_person:
-    '#title': 'Individual membership fee (€/year)'
-  fee_community:
-    '#title': 'Community member (€/year)'
   jasenmaara:
     '#title': 'Numbers of members'
-  members_applicant_person_local:
-    '#title': 'Total number of individual members in Helsinki'
-    '#help': 'How many individual members does the community currently have in Helsinki who have paid the membership fee?'
-    '#pattern_error': 'Only numbers'
+  jasenmaara_fieldset:
+    '#help': 'Jos yhteis&ouml;ll&auml; on j&auml;seni&auml;, merkitse ne t&auml;h&auml;n.'
   members_applicant_person_global:
     '#title': 'Total number of individual members'
-    '#help': 'How many individual members does the community currently have who have paid the membership fee?'
-    '#pattern_error': 'Only numbers'
-  members_applicant_community_local:
-    '#title': 'Total number of community members in Helsinki'
-    '#help': 'How many community members does the community currently have in Helsinki who have paid the membership fee? Community members are non-individual members, such as associations, foundations, companies or municipalities.'
-    '#pattern_error': 'Only numbers'
+  members_applicant_person_local:
+    '#title': 'Total number of individual members in Helsinki'
   members_applicant_community_global:
     '#title': 'Community members'
-    '#help': 'How many community members does the community currently have who have paid the membership fee? Community members are non-individual members, such as associations, foundations, companies or municipalities.'
-    '#pattern_error': 'Only numbers'
+  members_applicant_community_local:
+    '#title': 'Total number of community members in Helsinki'
+  maara_helsingissa:
+    '#help': '&Auml;l&auml; t&auml;yt&auml; samoja k&auml;vij&ouml;it&auml; kahteen kertaan, esim. n&auml;yttelytilassa j&auml;rjestetty&auml; ty&ouml;pajaa sek&auml; n&auml;yttelyihin ett&auml; ty&ouml;pajoihin.'
+  maara_kaikkiaan:
+    '#help': 'M&auml;&auml;r&auml; kaikkiaan -kohdassa t&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
+  yleisolle_avoin_toiminta:
+    '#help': 'Yleis&ouml;lle avoimella toiminnalla tarkoitetaan t&auml;ss&auml; mm. esityksi&auml;, n&auml;yttelyit&auml; ja ty&ouml;pajoja tai muita osallistavia toimintamuotoja.'
+  toiminta_taiteelliset_lahtokohdat:
+    '#help': 'Voit nostaa my&ouml;s esiin esimerkisksi keskeisi&auml; palkintoja tai muita noteerauksia.'
+  talousarvio:
+    '#title': 'Budget (for the year for which you are applying for a grant)'
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and appendices'
   lisatietoja_hakemukseen_liittyen:
@@ -189,59 +106,18 @@ elements: |
   liitteet:
     '#title': Appendices
   attachments_info:
-    '#markup': "All the appendices listed below must be submitted for the processing of the grant application. The grant application may be rejected if the appendices are not submitted. If any of the appendices is missing, let us know in the Further clarification on attachments section of the application.<br />\r\n<br />\r\n<strong>Required appendices</strong><br />\r\nFor the processing of the grant application, the required appendices are the confirmed appendices approved and signed by the community at its meeting for the previous accounting period and for the operating year for which the grant is being applied for. The appendices concerning the previous accounting period are the financial statements, the annual report, the audit or performance audit report and the minutes of the annual meeting. The appendices for the year for which the grant is being applied for are the budget and action plan.<br />\r\n<br />\r\n<strong>Submission of several appendices as a single file</strong><br />\r\nIf you wish, you can submit several appendices as a single file under Financial statements or Budget. In this case, under the other appendix headings, indicate &ldquo;The appendix has been submitted as a single file or with another application.&rdquo;<br />\r\n<br />\r\n<strong>Appendices previously submitted to the City of Helsinki</strong><br />\r\nIf the required appendices have already been submitted as appendices to another grant application addressed to the City of Helsinki, the same appendices do not need to be submitted again. The confirmed financial statements, annual report, action plan and budget of the community cannot be different from one application to another. In this case, under the submitted appendices, indicate &ldquo;The appendix has been submitted as a single file or with another application&rdquo;."
+    '#markup': "All the appendices listed below must be submitted for the processing of the grant application. The grant application may be rejected if the appendices are not submitted. If any of the appendices is missing, let us know in the Further clarification on attachments section of the application.<br />\r\n<br />\r\n<strong>Required appendices</strong><br />\r\nFor the processing of the grant application, the required appendices are curricula vitae of the members of the working group in the case of a project by art professionals.<br />\r\n<br />\r\nAs a new applicant or when your banking information has changed, you are also required to submit a bank statement or similar document indicating the account holder&rsquo;s name and the account number in the applicant&rsquo;s own information.<br />\r\n<br />\r\n<strong>Submission of several appendices</strong><br />\r\nYou can submit several curricula vitae of the members of the working group as separate files in the Other appendice -field. If you wish, you can also submit several appendices as a single file."
   notification_attachments:
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>The contents of the attachments cannot be viewed afterwards</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Please note that you will not be able to open the attachments after you have attached them to the form. You will only see the file name of the attachment.</p>\r\n\r\n<p>Although you cannot view the attachments afterwards, the attachments to the form are sent along with the other information on the form to the grant application processor.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
-  vahvistettu_tilinpaatos:
-    '#title': 'Confirmed financial statements (for the previous accounting period)'
-    '#help': "The financial statements must include at least the profit and loss account and the balance sheet. An association must append to this section the financial statements confirmed and signed at the association&rsquo;s annual meeting.<br />\r\nThe community&rsquo;s accounting period may be a calendar year or some other period. In the case of associations, their own rules state what the association&rsquo;s accounting period is."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vahvistettu_toimintakertomus:
-    '#title': 'Confirmed annual report (for the previous accounting period)'
-    '#help': "An association must append to this section the annual report confirmed at the association&rsquo;s annual meeting.<br />\r\nIf the annual report is part of the financial statements and you have already appended it to the form with the financial statements, it does not need to be appended here separately. In this case, under the annual report, indicate &ldquo;The appendix has been submitted as a single file or with another application&rdquo;."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vahvistettu_tilin_tai_toiminnantarkastuskertomus:
-    '#title': 'Confirmed audit or performance audit report (for the previous accounting period)'
-    '#help': "An association must append to this section the annual report confirmed at the association&rsquo;s annual meeting.<br />\r\nIf the annual report is part of the financial statements and you have already appended it to the form with the financial statements, it does not need to be appended here separately. In this case, under the annual report, indicate &ldquo;The appendix has been submitted as a single file or with another application&rdquo;."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vuosikokouksen_poytakirja:
-    '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this appendix does not need to be submitted.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  toimintasuunnitelma:
-    '#title': 'Action plan (for the year for which you are applying for a grant)'
-    '#help': 'Append here the action plan for the whole community.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  talousarvio:
-    '#title': 'Budget (for the year for which you are applying for a grant)'
-    '#help': 'Budget (for the year for which you are applying for a grant)'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
   extra_info:
     '#title': 'Further clarification on attachments'
   muu_liite:
-    '#title': 'Other attachment'
+    '#title': 'Other appendice'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   actions:
     '#submit__label': Submit
     '#wizard_prev__label': '< Previous'

--- a/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
@@ -1,0 +1,104 @@
+elements: |
+  contact_markup:
+    '#markup': 'Ilmoita t&auml;ss&auml; sellainen yhteis&ouml;n s&auml;hk&ouml;postiosoite, jota luetaan aktiivisesti. S&auml;hk&ouml;postiin l&auml;hetet&auml;&auml;n avustushakemukseen liittyvi&auml; yhteydenottoja esim. lis&auml;selvitys- ja t&auml;ydennyspyynt&ouml;j&auml;.'
+  email:
+    '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyv&auml;t viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+  community_address:
+    '#description': 'Valitse osoite, osoitteita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
+  bank_account:
+    '#description': 'Valitse tilinumero, tilinumeroita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
+    '#account_number__title': ''
+    '#account_number_owner_name__title': ''
+    '#account_number_ssn__title': ''
+  community_officials:
+    '#description': 'Valitse toiminnasta vastaavat henkil&ouml;t, henki&ouml;it&auml; yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa henkil&ouml;it&auml; tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n henkil&ouml;iden tietoja omiin tietoihin.'
+  info_subvention_summa:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Yli 5000€ avustusten syöttäminen avaa joukon lisäkysymyksiä.</span></div>\r\n</div>\r\n</div>\r\n"
+  info_monivuotinen:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  info_muut_samaan_tarkoitukseen_myonnetty:
+    '#text': "<p>Ilmoita tähän ainoastaan avustukset, jotka on myönnetty muualta kuin Helsingin kaupungilta kuluvana ja kahtena edellisenä verovuotena.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  myonnetty_avustus:
+    '#element':
+      issuer_name:
+        '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
+      purpose:
+        '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
+  jasenmaara_fieldset:
+    '#help': 'Jos yhteis&ouml;ll&auml; on j&auml;seni&auml;, merkitse ne t&auml;h&auml;n.'
+  henkilosto:
+    '#help': 'Henkil&ouml;st&ouml;&ouml;n voi sis&auml;llytt&auml;&auml; muitakin kuin palkattuja ty&ouml;ntekij&ouml;it&auml;, mm. palkkioilla tai muilla korvauksilla ty&ouml;skentelevi&auml; tai ostopalveluna ostettavaa ty&ouml;t&auml;. Kokoaikaiset ty&ouml;ntekij&auml;t voivat sis&auml;lt&auml;&auml; my&ouml;s m&auml;&auml;r&auml;aikaisia ty&ouml;ntekij&ouml;it&auml;, jos n&auml;m&auml; ty&ouml;skentelev&auml;t t&auml;ysp&auml;iv&auml;isesti. Henkil&ouml;ty&ouml;vuosi kuvaa kokoaikaiseksi muutetun henkil&ouml;n ty&ouml;panosta. Esimerkiksi 6kk kokop&auml;iv&auml;isesti ty&ouml;skentelev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,5 henkil&ouml;ty&ouml;vuotta. Vastaavasti koko vuoden osa-aikaisesti 30% ty&ouml;m&auml;&auml;r&auml;&auml; tekev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,3 henkil&ouml;ty&ouml;vuotta. Jos toimitatte tietoja henkil&ouml;ty&ouml;vuosistanne valtiolle tai muun tahon tilastointiin, niin k&auml;ytt&auml;k&auml;&auml; t&auml;ss&auml; samaa laskentatapaa jos mahdollista.'
+  info_taiteellisen_toiminnan_tilat:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  arvio_maarasta_markup:
+    '#markup': "<h3>Arvio m&auml;&auml;rist&auml;</h3>\r\n\r\n<p>Sy&ouml;t&auml; tiedot koskien omaa toimintaa vuonna, jolle avustusta haetaan. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.</p>"
+  ensi_iltojen_maara_helsingissa:
+    '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimm&auml;ist&auml; esityst&auml;. T&auml;yt&auml; t&auml;h&auml;n ne ensi-illat, jotka tapahtuvat Helsingiss&auml;.'
+  festivaali_paivanmaarat_maarasta_markup:
+    '#markup': '<h3>Tapahtuman tai festivaalin p&auml;iv&auml;m&auml;&auml;r&auml;t</h3>'
+  toimintamuodot_markup:
+    '#markup': "<h3>Muut keskeiset toimintamuodot</h3>\r\n\r\n<p>Jos toiminta sis&auml;lt&auml;&auml; yleis&ouml;lle avointen esitysten, n&auml;yttelyiden ja ty&ouml;pajojen tai muiden osallistavien toimintamuotojen lis&auml;ksi muita keskeisi&auml; muotoja, listaa ne t&auml;h&auml;n.</p>"
+  toteutuneet_markup:
+    '#markup': "<h3>Toteutuneet m&auml;&auml;r&auml;t</h3>\r\n\r\n<p>Sy&ouml;t&auml; tiedot koskien omaa toimintaa edellisen&auml; p&auml;&auml;ttyneen&auml; vuonna. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.</p>"
+  maara_helsingissa_toteutuneet:
+    '#help': '&Auml;l&auml; t&auml;yt&auml; samoja k&auml;vij&ouml;it&auml; kahteen kertaan, esim. n&auml;yttelytilassa j&auml;rjestetty&auml; ty&ouml;pajaa sek&auml; n&auml;yttelyihin ett&auml; ty&ouml;pajoihin.'
+  maara_kaikkiaan_toteutuneet:
+    '#help': 'M&auml;&auml;r&auml; kaikkiaan -kohdassa t&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
+  toeutuneet_ensi_iltojen_maara_helsingissa:
+    '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimm&auml;ist&auml; esityst&auml;. T&auml;yt&auml; t&auml;h&auml;n ne ensi-illat, jotka tapahtuvat Helsingiss&auml;.'
+  arvio_maarasta_toteutuneet_markup:
+    '#markup': '<h3>Helsingiss&auml; j&auml;rjestett&auml;v&auml; yleis&ouml;lle avoin toiminta toteutettiin</h3>'
+  toiminta_taiteelliset_lahtokohdat:
+    '#help': 'Voit nostaa my&ouml;s esiin esimerkisksi keskeisi&auml; palkintoja tai muita noteerauksia.'
+  attachments_info:
+    '#markup': "All the appendices listed below must be submitted for the processing of the grant application. The grant application may be rejected if the appendices are not submitted. If any of the appendices is missing, let us know in the Further clarification on attachments section of the application.<br />\r\n<br />\r\n<strong>Required appendices</strong><br />\r\nFor the processing of the grant application, the required appendices are the confirmed appendices approved and signed by the community at its meeting for the previous accounting year and for the operating year for which the grant is being applied for. The appendices concerning the previous accounting year are the financial statements, the annual report, and the audit or performance audit report. The appendices for the year for which the grant is being applied for are the budget and action plan.<br />\r\n<br />\r\nAs a new applicant or when your banking information has changed, you are also required to submit a bank statement or similar document indicating the account holder&rsquo;s name and the account number in the applicant&rsquo;s own information. As a new applicant or when the rules of your community have changed since your last application, you are also required to submit the rules of your community.<br />\r\n<br />\r\n<strong>Submission of several appendices as a single file</strong><br />\r\nIf you wish, you can submit several appendices as a single file under Financial statements or Budget. In this case, under the other appendix headings, indicate &ldquo;The appendix has been submitted as a single file or with another application.&rdquo;<br />\r\n<br />\r\n<strong>Appendices previously submitted to the City of Helsinki</strong><br />\r\nIf the required appendices have already been submitted as appendices to another grant application addressed to the City of Helsinki, the same appendices do not need to be submitted again. In this case, under the submitted appendices, indicate &ldquo;The appendix has been submitted as a single file or with another application&rdquo;. The confirmed financial statements, annual report, action plan and budget of the community cannot be different from one application to another."
+  notification_attachments:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>\r\n\r\n<p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
+  yhteison_saannot:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  vahvistettu_tilinpaatos_edelliselta_paattyneelta_tilikaudelta_:
+    '#help': "Tilinp&auml;&auml;t&ouml;ksen t&auml;ytyy sis&auml;lt&auml;&auml; v&auml;hint&auml;&auml;n tuloslaskelma ja tase. Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun ja allekirjoitetun tilinp&auml;&auml;t&ouml;ksen.<br />\r\n<br />\r\nYhteis&ouml;n tilikausi voi olla kalenterivuosi tai jokin muu kausi. Yhdistysten kohdalla niiden omissa s&auml;&auml;nn&ouml;iss&auml; lukee, mik&auml; on yhdistyksen tilikausi."
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  vahvistettu_toimintakertomus_edelliselta_paattyneelta_tilikaudel:
+    '#help': "Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun toimintakertomuksen.<br />\r\nJos toimintakertomus on osana tilinp&auml;&auml;t&ouml;st&auml; ja liititte sen jo tilinp&auml;&auml;t&ouml;ksen mukana lomakkeelle, sit&auml; ei tarvitse liitt&auml;&auml; t&auml;h&auml;n erikseen. Valitse t&auml;llaisessa tilanteessa toimintakertomuksen kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;."
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  vahvistettu_tilin_tai_toiminnantarkastuskertomus_edelliselta_paa:
+    '#help': "&quot;Liit&auml; t&auml;h&auml;n allekirjoitettu tilin- tai toiminnantarkastuskertomus yhteis&ouml;n edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilikaudelta.<br />\r\nJos allekirjoitettu tilin- tai toiminnantarkastuskertomus on osa yhteis&ouml;nne tilinp&auml;&auml;t&ouml;st&auml; ja liitit sen jo lomakkeelle tilinp&auml;&auml;t&ouml;ksen kohdalla, valitse t&auml;ss&auml; kohdassa &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.&quot;"
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  toimintasuunnitelma_sille_vuodelle_jolle_haet_avustusta_monivuot:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  talousarvio_sille_vuodelle_jolle_haet_avustusta_monivuotisissa_k:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  muu_liite:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''

--- a/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -4,30 +4,8 @@ elements: |
     '#title': '1. Applicant details'
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
-  yhteiso_jolle_haetaan_avustusta:
-    '#title': 'Community for which the grant is being applied for'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">The indicated information has been retrieved from the register of the Finnish Patent and Registration Office (PRH), and changing the information is only possible in the online service in question.</div>'
-  community_official_name:
-    '#title': 'Name of community'
-  company_number:
-    '#title': 'Business ID'
-  home:
-    '#title': Domicile
-  registration_date:
-    '#title': 'Date of registration'
-  perustamisvuosi:
-    '#title': 'Year of establishment'
-  founding_year:
-    '#title': 'Year of establishment'
-  yhteison_lyhenne:
-    '#title': 'Abbreviated name'
-  community_official_name_short:
-    '#title': 'Abbreviated name'
-  verkkosivut:
-    '#title': Website
-  homepage:
-    '#title': Website
   contact_person_email_section:
     '#title': Email
   contact_markup:
@@ -45,17 +23,25 @@ elements: |
     '#title': Address
   community_address:
     '#title': Address
+    '#description': 'Valitse osoite, osoitteita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
     '#community_address_select__title': 'Select the address'
   tilinumero:
     '#title': 'Account number'
   bank_account:
     '#title': 'Account number'
+    '#description': 'Valitse tilinumero, tilinumeroita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
     '#account_number_select__title': 'Select the account number'
     '#account_number__title': ''
+    '#account_number_owner_name__title': ''
+    '#account_number_ssn__title': ''
   toiminnasta_vastaavat_henkilot:
     '#title': 'Persons responsible for operations'
   community_officials:
     '#title': 'Persons responsible within the community'
+    '#description': 'Valitse toiminnasta vastaavat henkil&ouml;t, henki&ouml;it&auml; yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa henkil&ouml;it&auml; tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n henkil&ouml;iden tietoja omiin tietoihin.'
   2_avustustiedot:
     '#title': '2. Grant details'
     '#prev_button_label': '< Previous'
@@ -68,21 +54,20 @@ elements: |
     '#title': 'Types of grant'
   subventions:
     '#title': Grants
-  kayttotarkoitus:
-    '#title': 'Purpose of use'
-  compensation_purpose:
-    '#title': 'Brief description of the purpose(s) of the grant(s) applied for'
-    '#help': 'Indicate the purpose for which the grant is applied for. If necessary, specify the different uses. Also tell us what is intended to be achieved with the grant and what goals are associated with the activities to be supported.'
-    '#counter_maximum_message': '%d/5000 characters remaining'
+  info_kyseessa_on_monivuotinen_avustus:
+    '#text': "<p>&nbsp;</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  vuodet_joille_monivuotista_avustusta_on_haettu_tai_myonetty:
+    '#help': 'T&auml;yt&auml; vuodet vain t&auml;st&auml; eteenp&auml;in haettavan avustuskauden osalta. &Auml;l&auml; kirjaa saman tai aikaisemman avustuskauden aikaisempia vuosia.'
+  hankkeen_nimi:
+    '#help': 'Valitse hankkeelle nimi, joka voidaan julkaista p&auml;&auml;t&ouml;ksen yhteydess&auml;.'
+  kyseessa_on_festivaali_tai_tapahtuma:
+    '#help': 'T&auml;ss&auml; tarkoitetaan festivaalia tai tapahtumaa, joka tapahtuu tiiviin ajanjakson sis&auml;ll&auml; ja on ohjelmaltaan ja kestoltaan laajempi kuin yksitt&auml;inen konsertti, esitys tms. Festivaali tai tapahtuma sis&auml;lt&auml;&auml; useampia eri ohjelmasis&auml;lt&ouml;j&auml;, esim. esityksi&auml;, joiden v&auml;liss&auml; yleis&ouml; voi my&ouml;s vaihtua. Esimerkiksi kaupunginosatapahtumat. Ei esimerkiksi esityssarjat. Festivaali tai tapahtuma voi olla toistuva tai kertaluonteinen.'
   muut_samaan_tarkoitukseen_myonnetyt_avustukset:
     '#title': 'Other grants received for the same purpose'
   info_muut_samaan_tarkoitukseen_myonnetty:
     '#text': "<p>Indicate here only the grants received from somewhere other than the City of Helsinki in the current and two previous tax years.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
   olemme_saaneet_muita_avustuksia:
     '#title': 'We have received other grants'
-    '#options':
-      Kyllä: 'Yes'
-      Ei: 'No'
   myonnetty_avustus:
     '#title': 'Received grant'
     '#multiple__add_more_button_label': 'Add new received grant'
@@ -94,90 +79,31 @@ elements: |
       purpose:
         '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
         '#counter_maximum_message': '%d/1000 characters remaining'
-  muut_samaan_tarkoitukseen_haetut_avustukset:
-    '#title': 'Other grants applied for to be used for the same purpose'
-  info_muut_samaan_tarkoitukseen_haettu:
-    '#text': "<p>Indicate here only the grants that have been applied for from somewhere other than the City of Helsinki and for which the decisions have not been made yet.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta:
-    '#title': 'We have applied for grants from somewhere other than the City of Helsinki'
-    '#options':
-      Kyllä: 'Yes'
-      Ei: 'No'
-  haettu_avustus_tieto:
-    '#title': 'Add new grant applied for'
-    '#multiple__add_more_button_label': 'Add new grant applied for'
-    '#element':
-      issuer_name:
-        '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
-      year:
-        '#pattern_error': 'Only numbers'
-      purpose:
-        '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
-        '#counter_maximum_message': '%d/1000 characters remaining'
-  kaupungilta_saadut_lainat_ja_takaukset:
-    '#title': 'Loans and guarantees received from the city'
-  kaupungilta_saadut_1:
-    '#markup': 'For loans received from the city, indicate the original loan amount, remaining loan amount, loan period, interest rate and purpose for which the loan was granted. For guarantees, indicate the monetary value and purpose.'
-  benefits_loans:
-    '#title': 'Description of loans and guarantees'
-    '#counter_maximum_message': '%d/500 characters remaining'
-  kaupungilta_saatu_tiloihin_liittyva_tuki:
-    '#title': 'Support from the city related to facilities'
-  tilate_1:
-    '#markup': 'Facilities that the city has given free of charge or rented to the applicant (name or address of the facility, rent amount &euro;/month)'
-  benefits_premises:
-    '#title': 'Description of the support related to facilities'
-    '#counter_maximum_message': '%d/500 characters remaining'
-  edellisen_avustuksen_kayttoselvitys:
-    '#title': 'Report on the use of the previous grant'
-  compensation_boolean_info:
-    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  compensation_boolean:
-    '#title': 'Report on the use of the grant I received in the previous year'
-  markup:
-    '#markup': 'Provide a report on the use of the grant received from the City of Helsinki. A report on the use of the grant must be drawn up for the grant concerning the previous accounting period. A report on the use should not be drawn up for the current accounting period. Providing the report on the use is a prerequisite for receiving the next grant. If no report on the use is provided, the grant will not be awarded or paid. A grant awarded may be recovered if the use of the previous grant has not been satisfactorily reported.'
-  compensation_explanation:
-    '#title': 'Report on the use of the grant'
-    '#help': 'The report on the use must briefly describe how the received grant has been used. The recipient must arrange its accounting in such a way that it is possible to monitor the use of the grant. For example, if a community has received a lease grant, the profit and loss account in the financial statements must show the grant in both income and expenses. Further information on the use of the grant can also be written in a separate appendix, which can be returned under Report on the use.'
-    '#counter_maximum_message': '%d/5000 characters remaining'
   3_yhteison_tiedot:
     '#title': '3. Activities of the community'
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
-  business_info:
-    '#title': 'Description of activities'
-  community_purpose:
-    '#title': 'Description of activities'
-    '#help': 'The description of activities is maintained in your data.'
-  community_practices_business:
-    '#title': 'Is the entity engaged in business?'
-    '#options':
-      1: 'Yes'
-      0: 'No'
-  ensimmainen_otsikko:
-    '#title': 'Membership fees'
-  fee_person:
-    '#title': 'Individual membership fee (€/year)'
-  fee_community:
-    '#title': 'Community member (€/year)'
   jasenmaara:
     '#title': 'Numbers of members'
-  members_applicant_person_local:
-    '#title': 'Total number of individual members in Helsinki'
-    '#help': 'How many individual members does the community currently have in Helsinki who have paid the membership fee?'
-    '#pattern_error': 'Only numbers'
+  jasenmaara_fieldset:
+    '#help': 'Jos yhteis&ouml;ll&auml; on j&auml;seni&auml;, merkitse ne t&auml;h&auml;n.'
   members_applicant_person_global:
     '#title': 'Total number of individual members'
-    '#help': 'How many individual members does the community currently have who have paid the membership fee?'
-    '#pattern_error': 'Only numbers'
-  members_applicant_community_local:
-    '#title': 'Total number of community members in Helsinki'
-    '#help': 'How many community members does the community currently have in Helsinki who have paid the membership fee? Community members are non-individual members, such as associations, foundations, companies or municipalities.'
-    '#pattern_error': 'Only numbers'
+  members_applicant_person_local:
+    '#title': 'Total number of individual members in Helsinki'
   members_applicant_community_global:
     '#title': 'Community members'
-    '#help': 'How many community members does the community currently have who have paid the membership fee? Community members are non-individual members, such as associations, foundations, companies or municipalities.'
-    '#pattern_error': 'Only numbers'
+  members_applicant_community_local:
+    '#title': 'Total number of community members in Helsinki'
+  henkilosto:
+    '#help': 'Henkil&ouml;st&ouml;&ouml;n voi sis&auml;llytt&auml;&auml; muitakin kuin palkattuja ty&ouml;ntekij&ouml;it&auml;, mm. palkkioilla tai muilla korvauksilla ty&ouml;skentelevi&auml; tai ostopalveluna ostettavaa ty&ouml;t&auml;. Kokoaikaiset ty&ouml;ntekij&auml;t voivat sis&auml;lt&auml;&auml; my&ouml;s m&auml;&auml;r&auml;aikaisia ty&ouml;ntekij&ouml;it&auml;, jos n&auml;m&auml; ty&ouml;skentelev&auml;t t&auml;ysp&auml;iv&auml;isesti. Henkil&ouml;ty&ouml;vuosi kuvaa kokoaikaiseksi muutetun henkil&ouml;n ty&ouml;panosta. Esimerkiksi 6kk kokop&auml;iv&auml;isesti ty&ouml;skentelev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,5 henkil&ouml;ty&ouml;vuotta. Vastaavasti koko vuoden osa-aikaisesti 30% ty&ouml;m&auml;&auml;r&auml;&auml; tekev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,3 henkil&ouml;ty&ouml;vuotta. Kyseess&auml; on arvio, joka kuvaa suuntaa-antavasti projektiin osallistuvan henkil&ouml;st&ouml;n ty&ouml;panosta.'
+  tila:
+    '#multiple__no_items_message': 'Ei sy&ouml;tettyj&auml; tiloja. Lis&auml;&auml; tilan tiedot alta.'
+  toiminta_taiteelliset_lahtokohdat:
+    '#help': 'Voit nostaa my&ouml;s esiin esimerkisksi keskeisi&auml; palkintoja tai muita noteerauksia.'
+  talousarvio:
+    '#title': 'Budget (for the year for which you are applying for a grant)'
+    '#description': 'Koskien hankkeen sit&auml; vuotta, jolle avustusta t&auml;ll&auml; hakemuksella haetaan.'
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and appendices'
   lisatietoja_hakemukseen_liittyen:
@@ -189,51 +115,21 @@ elements: |
   liitteet:
     '#title': Appendices
   attachments_info:
-    '#markup': "All the appendices listed below must be submitted for the processing of the grant application. The grant application may be rejected if the appendices are not submitted. If any of the appendices is missing, let us know in the Further clarification on attachments section of the application.<br />\r\n<br />\r\n<strong>Required appendices</strong><br />\r\nFor the processing of the grant application, the required appendices are the confirmed appendices approved and signed by the community at its meeting for the previous accounting period and for the operating year for which the grant is being applied for. The appendices concerning the previous accounting period are the financial statements, the annual report, the audit or performance audit report and the minutes of the annual meeting. The appendices for the year for which the grant is being applied for are the budget and action plan.<br />\r\n<br />\r\n<strong>Submission of several appendices as a single file</strong><br />\r\nIf you wish, you can submit several appendices as a single file under Financial statements or Budget. In this case, under the other appendix headings, indicate &ldquo;The appendix has been submitted as a single file or with another application.&rdquo;<br />\r\n<br />\r\n<strong>Appendices previously submitted to the City of Helsinki</strong><br />\r\nIf the required appendices have already been submitted as appendices to another grant application addressed to the City of Helsinki, the same appendices do not need to be submitted again. The confirmed financial statements, annual report, action plan and budget of the community cannot be different from one application to another. In this case, under the submitted appendices, indicate &ldquo;The appendix has been submitted as a single file or with another application&rdquo;."
+    '#markup': "All the appendices listed below must be submitted for the processing of the grant application. The grant application may be rejected if the appendices are not submitted. If any of the appendices is missing, let us know in the Further clarification on attachments section of the application.<br />\r\n<br />\r\n<strong>Required appendices</strong><br />\r\nFor the processing of the grant application, the required appendices are a project plan for the applied period and a budget for the applied period.<br />\r\n<br />\r\nAs a new applicant or when your banking information has changed, you are also required to submit a bank statement or similar document indicating the account holder&rsquo;s name and the account number in the applicant&rsquo;s own information.<br />\r\n<br />\r\n<strong>Submission of several appendices as a single file</strong><br />\r\nIf you wish, you can submit several appendices as a single file. In this case, under the other appendix headings, indicate &ldquo;The appendix has been submitted as a single file or with another application.&rdquo;"
   notification_attachments:
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>The contents of the attachments cannot be viewed afterwards</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Please note that you will not be able to open the attachments after you have attached them to the form. You will only see the file name of the attachment.</p>\r\n\r\n<p>Although you cannot view the attachments afterwards, the attachments to the form are sent along with the other information on the form to the grant application processor.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
-  vahvistettu_tilinpaatos:
-    '#title': 'Confirmed financial statements (for the previous accounting period)'
-    '#help': "The financial statements must include at least the profit and loss account and the balance sheet. An association must append to this section the financial statements confirmed and signed at the association&rsquo;s annual meeting.<br />\r\nThe community&rsquo;s accounting period may be a calendar year or some other period. In the case of associations, their own rules state what the association&rsquo;s accounting period is."
+  projektisuunnitelma_liite:
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
-  vahvistettu_toimintakertomus:
-    '#title': 'Confirmed annual report (for the previous accounting period)'
-    '#help': "An association must append to this section the annual report confirmed at the association&rsquo;s annual meeting.<br />\r\nIf the annual report is part of the financial statements and you have already appended it to the form with the financial statements, it does not need to be appended here separately. In this case, under the annual report, indicate &ldquo;The appendix has been submitted as a single file or with another application&rdquo;."
+    '#isAttachmentNew__title': ''
+  talousarvio_liite:
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
-  vahvistettu_tilin_tai_toiminnantarkastuskertomus:
-    '#title': 'Confirmed audit or performance audit report (for the previous accounting period)'
-    '#help': "An association must append to this section the annual report confirmed at the association&rsquo;s annual meeting.<br />\r\nIf the annual report is part of the financial statements and you have already appended it to the form with the financial statements, it does not need to be appended here separately. In this case, under the annual report, indicate &ldquo;The appendix has been submitted as a single file or with another application&rdquo;."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vuosikokouksen_poytakirja:
-    '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this appendix does not need to be submitted.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  toimintasuunnitelma:
-    '#title': 'Action plan (for the year for which you are applying for a grant)'
-    '#help': 'Append here the action plan for the whole community.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  talousarvio:
-    '#title': 'Budget (for the year for which you are applying for a grant)'
-    '#help': 'Budget (for the year for which you are applying for a grant)'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   extra_info:
     '#title': 'Further clarification on attachments'
   muu_liite:
@@ -242,6 +138,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   actions:
     '#submit__label': Submit
     '#wizard_prev__label': '< Previous'

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -3,30 +3,8 @@ description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'
-  yhteiso_jolle_haetaan_avustusta:
-    '#title': 'Samfund för vilket understödet ansöks'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
-  community_official_name:
-    '#title': 'Samfundets namn'
-  company_number:
-    '#title': FO-nummer
-  home:
-    '#title': Hemort
-  registration_date:
-    '#title': Registreringsdatum
-  perustamisvuosi:
-    '#title': Stiftelseår
-  founding_year:
-    '#title': Stiftelseår
-  yhteison_lyhenne:
-    '#title': 'Samfundets förkortning'
-  community_official_name_short:
-    '#title': 'Samfundets förkortning'
-  verkkosivut:
-    '#title': Webbsidor
-  homepage:
-    '#title': Webbsidor
   contact_person_email_section:
     '#title': E-post
   contact_markup:
@@ -44,16 +22,24 @@ elements: |
     '#title': Adress
   community_address:
     '#title': Adress
+    '#description': 'Valitse osoite, osoitteita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
     '#community_address_select__title': 'Välj en adress'
   tilinumero:
     '#title': Kontonummer
   bank_account:
     '#title': Kontonummer
+    '#description': 'Valitse tilinumero, tilinumeroita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
     '#account_number_select__title': 'Välj ett kontonummer'
     '#account_number__title': ''
+    '#account_number_owner_name__title': ''
+    '#account_number_ssn__title': ''
   toiminnasta_vastaavat_henkilot:
     '#title': 'Personer som ansvarar för verksamheten'
   community_officials:
+    '#description': 'Valitse toiminnasta vastaavat henkil&ouml;t, henki&ouml;it&auml; yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa henkil&ouml;it&auml; tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n henkil&ouml;iden tietoja omiin tietoihin.'
     '#title': 'Personer som ansvarar för samfundet'
   2_avustustiedot:
     '#title': '2. Uppgifter om understödet'
@@ -61,25 +47,14 @@ elements: |
     '#title': 'Uppgifter om understödet'
   acting_year:
     '#title': 'År för vilket jag ansöker om understöd'
-  avustuslajit:
-    '#title': Understödskategorier
   subventions:
     '#title': Understöd
-  kayttotarkoitus:
-    '#title': Användningsändamål
-  compensation_purpose:
-    '#title': 'En kort beskrivning av användningsändamålet för det/de understöd som ansöks'
-    '#help': 'Ange f&ouml;r vilket &auml;ndam&aring;l underst&ouml;det ans&ouml;ks och vid behov specificera de olika &auml;ndam&aring;len. Ange ocks&aring; vad underst&ouml;det &auml;r avsett f&ouml;r och vilka m&aring;l som &auml;r relaterade till den underst&ouml;dda verksamheten.'
-    '#counter_maximum_message': '%d/5000 tecken kvar'
   muut_samaan_tarkoitukseen_myonnetyt_avustukset:
     '#title': 'Övriga understöd som beviljats för samma ändamål'
   info_muut_samaan_tarkoitukseen_myonnetty:
     '#text': "<p>Ange här endast de understöd som beviljats från annanstans än Helsingfors stad under det innevarande beskattningsåret eller de föregående två beskattningsåren.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
   olemme_saaneet_muita_avustuksia:
     '#title': 'Vi har fått andra understöd'
-    '#options':
-      Kyllä: Ja
-      Ei: Nej
   myonnetty_avustus:
     '#multiple__add_more_button_label': 'Lägg till understöd som beviljats'
     '#element':
@@ -88,82 +63,30 @@ elements: |
       purpose:
         '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
         '#counter_maximum_message': '%d/1000 tecken kvar'
-  muut_samaan_tarkoitukseen_haetut_avustukset:
-    '#title': 'Övriga understöd som ansökts för samma ändamål'
-  info_muut_samaan_tarkoitukseen_haettu:
-    '#text': "<p>Ange här endast de understöd som har ansökts från annanstans än Helsingfors stad, men beslut har ännu inte fattats.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta:
-    '#title': 'Vi har ansökt om understöd från annanstans än Helsingfors stad.'
-    '#options':
-      Kyllä: Ja
-      Ei: Nej
-  haettu_avustus_tieto:
-    '#title': 'Lägg till nytt understöd som ansökts'
-    '#multiple__add_more_button_label': 'Lägg till nytt understöd som ansökts'
-    '#element':
-      issuer_name:
-        '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
-      purpose:
-        '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
-        '#counter_maximum_message': '%d/1000 tecken kvar'
-  kaupungilta_saadut_lainat_ja_takaukset:
-    '#title': 'Lån och borgen som fåtts från staden'
-  kaupungilta_saadut_1:
-    '#markup': 'G&auml;llande de l&aring;n som f&aring;tts fr&aring;n staden ska man ange det ursprungliga l&aring;nebeloppet, det &aring;terst&aring;ende l&aring;nebeloppet, l&aring;netiden, r&auml;ntesatsen och &auml;ndam&aring;let f&ouml;r vilket l&aring;net beviljades. Om borgen anges deras penningv&auml;rde och &auml;ndam&aring;l.'
-  benefits_loans:
-    '#title': 'Beskrivning av lån och borgen'
-    '#counter_maximum_message': '%d/500 tecken kvar'
-  kaupungilta_saatu_tiloihin_liittyva_tuki:
-    '#title': 'Understöd för lokaler som fåtts från staden'
-  tilate_1:
-    '#markup': 'Lokaler som staden har gett gratis eller hyrt till den s&ouml;kande (lokalens namn eller adress, hyresbelopp &euro;/m&aring;nad)'
-  benefits_premises:
-    '#title': 'Beskrivning av understödet för lokalerna'
-    '#counter_maximum_message': '%d/500 tecken kvar'
-  edellisen_avustuksen_kayttoselvitys:
-    '#title': 'Redovisning om det tidigare understödet'
-  compensation_boolean_info:
-    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  compensation_boolean:
-    '#title': 'Redovisning om understödet som jag fick under det föregående året'
-  markup:
-    '#markup': 'Ge en redovisning om underst&ouml;det som f&aring;tts fr&aring;n Helsingfors stad. Redovisningen g&ouml;rs om underst&ouml;det som beviljats f&ouml;r den senaste avslutade r&auml;kenskapsperioden. Redovisning g&ouml;rs inte om den innevarande r&auml;kenskapsperioden. Redovisningen kr&auml;vs f&ouml;r att f&aring; ett nytt underst&ouml;d. Om en redovisning inte g&ouml;rs, kommer ett underst&ouml;d inte att beviljas eller betalas ut. Det beviljade underst&ouml;det kan &aring;terkr&auml;vas om anv&auml;ndningen av det tidigare underst&ouml;det inte har redogjorts f&ouml;r p&aring; ett tillfredsst&auml;llande s&auml;tt.'
-  compensation_explanation:
-    '#title': 'Redovisning om användningen av understödet'
-    '#help': 'I redovisningen ska det kortfattat anges hur det beviljade underst&ouml;det har anv&auml;nts. Underst&ouml;dstagaren ska ordna sin bokf&ouml;ring s&aring; att anv&auml;ndningen av underst&ouml;det kan f&ouml;ljas d&auml;r. Om samfundet till exempel har f&aring;tt hyresunderst&ouml;d ska det av resultatr&auml;kningen i bokslutet framg&aring; b&aring;de int&auml;kter och utgifter vad g&auml;ller underst&ouml;det. Mer information om anv&auml;ndningen av underst&ouml;det kan ocks&aring; skrivas i en separat bilaga som kan l&auml;mnas som Redovisning-bilaga.'
-    '#counter_maximum_message': '%d/5000 tecken kvar'
   3_yhteison_tiedot:
     '#title': '3. Samfundets verksamhet'
-  business_info:
-    '#title': Verksamhetsbeskrivning
-  community_purpose:
-    '#title': Verksamhetsbeskrivning
-    '#help': 'Verksamhetsbeskrivningen redigeras i dina uppgifter.'
-  community_practices_business:
-    '#title': 'Bedriver samfundet affärsverksamhet'
-    '#options':
-      1: Ja
-      0: Nej
-  ensimmainen_otsikko:
-    '#title': Medlemsavgifter
-  fee_person:
-    '#title': 'Medlemsavgift för personmedlemmar (€/år)'
-  fee_community:
-    '#title': 'Samfundsmedlem (€/år)'
   jasenmaara:
     '#title': 'Antal medlemmar'
-  members_applicant_person_local:
-    '#title': 'Personmedlemmar från Helsingfors sammanlagt'
-    '#help': 'Hur m&aring;nga personmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande?'
+  jasenmaara_fieldset:
+    '#help': 'Jos yhteis&ouml;ll&auml; on j&auml;seni&auml;, merkitse ne t&auml;h&auml;n.'
   members_applicant_person_global:
     '#title': 'Personmedlemmar sammanlagt'
-    '#help': 'Hur m&aring;nga personmedlemmar som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande?'
-  members_applicant_community_local:
-    '#title': 'Samfundsmedlemmar från Helsingfors sammanlagt'
-    '#help': 'Hur m&aring;nga samfundsmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
+  members_applicant_person_local:
+    '#title': 'Personmedlemmar från Helsingfors sammanlagt'
   members_applicant_community_global:
     '#title': Samfundsmedlemmar
-    '#help': 'Hur m&aring;nga samfundsmedlemmar som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
+  members_applicant_community_local:
+    '#title': 'Samfundsmedlemmar från Helsingfors sammanlagt'
+  maara_helsingissa:
+    '#help': '&Auml;l&auml; t&auml;yt&auml; samoja k&auml;vij&ouml;it&auml; kahteen kertaan, esim. n&auml;yttelytilassa j&auml;rjestetty&auml; ty&ouml;pajaa sek&auml; n&auml;yttelyihin ett&auml; ty&ouml;pajoihin.'
+  maara_kaikkiaan:
+    '#help': 'M&auml;&auml;r&auml; kaikkiaan -kohdassa t&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
+  yleisolle_avoin_toiminta:
+    '#help': 'Yleis&ouml;lle avoimella toiminnalla tarkoitetaan t&auml;ss&auml; mm. esityksi&auml;, n&auml;yttelyit&auml; ja ty&ouml;pajoja tai muita osallistavia toimintamuotoja.'
+  toiminta_taiteelliset_lahtokohdat:
+    '#help': 'Voit nostaa my&ouml;s esiin esimerkisksi keskeisi&auml; palkintoja tai muita noteerauksia.'
+  talousarvio:
+    '#title': 'Budget (för det år du ansöker om understödet)'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:
@@ -175,51 +98,9 @@ elements: |
   liitteet:
     '#title': Bilagor
   attachments_info:
-    '#markup': "Alla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan om underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas, meddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Erforderliga bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs styrkta bilagor fr&aring;n den f&ouml;reg&aring;ende r&auml;kenskapsperioden som samfundet har godk&auml;nt och undertecknat vid sitt m&ouml;te samt bilagor f&ouml;r det verksamhets&aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks. Bilagorna fr&aring;n den f&ouml;reg&aring;ende r&auml;kenskapsperioden &auml;r: bokslut, verksamhetsber&auml;ttelse, revisionsber&auml;ttelse och protokoll fr&aring;n &aring;rsst&auml;mman. Bilagorna f&ouml;r det &aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks &auml;r: budget och verksamhetsplan.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor i en fil</strong><br />\r\nOm du vill kan du l&auml;mna in flera bilagor i en fil i punkten Bokslut eller budget. Ange i detta fall vid andra bilagor att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;.<br />\r\n<br />\r\n<strong>Bilagor som tidigare l&auml;mnats in till Helsingfors stad</strong><br />\r\nOm de erforderliga bilagorna redan har l&auml;mnats in som bilaga till en annan ans&ouml;kan om underst&ouml;d till Helsingfors stad, beh&ouml;ver samma bilagor inte l&auml;mnas in igen. Samfundets fastst&auml;llda bokslut, verksamhetsber&auml;ttelse, verksamhetsplan och budget f&aring;r inte vara olika i bilagor till de olika ans&ouml;kningarna. Ange i detta fall vid de inl&auml;mnade bilagorna att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
+    '#markup': "Alla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan om underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas, meddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Obligatoriska bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs meritf&ouml;rteckningar f&ouml;r arbetsgruppens medlemmar n&auml;r det g&auml;ller projekt f&ouml;r yrkesm&auml;ssiga konstut&ouml;vare.<br />\r\n<br />\r\nF&ouml;r ny s&ouml;kande eller om bankkontaktuppgifterna har &auml;ndrats beh&ouml;vs &auml;ven kontoutdrag eller motsvarande dokument som anger kontoinnehavarens namn och kontonummer i den s&ouml;kandes egna uppgifter.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor</strong><br />\r\nDu kan bifoga flera meritf&ouml;rteckningar f&ouml;r arbetsgruppens medlemmar som enskilda bilagor genom att l&auml;gga till dem under rubriken &Ouml;vriga bilagor. Om du vill kan du ocks&aring; l&auml;mna in flera bilagor i en fil."
   notification_attachments:
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Innehållet i bilagorna kan inte granskas i efterhand</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Observera att du inte kan öppna bilagorna efter att du har bifogat dem blanketten. Du ser bara bilagans filnamn.</p>\r\n\r\n<p>Även om du inte kan granska innehållet i bilagorna i efterhand skickas bilagorna som bifogats blanketten med övriga uppgifter till personen som behandlar ansökan om understöd.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
-  vahvistettu_tilinpaatos:
-    '#title': 'Fastställt bokslut (för den föregående avslutade räkenskapsperioden)'
-    '#help': "Bokslutet ska inneh&aring;lla minst resultatr&auml;kningen och balansr&auml;kningen. Samfundet ska till denna punkt l&auml;gga till bokslutet som godk&auml;nts och undertecknats vid samfundets medlemsm&ouml;te.<br />\r\nSamfundets r&auml;kenskapsperiod kan vara ett kalender&aring;r eller en annan period. Vad g&auml;ller samfund anges det i deras egna stadgar vad samfundets r&auml;kenskapsperiod &auml;r."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vahvistettu_toimintakertomus:
-    '#title': 'Fastställd verksamhetsberättelse (för den föregående avslutade räkenskapsperioden)'
-    '#help': "Samfundet ska till denna punkt bifoga verksamhetsber&auml;ttelsen som godk&auml;nts och undertecknats vid samfundets medlemsm&ouml;te.<br />\r\nOm verksamhetsber&auml;ttelsen ing&aring;r i bokslutet och du redan har bifogat den blanketten, beh&ouml;ver den inte bifogas separat. Ange i detta fall vid verksamhetsber&auml;ttelsen att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vahvistettu_tilin_tai_toiminnantarkastuskertomus:
-    '#title': 'Fastställd revisionsberättelse (för det föregående avslutade räkenskapsåret)'
-    '#help': "Bifoga den undertecknade revisionsber&auml;ttelsen f&ouml;r samfundets senaste avslutade r&auml;kenskapsperiod h&auml;r.<br />\r\nOm den undertecknade revisionsber&auml;ttelsen ing&aring;r i samfundets bokslut och du redan bifogat den till blanketten i samband med bokslutet, ange &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo; h&auml;r."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vuosikokouksen_poytakirja:
-    '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  toimintasuunnitelma:
-    '#title': 'Verksamhetsplan (för det år du ansöker om understödet)'
-    '#help': 'Bifoga verksamhetsplanen f&ouml;r hela f&ouml;r samfundet h&auml;r.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  talousarvio:
-    '#title': 'Budget (för det år du ansöker om understödet)'
-    '#help': 'Budget (f&ouml;r det &aring;r du ans&ouml;ker om underst&ouml;det)'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
   extra_info:
     '#title': 'Ytterligare information om bilagorna'
     '#counter_maximum_message': 'Max 5000 tecken.'
@@ -229,6 +110,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
 settings:
   preview_label: '5. Bekräfta, förhandsgranska och skicka'
   preview_title: 'Bekräfta, förhandsgranska och skicka'

--- a/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
@@ -1,0 +1,104 @@
+elements: |
+  contact_markup:
+    '#markup': 'Ilmoita t&auml;ss&auml; sellainen yhteis&ouml;n s&auml;hk&ouml;postiosoite, jota luetaan aktiivisesti. S&auml;hk&ouml;postiin l&auml;hetet&auml;&auml;n avustushakemukseen liittyvi&auml; yhteydenottoja esim. lis&auml;selvitys- ja t&auml;ydennyspyynt&ouml;j&auml;.'
+  email:
+    '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyv&auml;t viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+  community_address:
+    '#description': 'Valitse osoite, osoitteita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
+  bank_account:
+    '#description': 'Valitse tilinumero, tilinumeroita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
+    '#account_number__title': ''
+    '#account_number_owner_name__title': ''
+    '#account_number_ssn__title': ''
+  community_officials:
+    '#description': 'Valitse toiminnasta vastaavat henkil&ouml;t, henki&ouml;it&auml; yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa henkil&ouml;it&auml; tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n henkil&ouml;iden tietoja omiin tietoihin.'
+  info_subvention_summa:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Yli 5000€ avustusten syöttäminen avaa joukon lisäkysymyksiä.</span></div>\r\n</div>\r\n</div>\r\n"
+  info_monivuotinen:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  info_muut_samaan_tarkoitukseen_myonnetty:
+    '#text': "<p>Ilmoita tähän ainoastaan avustukset, jotka on myönnetty muualta kuin Helsingin kaupungilta kuluvana ja kahtena edellisenä verovuotena.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  myonnetty_avustus:
+    '#element':
+      issuer_name:
+        '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
+      purpose:
+        '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
+  jasenmaara_fieldset:
+    '#help': 'Jos yhteis&ouml;ll&auml; on j&auml;seni&auml;, merkitse ne t&auml;h&auml;n.'
+  henkilosto:
+    '#help': 'Henkil&ouml;st&ouml;&ouml;n voi sis&auml;llytt&auml;&auml; muitakin kuin palkattuja ty&ouml;ntekij&ouml;it&auml;, mm. palkkioilla tai muilla korvauksilla ty&ouml;skentelevi&auml; tai ostopalveluna ostettavaa ty&ouml;t&auml;. Kokoaikaiset ty&ouml;ntekij&auml;t voivat sis&auml;lt&auml;&auml; my&ouml;s m&auml;&auml;r&auml;aikaisia ty&ouml;ntekij&ouml;it&auml;, jos n&auml;m&auml; ty&ouml;skentelev&auml;t t&auml;ysp&auml;iv&auml;isesti. Henkil&ouml;ty&ouml;vuosi kuvaa kokoaikaiseksi muutetun henkil&ouml;n ty&ouml;panosta. Esimerkiksi 6kk kokop&auml;iv&auml;isesti ty&ouml;skentelev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,5 henkil&ouml;ty&ouml;vuotta. Vastaavasti koko vuoden osa-aikaisesti 30% ty&ouml;m&auml;&auml;r&auml;&auml; tekev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,3 henkil&ouml;ty&ouml;vuotta. Jos toimitatte tietoja henkil&ouml;ty&ouml;vuosistanne valtiolle tai muun tahon tilastointiin, niin k&auml;ytt&auml;k&auml;&auml; t&auml;ss&auml; samaa laskentatapaa jos mahdollista.'
+  info_taiteellisen_toiminnan_tilat:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  arvio_maarasta_markup:
+    '#markup': "<h3>Arvio m&auml;&auml;rist&auml;</h3>\r\n\r\n<p>Sy&ouml;t&auml; tiedot koskien omaa toimintaa vuonna, jolle avustusta haetaan. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.</p>"
+  ensi_iltojen_maara_helsingissa:
+    '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimm&auml;ist&auml; esityst&auml;. T&auml;yt&auml; t&auml;h&auml;n ne ensi-illat, jotka tapahtuvat Helsingiss&auml;.'
+  festivaali_paivanmaarat_maarasta_markup:
+    '#markup': '<h3>Tapahtuman tai festivaalin p&auml;iv&auml;m&auml;&auml;r&auml;t</h3>'
+  toimintamuodot_markup:
+    '#markup': "<h3>Muut keskeiset toimintamuodot</h3>\r\n\r\n<p>Jos toiminta sis&auml;lt&auml;&auml; yleis&ouml;lle avointen esitysten, n&auml;yttelyiden ja ty&ouml;pajojen tai muiden osallistavien toimintamuotojen lis&auml;ksi muita keskeisi&auml; muotoja, listaa ne t&auml;h&auml;n.</p>"
+  toteutuneet_markup:
+    '#markup': "<h3>Toteutuneet m&auml;&auml;r&auml;t</h3>\r\n\r\n<p>Sy&ouml;t&auml; tiedot koskien omaa toimintaa edellisen&auml; p&auml;&auml;ttyneen&auml; vuonna. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.</p>"
+  maara_helsingissa_toteutuneet:
+    '#help': '&Auml;l&auml; t&auml;yt&auml; samoja k&auml;vij&ouml;it&auml; kahteen kertaan, esim. n&auml;yttelytilassa j&auml;rjestetty&auml; ty&ouml;pajaa sek&auml; n&auml;yttelyihin ett&auml; ty&ouml;pajoihin.'
+  maara_kaikkiaan_toteutuneet:
+    '#help': 'M&auml;&auml;r&auml; kaikkiaan -kohdassa t&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
+  toeutuneet_ensi_iltojen_maara_helsingissa:
+    '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimm&auml;ist&auml; esityst&auml;. T&auml;yt&auml; t&auml;h&auml;n ne ensi-illat, jotka tapahtuvat Helsingiss&auml;.'
+  arvio_maarasta_toteutuneet_markup:
+    '#markup': '<h3>Helsingiss&auml; j&auml;rjestett&auml;v&auml; yleis&ouml;lle avoin toiminta toteutettiin</h3>'
+  toiminta_taiteelliset_lahtokohdat:
+    '#help': 'Voit nostaa my&ouml;s esiin esimerkisksi keskeisi&auml; palkintoja tai muita noteerauksia.'
+  attachments_info:
+    '#markup': "Alla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan om underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas, meddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Obligatoriska bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs styrkta bilagor fr&aring;n det f&ouml;reg&aring;ende r&auml;kenskaps&aring;ret som samfundet har godk&auml;nt och undertecknat vid sitt m&ouml;te samt bilagor f&ouml;r det verksamhets&aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks. Bilagorna fr&aring;n det f&ouml;reg&aring;ende r&auml;kenskaps&aring;ret &auml;r: bokslut, verksamhetsber&auml;ttelse och revisionsber&auml;ttelse. Bilagorna f&ouml;r det &aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks &auml;r: budget och verksamhetsplan.<br />\r\n<br />\r\nF&ouml;r ny s&ouml;kande eller om bankkontaktuppgifterna har &auml;ndrats beh&ouml;vs &auml;ven kontoutdrag eller motsvarande dokument som anger kontoinnehavarens namn och kontonummer i den s&ouml;kandes egna uppgifter. F&ouml;r ny s&ouml;kande eller om stadgarna har &auml;ndrats sedan f&ouml;reg&aring;ende ans&ouml;kan beh&ouml;vs &auml;ven f&ouml;reningens stadgar.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor i en fil</strong><br />\r\nOm du vill kan du l&auml;mna in flera bilagor i en fil i punkten Bokslut eller budget. Ange i detta fall vid andra bilagor att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;.<br />\r\n<br />\r\n<strong>Bilagor som tidigare l&auml;mnats in till Helsingfors stad</strong><br />\r\nOm de obligatoriska bilagorna redan har l&auml;mnats in som bilagor till en annan ans&ouml;kan om underst&ouml;d till Helsingfors stad, beh&ouml;ver samma bilagor inte l&auml;mnas in igen. Ange i detta fall vid de inl&auml;mnade bilagorna att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;. Men samfundets fastst&auml;llda bokslut, verksamhetsber&auml;ttelse, verksamhetsplan och budget f&aring;r inte vara sinsemellan olika i bilagor till de olika ans&ouml;kningarna."
+  notification_attachments:
+    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>\r\n\r\n<p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
+  yhteison_saannot:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  vahvistettu_tilinpaatos_edelliselta_paattyneelta_tilikaudelta_:
+    '#help': "Tilinp&auml;&auml;t&ouml;ksen t&auml;ytyy sis&auml;lt&auml;&auml; v&auml;hint&auml;&auml;n tuloslaskelma ja tase. Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun ja allekirjoitetun tilinp&auml;&auml;t&ouml;ksen.<br />\r\n<br />\r\nYhteis&ouml;n tilikausi voi olla kalenterivuosi tai jokin muu kausi. Yhdistysten kohdalla niiden omissa s&auml;&auml;nn&ouml;iss&auml; lukee, mik&auml; on yhdistyksen tilikausi."
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  vahvistettu_toimintakertomus_edelliselta_paattyneelta_tilikaudel:
+    '#help': "Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun toimintakertomuksen.<br />\r\nJos toimintakertomus on osana tilinp&auml;&auml;t&ouml;st&auml; ja liititte sen jo tilinp&auml;&auml;t&ouml;ksen mukana lomakkeelle, sit&auml; ei tarvitse liitt&auml;&auml; t&auml;h&auml;n erikseen. Valitse t&auml;llaisessa tilanteessa toimintakertomuksen kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;."
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  vahvistettu_tilin_tai_toiminnantarkastuskertomus_edelliselta_paa:
+    '#help': "&quot;Liit&auml; t&auml;h&auml;n allekirjoitettu tilin- tai toiminnantarkastuskertomus yhteis&ouml;n edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilikaudelta.<br />\r\nJos allekirjoitettu tilin- tai toiminnantarkastuskertomus on osa yhteis&ouml;nne tilinp&auml;&auml;t&ouml;st&auml; ja liitit sen jo lomakkeelle tilinp&auml;&auml;t&ouml;ksen kohdalla, valitse t&auml;ss&auml; kohdassa &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.&quot;"
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  toimintasuunnitelma_sille_vuodelle_jolle_haet_avustusta_monivuot:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  talousarvio_sille_vuodelle_jolle_haet_avustusta_monivuotisissa_k:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
+  muu_liite:
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -3,30 +3,8 @@ description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'
-  yhteiso_jolle_haetaan_avustusta:
-    '#title': 'Samfund för vilket understödet ansöks'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
-  community_official_name:
-    '#title': 'Samfundets namn'
-  company_number:
-    '#title': FO-nummer
-  home:
-    '#title': Hemort
-  registration_date:
-    '#title': Registreringsdatum
-  perustamisvuosi:
-    '#title': Stiftelseår
-  founding_year:
-    '#title': Stiftelseår
-  yhteison_lyhenne:
-    '#title': 'Samfundets förkortning'
-  community_official_name_short:
-    '#title': 'Samfundets förkortning'
-  verkkosivut:
-    '#title': Webbsidor
-  homepage:
-    '#title': Webbsidor
   contact_person_email_section:
     '#title': E-post
   contact_markup:
@@ -44,17 +22,25 @@ elements: |
     '#title': Adress
   community_address:
     '#title': Adress
+    '#description': 'Valitse osoite, osoitteita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
     '#community_address_select__title': 'Välj en adress'
   tilinumero:
     '#title': Kontonummer
   bank_account:
     '#title': Kontonummer
+    '#description': 'Valitse tilinumero, tilinumeroita yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
     '#account_number_select__title': 'Välj ett kontonummer'
     '#account_number__title': ''
+    '#account_number_owner_name__title': ''
+    '#account_number_ssn__title': ''
   toiminnasta_vastaavat_henkilot:
     '#title': 'Personer som ansvarar för verksamheten'
   community_officials:
     '#title': 'Personer som ansvarar för samfundet'
+    '#description': 'Valitse toiminnasta vastaavat henkil&ouml;t, henki&ouml;it&auml; yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa henkil&ouml;it&auml; tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n henkil&ouml;iden tietoja omiin tietoihin.'
   2_avustustiedot:
     '#title': '2. Uppgifter om understödet'
   avustuksen_tiedot:
@@ -65,21 +51,20 @@ elements: |
     '#title': Understödskategorier
   subventions:
     '#title': Understöd
-  kayttotarkoitus:
-    '#title': Användningsändamål
-  compensation_purpose:
-    '#title': 'En kort beskrivning av användningsändamålet för det/de understöd som ansöks'
-    '#help': 'Ange f&ouml;r vilket &auml;ndam&aring;l underst&ouml;det ans&ouml;ks och vid behov specificera de olika &auml;ndam&aring;len. Ange ocks&aring; vad underst&ouml;det &auml;r avsett f&ouml;r och vilka m&aring;l som &auml;r relaterade till den underst&ouml;dda verksamheten.'
-    '#counter_maximum_message': '%d/5000 tecken kvar'
+  info_kyseessa_on_monivuotinen_avustus:
+    '#text': "<p>&nbsp;</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+  vuodet_joille_monivuotista_avustusta_on_haettu_tai_myonetty:
+    '#help': 'T&auml;yt&auml; vuodet vain t&auml;st&auml; eteenp&auml;in haettavan avustuskauden osalta. &Auml;l&auml; kirjaa saman tai aikaisemman avustuskauden aikaisempia vuosia.'
+  hankkeen_nimi:
+    '#help': 'Valitse hankkeelle nimi, joka voidaan julkaista p&auml;&auml;t&ouml;ksen yhteydess&auml;.'
+  kyseessa_on_festivaali_tai_tapahtuma:
+    '#help': 'T&auml;ss&auml; tarkoitetaan festivaalia tai tapahtumaa, joka tapahtuu tiiviin ajanjakson sis&auml;ll&auml; ja on ohjelmaltaan ja kestoltaan laajempi kuin yksitt&auml;inen konsertti, esitys tms. Festivaali tai tapahtuma sis&auml;lt&auml;&auml; useampia eri ohjelmasis&auml;lt&ouml;j&auml;, esim. esityksi&auml;, joiden v&auml;liss&auml; yleis&ouml; voi my&ouml;s vaihtua. Esimerkiksi kaupunginosatapahtumat. Ei esimerkiksi esityssarjat. Festivaali tai tapahtuma voi olla toistuva tai kertaluonteinen.'
   muut_samaan_tarkoitukseen_myonnetyt_avustukset:
     '#title': 'Övriga understöd som beviljats för samma ändamål'
   info_muut_samaan_tarkoitukseen_myonnetty:
     '#text': "<p>Ange här endast de understöd som beviljats från annanstans än Helsingfors stad under det innevarande beskattningsåret eller de föregående två beskattningsåren.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
   olemme_saaneet_muita_avustuksia:
     '#title': 'Vi har fått andra understöd'
-    '#options':
-      Kyllä: Ja
-      Ei: Nej
   myonnetty_avustus:
     '#multiple__add_more_button_label': 'Lägg till understöd som beviljats'
     '#element':
@@ -88,82 +73,29 @@ elements: |
       purpose:
         '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
         '#counter_maximum_message': '%d/1000 tecken kvar'
-  muut_samaan_tarkoitukseen_haetut_avustukset:
-    '#title': 'Övriga understöd som ansökts för samma ändamål'
-  info_muut_samaan_tarkoitukseen_haettu:
-    '#text': "<p>Ange här endast de understöd som har ansökts från annanstans än Helsingfors stad, men beslut har ännu inte fattats.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta:
-    '#title': 'Vi har ansökt om understöd från annanstans än Helsingfors stad.'
-    '#options':
-      Kyllä: Ja
-      Ei: Nej
-  haettu_avustus_tieto:
-    '#title': 'Lägg till nytt understöd som ansökts'
-    '#multiple__add_more_button_label': 'Lägg till nytt understöd som ansökts'
-    '#element':
-      issuer_name:
-        '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
-      purpose:
-        '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
-        '#counter_maximum_message': '%d/1000 tecken kvar'
-  kaupungilta_saadut_lainat_ja_takaukset:
-    '#title': 'Lån och borgen som fåtts från staden'
-  kaupungilta_saadut_1:
-    '#markup': 'G&auml;llande de l&aring;n som f&aring;tts fr&aring;n staden ska man ange det ursprungliga l&aring;nebeloppet, det &aring;terst&aring;ende l&aring;nebeloppet, l&aring;netiden, r&auml;ntesatsen och &auml;ndam&aring;let f&ouml;r vilket l&aring;net beviljades. Om borgen anges deras penningv&auml;rde och &auml;ndam&aring;l.'
-  benefits_loans:
-    '#title': 'Beskrivning av lån och borgen'
-    '#counter_maximum_message': '%d/500 tecken kvar'
-  kaupungilta_saatu_tiloihin_liittyva_tuki:
-    '#title': 'Understöd för lokaler som fåtts från staden'
-  tilate_1:
-    '#markup': 'Lokaler som staden har gett gratis eller hyrt till den s&ouml;kande (lokalens namn eller adress, hyresbelopp &euro;/m&aring;nad)'
-  benefits_premises:
-    '#title': 'Beskrivning av understödet för lokalerna'
-    '#counter_maximum_message': '%d/500 tecken kvar'
-  edellisen_avustuksen_kayttoselvitys:
-    '#title': 'Redovisning om det tidigare understödet'
-  compensation_boolean_info:
-    '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  compensation_boolean:
-    '#title': 'Redovisning om understödet som jag fick under det föregående året'
-  markup:
-    '#markup': 'Ge en redovisning om underst&ouml;det som f&aring;tts fr&aring;n Helsingfors stad. Redovisningen g&ouml;rs om underst&ouml;det som beviljats f&ouml;r den senaste avslutade r&auml;kenskapsperioden. Redovisning g&ouml;rs inte om den innevarande r&auml;kenskapsperioden. Redovisningen kr&auml;vs f&ouml;r att f&aring; ett nytt underst&ouml;d. Om en redovisning inte g&ouml;rs, kommer ett underst&ouml;d inte att beviljas eller betalas ut. Det beviljade underst&ouml;det kan &aring;terkr&auml;vas om anv&auml;ndningen av det tidigare underst&ouml;det inte har redogjorts f&ouml;r p&aring; ett tillfredsst&auml;llande s&auml;tt.'
-  compensation_explanation:
-    '#title': 'Redovisning om användningen av understödet'
-    '#help': 'I redovisningen ska det kortfattat anges hur det beviljade underst&ouml;det har anv&auml;nts. Underst&ouml;dstagaren ska ordna sin bokf&ouml;ring s&aring; att anv&auml;ndningen av underst&ouml;det kan f&ouml;ljas d&auml;r. Om samfundet till exempel har f&aring;tt hyresunderst&ouml;d ska det av resultatr&auml;kningen i bokslutet framg&aring; b&aring;de int&auml;kter och utgifter vad g&auml;ller underst&ouml;det. Mer information om anv&auml;ndningen av underst&ouml;det kan ocks&aring; skrivas i en separat bilaga som kan l&auml;mnas som Redovisning-bilaga.'
-    '#counter_maximum_message': '%d/5000 tecken kvar'
   3_yhteison_tiedot:
     '#title': '3. Samfundets verksamhet'
-  business_info:
-    '#title': Verksamhetsbeskrivning
-  community_purpose:
-    '#title': Verksamhetsbeskrivning
-    '#help': 'Verksamhetsbeskrivningen redigeras i dina uppgifter.'
-  community_practices_business:
-    '#title': 'Bedriver samfundet affärsverksamhet'
-    '#options':
-      1: Ja
-      0: Nej
-  ensimmainen_otsikko:
-    '#title': Medlemsavgifter
-  fee_person:
-    '#title': 'Medlemsavgift för personmedlemmar (€/år)'
-  fee_community:
-    '#title': 'Samfundsmedlem (€/år)'
   jasenmaara:
     '#title': 'Antal medlemmar'
-  members_applicant_person_local:
-    '#title': 'Personmedlemmar från Helsingfors sammanlagt'
-    '#help': 'Hur m&aring;nga personmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande?'
+  jasenmaara_fieldset:
+    '#help': 'Jos yhteis&ouml;ll&auml; on j&auml;seni&auml;, merkitse ne t&auml;h&auml;n.'
   members_applicant_person_global:
     '#title': 'Personmedlemmar sammanlagt'
-    '#help': 'Hur m&aring;nga personmedlemmar som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande?'
-  members_applicant_community_local:
-    '#title': 'Samfundsmedlemmar från Helsingfors sammanlagt'
-    '#help': 'Hur m&aring;nga samfundsmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
+  members_applicant_person_local:
+    '#title': 'Personmedlemmar från Helsingfors sammanlagt'
   members_applicant_community_global:
     '#title': Samfundsmedlemmar
-    '#help': 'Hur m&aring;nga samfundsmedlemmar som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
+  members_applicant_community_local:
+    '#title': 'Samfundsmedlemmar från Helsingfors sammanlagt'
+  henkilosto:
+    '#help': 'Henkil&ouml;st&ouml;&ouml;n voi sis&auml;llytt&auml;&auml; muitakin kuin palkattuja ty&ouml;ntekij&ouml;it&auml;, mm. palkkioilla tai muilla korvauksilla ty&ouml;skentelevi&auml; tai ostopalveluna ostettavaa ty&ouml;t&auml;. Kokoaikaiset ty&ouml;ntekij&auml;t voivat sis&auml;lt&auml;&auml; my&ouml;s m&auml;&auml;r&auml;aikaisia ty&ouml;ntekij&ouml;it&auml;, jos n&auml;m&auml; ty&ouml;skentelev&auml;t t&auml;ysp&auml;iv&auml;isesti. Henkil&ouml;ty&ouml;vuosi kuvaa kokoaikaiseksi muutetun henkil&ouml;n ty&ouml;panosta. Esimerkiksi 6kk kokop&auml;iv&auml;isesti ty&ouml;skentelev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,5 henkil&ouml;ty&ouml;vuotta. Vastaavasti koko vuoden osa-aikaisesti 30% ty&ouml;m&auml;&auml;r&auml;&auml; tekev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,3 henkil&ouml;ty&ouml;vuotta. Kyseess&auml; on arvio, joka kuvaa suuntaa-antavasti projektiin osallistuvan henkil&ouml;st&ouml;n ty&ouml;panosta.'
+  tila:
+    '#multiple__no_items_message': 'Ei sy&ouml;tettyj&auml; tiloja. Lis&auml;&auml; tilan tiedot alta.'
+  toiminta_taiteelliset_lahtokohdat:
+    '#help': 'Voit nostaa my&ouml;s esiin esimerkisksi keskeisi&auml; palkintoja tai muita noteerauksia.'
+  talousarvio:
+    '#title': 'Budget (för det år du ansöker om understödet)'
+    '#description': 'Koskien hankkeen sit&auml; vuotta, jolle avustusta t&auml;ll&auml; hakemuksella haetaan.'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:
@@ -175,51 +107,21 @@ elements: |
   liitteet:
     '#title': Bilagor
   attachments_info:
-    '#markup': "Alla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan om underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas, meddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Erforderliga bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs styrkta bilagor fr&aring;n den f&ouml;reg&aring;ende r&auml;kenskapsperioden som samfundet har godk&auml;nt och undertecknat vid sitt m&ouml;te samt bilagor f&ouml;r det verksamhets&aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks. Bilagorna fr&aring;n den f&ouml;reg&aring;ende r&auml;kenskapsperioden &auml;r: bokslut, verksamhetsber&auml;ttelse, revisionsber&auml;ttelse och protokoll fr&aring;n &aring;rsst&auml;mman. Bilagorna f&ouml;r det &aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks &auml;r: budget och verksamhetsplan.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor i en fil</strong><br />\r\nOm du vill kan du l&auml;mna in flera bilagor i en fil i punkten Bokslut eller budget. Ange i detta fall vid andra bilagor att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;.<br />\r\n<br />\r\n<strong>Bilagor som tidigare l&auml;mnats in till Helsingfors stad</strong><br />\r\nOm de erforderliga bilagorna redan har l&auml;mnats in som bilaga till en annan ans&ouml;kan om underst&ouml;d till Helsingfors stad, beh&ouml;ver samma bilagor inte l&auml;mnas in igen. Samfundets fastst&auml;llda bokslut, verksamhetsber&auml;ttelse, verksamhetsplan och budget f&aring;r inte vara olika i bilagor till de olika ans&ouml;kningarna. Ange i detta fall vid de inl&auml;mnade bilagorna att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
+    '#markup': "Alla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan om underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas, meddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Obligatoriska bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs projektplan f&ouml;r den tid som ans&ouml;kan g&auml;ller och budget f&ouml;r den tid som ans&ouml;kan g&auml;ller.<br />\r\n<br />\r\nF&ouml;r ny s&ouml;kande eller om bankkontaktuppgifterna har &auml;ndrats beh&ouml;vs &auml;ven kontoutdrag eller motsvarande dokument som anger kontoinnehavarens namn och kontonummer i den s&ouml;kandes egna uppgifter.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor i en fil</strong><br />\r\nOm du vill kan du l&auml;mna in flera bilagor i en fil. Ange i detta fall vid andra bilagor att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
   notification_attachments:
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Innehållet i bilagorna kan inte granskas i efterhand</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Observera att du inte kan öppna bilagorna efter att du har bifogat dem blanketten. Du ser bara bilagans filnamn.</p>\r\n\r\n<p>Även om du inte kan granska innehållet i bilagorna i efterhand skickas bilagorna som bifogats blanketten med övriga uppgifter till personen som behandlar ansökan om understöd.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
-  vahvistettu_tilinpaatos:
-    '#title': 'Fastställt bokslut (för den föregående avslutade räkenskapsperioden)'
-    '#help': "Bokslutet ska inneh&aring;lla minst resultatr&auml;kningen och balansr&auml;kningen. Samfundet ska till denna punkt l&auml;gga till bokslutet som godk&auml;nts och undertecknats vid samfundets medlemsm&ouml;te.<br />\r\nSamfundets r&auml;kenskapsperiod kan vara ett kalender&aring;r eller en annan period. Vad g&auml;ller samfund anges det i deras egna stadgar vad samfundets r&auml;kenskapsperiod &auml;r."
+  projektisuunnitelma_liite:
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
-  vahvistettu_toimintakertomus:
-    '#title': 'Fastställd verksamhetsberättelse (för den föregående avslutade räkenskapsperioden)'
-    '#help': "Samfundet ska till denna punkt bifoga verksamhetsber&auml;ttelsen som godk&auml;nts och undertecknats vid samfundets medlemsm&ouml;te.<br />\r\nOm verksamhetsber&auml;ttelsen ing&aring;r i bokslutet och du redan har bifogat den blanketten, beh&ouml;ver den inte bifogas separat. Ange i detta fall vid verksamhetsber&auml;ttelsen att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
+    '#isAttachmentNew__title': ''
+  talousarvio_liite:
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
-  vahvistettu_tilin_tai_toiminnantarkastuskertomus:
-    '#title': 'Fastställd revisionsberättelse (för det föregående avslutade räkenskapsåret)'
-    '#help': "Bifoga den undertecknade revisionsber&auml;ttelsen f&ouml;r samfundets senaste avslutade r&auml;kenskapsperiod h&auml;r.<br />\r\nOm den undertecknade revisionsber&auml;ttelsen ing&aring;r i samfundets bokslut och du redan bifogat den till blanketten i samband med bokslutet, ange &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo; h&auml;r."
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  vuosikokouksen_poytakirja:
-    '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  toimintasuunnitelma:
-    '#title': 'Verksamhetsplan (för det år du ansöker om understödet)'
-    '#help': 'Bifoga verksamhetsplanen f&ouml;r hela f&ouml;r samfundet h&auml;r.'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
-  talousarvio:
-    '#title': 'Budget (för det år du ansöker om understödet)'
-    '#help': 'Budget (f&ouml;r det &aring;r du ans&ouml;ker om underst&ouml;det)'
-    '#attachmentName__title': ''
-    '#fileStatus__title': ''
-    '#fileType__title': ''
-    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   extra_info:
     '#title': 'Ytterligare information om bilagorna'
     '#counter_maximum_message': 'Max 5000 tecken.'
@@ -229,6 +131,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
 settings:
   preview_label: '5. Bekräfta, förhandsgranska och skicka'
   preview_title: 'Bekräfta, förhandsgranska och skicka'

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -132,7 +132,7 @@ elements: |-
           - grants-profile--imported-section
       prh_markup:
         '#type': webform_markup
-        '#markup': 'Tämä haetaan automaattisesti muualta. Komponentti tulee jossain vaiheessa (tm)'
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
       hakijan_tiedot:
         '#type': applicant_info
         '#title': 'Hakijan tiedot'
@@ -1003,7 +1003,7 @@ elements: |-
           <strong>Vaaditut liitteet</strong><br />
           Avustushakemuksen k&auml;sittely&auml; varten tarvitaan ty&ouml;ryhm&auml;n j&auml;senten ansioluettelot, kun kyseess&auml; on taiteen ammattilaisten hanke.&nbsp;<br />
           <br />
-          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero.<br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan&nbsp;hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero.<br />
           <br />
           <strong>Usean liitteen toimittaminen</strong><br />
           Voit toimittaa useampia ty&ouml;ryhm&auml;n j&auml;senten ansioluetteloita erillisin&auml; tiedostoina liitt&auml;m&auml;ll&auml; ne Muu liite -kohtaan. Voit halutessasi my&ouml;s toimittaa useampia liitteit&auml; yhten&auml; tiedostona.

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -131,7 +131,7 @@ elements: |-
           - grants-profile--imported-section
       prh_markup:
         '#type': webform_markup
-        '#markup': 'Tämä haetaan automaattisesti muualta. Komponentti tulee jossain vaiheessa (tm)'
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
       hakijan_tiedot:
         '#type': applicant_info
         '#title': 'Hakijan tiedot'
@@ -711,8 +711,7 @@ elements: |-
           '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimmäistä esitystä. Täytä tähän ne ensi-illat, jotka tapahtuvat Helsingissä.'
       festivaali_paivanmaarat_maarasta_markup:
         '#type': webform_markup
-        '#markup': |-
-          <h3>Tapahtuman tai festivaalin päivämäärät</h3>
+        '#markup': '<h3>Tapahtuman tai festivaalin päivämäärät</h3>'
       festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
         '#type': textarea
         '#attributes':
@@ -839,10 +838,9 @@ elements: |-
           '#attributes':
             class:
               - webform--small
-      arvio_maarasta_markup:
+      arvio_maarasta_toteutuneet_markup:
         '#type': webform_markup
-        '#markup': |-
-          <h3>Helsingissä järjestettävä yleisölle avoin toiminta toteutettiin</h3>
+        '#markup': '<h3>Helsingissä järjestettävä yleisölle avoin toiminta toteutettiin</h3>'
       toteutuneet_tila:
         '#type': premises_composite
         '#title': Tila
@@ -1265,33 +1263,32 @@ elements: |-
       attachments_info:
         '#type': webform_markup
         '#markup': |-
-          Avustushakemuksen käsittelyä varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hylätä, jos liitteitä ei ole toimitettu. Mikäli joku liitteistä puuttuu, kerro siitä hakemuksen Lisäselvitys liitteistä -kohdassa.
-          <br><br>
-          <strong>Vaaditut liitteet</strong><br>
-          Avustushakemuksen käsittelyä varten tarvitaan vahvistettuja, yhteisön kokouksessaan hyväksymiä ja allekirjoittamia, liitteitä edelliseltä päättyneeltä tilivuodelta sekä liitteitä sille toimintavuodelle, jolle avustusta haetaan. Edellistä tilivuotta koskevat liitteet ovat: tilinpäätös, toimintakertomus ja tilin- tai toiminnantarkastuskertomus. Liitteet vuodelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.
-          <br><br>
-          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan myös tiliote tai vastaava asiakirja, josta selviää tilinomistajan nimi ja tilinumero. Uusilta hakijoilta ja tapauksissa, joissa säännöt ovat muuttuneet edellisen hakemuksen jälkeen, tarvitaan myös yhdistyksen säännöt.
-          <br><br>
-          <strong>Usean liitteen toimittaminen yhtenä tiedostona</strong><br>
-          Voit halutessasi toimittaa useampia liitteitä yhtenä tiedostona Tilinpäätös tai talousarvio -liitekohdassa. Merkitse tällöin muiden liiteotsikoiden kohdalla ”Liite on toimitettu yhtenä tiedostona tai toisen hakemuksen yhteydessä”.
-          <br><br>
-          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong><br>
-          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteenä, samoja liitteitä ei tarvitse toimittaa uudelleen. Merkitse tällöin toimitettujen liitteiden kohdalla ”Liite on toimitettu yhtenä tiedostona tai toisen hakemuksen yhteydessä”. Yhteisön vahvistettu tilinpäätös, toimintakertomus, toimintasuunnitelma ja talousarvio eivät voi olla erilaisia eri hakemusten liitteenä.
-          <br><br>
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet</strong><br />
+          Avustushakemuksen k&auml;sittely&auml; varten tarvitaan vahvistettuja, yhteis&ouml;n kokouksessaan hyv&auml;ksymi&auml; ja allekirjoittamia, liitteit&auml; edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilivuodelta sek&auml; liitteit&auml; sille toimintavuodelle, jolle avustusta haetaan. Edellist&auml; tilivuotta koskevat liitteet ovat: tilinp&auml;&auml;t&ouml;s, toimintakertomus ja tilin- tai toiminnantarkastuskertomus. Liitteet vuodelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.<br />
+          <br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan&nbsp;hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero. Uusilta hakijoilta ja tapauksissa, joissa s&auml;&auml;nn&ouml;t ovat muuttuneet edellisen hakemuksen j&auml;lkeen, tarvitaan my&ouml;s yhdistyksen s&auml;&auml;nn&ouml;t.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
+          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
+          <br />
+          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong><br />
+          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;.<br />
+          &nbsp;
           <h3>Monivuotiset toiminta-avustukset</h3>
-          <br><br>
-          Avustushakemuksen käsittelyä varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hylätä, jos liitteitä ei ole toimitettu. Mikäli joku liitteistä puuttuu, kerro siitä hakemuksen Lisäselvitys liitteistä -kohdassa.
-          <br><br>
-          <strong>Vaaditut liittee</strong>t<br>
-          Avustushakemuksen käsittelyä varten tarvitaan vahvistettuja, yhteisön kokouksessaan hyväksymiä ja allekirjoittamia, liitteitä edelliseltä päättyneeltä tilivuodelta sekä liitteitä sille toimintakaudelle, jolle avustusta haetaan. Edellistä tilivuotta koskevat liitteet ovat: tilinpäätös, toimintakertomus ja tilin- tai toiminnantarkastuskertomus. Liitteet kaudelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.
-          <br><br>
-          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan myös tiliote tai vastaava asiakirja, josta selviää tilinomistajan nimi ja tilinumero. Uusilta hakijoilta ja tapauksissa, joissa säännöt ovat muuttuneet edellisen hakemuksen jälkeen, tarvitaan myös yhdistyksen säännöt.
-          <br><br>
-          <strong>Usean liitteen toimittaminen yhtenä tiedostona</strong>
-          Voit halutessasi toimittaa useampia liitteitä yhtenä tiedostona Tilinpäätös tai talousarvio -liitekohdassa. Merkitse tällöin muiden liiteotsikoiden kohdalla ”Liite on toimitettu yhtenä tiedostona tai toisen hakemuksen yhteydessä”.
-          <br><br>
-          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong>
-          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteenä, samoja liitteitä ei tarvitse toimittaa uudelleen. Merkitse tällöin toimitettujen liitteiden kohdalla ”Liite on toimitettu yhtenä tiedostona tai toisen hakemuksen yhteydessä”. Yhteisön vahvistettu tilinpäätös, toimintakertomus, toimintasuunnitelma ja talousarvio eivät voi olla erilaisia eri hakemusten liitteenä.
+          <br />
+          <br />
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liittee</strong>t<br />
+          Avustushakemuksen k&auml;sittely&auml; varten tarvitaan vahvistettuja, yhteis&ouml;n kokouksessaan hyv&auml;ksymi&auml; ja allekirjoittamia, liitteit&auml; edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilivuodelta sek&auml; liitteit&auml; sille toimintakaudelle, jolle avustusta haetaan. Edellist&auml; tilivuotta koskevat liitteet ovat: tilinp&auml;&auml;t&ouml;s, toimintakertomus ja tilin- tai toiminnantarkastuskertomus. Liitteet kaudelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.<br />
+          <br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero. Uusilta hakijoilta ja tapauksissa, joissa s&auml;&auml;nn&ouml;t ovat muuttuneet edellisen hakemuksen j&auml;lkeen, tarvitaan my&ouml;s yhdistyksen s&auml;&auml;nn&ouml;t.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong> Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
+          <br />
+          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong> Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;.
       notification_attachments:
         '#type': processed_text
         '#text': |

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -55,7 +55,7 @@ elements: |-
           - grants-profile--imported-section
       prh_markup:
         '#type': webform_markup
-        '#markup': 'Tämä haetaan automaattisesti muualta. Komponentti tulee jossain vaiheessa (tm)'
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
       hakijan_tiedot:
         '#type': applicant_info
         '#title': 'Hakijan tiedot'
@@ -746,7 +746,7 @@ elements: |-
 
           <div class="ewa-rteLine">sek&auml; budjetti haetulle ajanjaksolle.&nbsp;</div>
           <br />
-          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero.<br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero.<br />
           <br />
           <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
           Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.


### PR DESCRIPTION
# [AU-1103](https://helsinkisolutionoffice.atlassian.net/browse/AU-1103), [AU-1104](https://helsinkisolutionoffice.atlassian.net/browse/AU-1104)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change text in hakijan tiedot component
* Add new liite translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1104-hakijan-tiedot`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards


[AU-1103]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1104]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ