### PR TITLE
fix: AU-1042: Add translations

### DIFF
--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -7,26 +7,6 @@ elements: |
     '#title': 'Samfund för vilket understödet ansöks'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
-  community_official_name:
-    '#title': 'Samfundets namn'
-  company_number:
-    '#title': FO-nummer
-  home:
-    '#title': Hemort
-  registration_date:
-    '#title': Registreringsdatum
-  perustamisvuosi:
-    '#title': Stiftelseår
-  founding_year:
-    '#title': Stiftelseår
-  yhteison_lyhenne:
-    '#title': 'Samfundets förkortning'
-  community_official_name_short:
-    '#title': 'Samfundets förkortning'
-  verkkosivut:
-    '#title': Webbsidor
-  homepage:
-    '#title': Webbsidor
   contact_person_email_section:
     '#title': E-post
   contact_markup:
@@ -51,10 +31,15 @@ elements: |
     '#title': Kontonummer
     '#account_number_select__title': 'Välj ett kontonummer'
     '#account_number__title': ''
+    '#account_number_owner_name__title': ''
+    '#account_number_ssn__title': ''
   toiminnasta_vastaavat_henkilot:
     '#title': 'Personer som ansvarar för verksamheten'
   community_officials:
     '#title': 'Personer som ansvarar för samfundet'
+    '#multiple__no_items_message': 'Inga personer ansvariga f&ouml;r verksamheten. L&auml;gg till en ny person nedan.'
+    '#multiple__add_more_button_label': 'Lägg till en person'
+    '#community_officials_select__title': ' Välj motsvarande person'
   2_avustustiedot:
     '#title': '2. Uppgifter om understödet'
   avustuksen_tiedot:
@@ -74,32 +59,11 @@ elements: |
   muut_samaan_tarkoitukseen_myonnetyt_avustukset:
     '#title': 'Övriga understöd som beviljats för samma ändamål'
   info_muut_samaan_tarkoitukseen_myonnetty:
-    '#text': "<p>Ange här endast de understöd som beviljats från annanstans än Helsingfors stad under det innevarande beskattningsåret eller de föregående två beskattningsåren.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
+    '#text': "<p>Ange här endast de understöd som beviljats från annanstans än Helsingfors stad under det innevarande beskattningsåret eller de föregående två beskattningsåren.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\">Ett jakande svar öppnar ytterligare en fråga</div>\r\n</div>\r\n</div>\r\n"
   olemme_saaneet_muita_avustuksia:
     '#title': 'Vi har fått andra understöd'
-    '#options':
-      Kyllä: Ja
-      Ei: Nej
   myonnetty_avustus:
     '#multiple__add_more_button_label': 'Lägg till understöd som beviljats'
-    '#element':
-      issuer_name:
-        '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
-      purpose:
-        '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on my&ouml;nnetty?'
-        '#counter_maximum_message': '%d/1000 tecken kvar'
-  muut_samaan_tarkoitukseen_haetut_avustukset:
-    '#title': 'Övriga understöd som ansökts för samma ändamål'
-  info_muut_samaan_tarkoitukseen_haettu:
-    '#text': "<p>Ange här endast de understöd som har ansökts från annanstans än Helsingfors stad, men beslut har ännu inte fattats.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>\r\n</div>\r\n</div>\r\n"
-  olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta:
-    '#title': 'Vi har ansökt om understöd från annanstans än Helsingfors stad.'
-    '#options':
-      Kyllä: Ja
-      Ei: Nej
-  haettu_avustus_tieto:
-    '#title': 'Lägg till nytt understöd som ansökts'
-    '#multiple__add_more_button_label': 'Lägg till nytt understöd som ansökts'
     '#element':
       issuer_name:
         '#help': 'Mik&auml; taho avustusta on my&ouml;nt&auml;nyt (esim. ministeri&ouml;n nimi)'
@@ -136,9 +100,6 @@ elements: |
     '#title': '3. Samfundets verksamhet'
   business_info:
     '#title': Verksamhetsbeskrivning
-  community_purpose:
-    '#title': Verksamhetsbeskrivning
-    '#help': 'Verksamhetsbeskrivningen redigeras i dina uppgifter.'
   community_practices_business:
     '#title': 'Bedriver samfundet affärsverksamhet'
     '#options':
@@ -152,18 +113,20 @@ elements: |
     '#title': 'Samfundsmedlem (€/år)'
   jasenmaara:
     '#title': 'Antal medlemmar'
-  members_applicant_person_local:
-    '#title': 'Personmedlemmar från Helsingfors sammanlagt'
-    '#help': 'Hur m&aring;nga personmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande?'
+  jasenmaara_fieldset:
+    '#help': 'Jos yhteis&ouml;ll&auml; on j&auml;seni&auml;, merkitse ne t&auml;h&auml;n.'
   members_applicant_person_global:
     '#title': 'Personmedlemmar sammanlagt'
     '#help': 'Hur m&aring;nga personmedlemmar som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande?'
-  members_applicant_community_local:
-    '#title': 'Samfundsmedlemmar från Helsingfors sammanlagt'
-    '#help': 'Hur m&aring;nga samfundsmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
+  members_applicant_person_local:
+    '#title': 'Personmedlemmar från Helsingfors sammanlagt'
+    '#help': 'Hur m&aring;nga personmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande?'
   members_applicant_community_global:
     '#title': Samfundsmedlemmar
     '#help': 'Hur m&aring;nga samfundsmedlemmar som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
+  members_applicant_community_local:
+    '#title': 'Samfundsmedlemmar från Helsingfors sammanlagt'
+    '#help': 'Hur m&aring;nga samfundsmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:
@@ -178,6 +141,13 @@ elements: |
     '#markup': "&nbsp;<br />\r\nAlla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan om underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas, meddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Erforderliga bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs styrkta bilagor fr&aring;n den f&ouml;reg&aring;ende r&auml;kenskapsperioden som samfundet har godk&auml;nt och undertecknat vid sitt m&ouml;te samt bilagor f&ouml;r det verksamhets&aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks. Bilagorna fr&aring;n den f&ouml;reg&aring;ende r&auml;kenskapsperioden &auml;r: bokslut, verksamhetsber&auml;ttelse, revisionsber&auml;ttelse och protokoll fr&aring;n &aring;rsst&auml;mman. Bilagorna f&ouml;r det &aring;r f&ouml;r vilket underst&ouml;det ans&ouml;ks &auml;r: budget och verksamhetsplan.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor i en fil</strong><br />\r\nOm du vill kan du l&auml;mna in flera bilagor i en fil i punkten Bokslut eller budget. Ange i detta fall vid andra bilagor att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;.<br />\r\n<br />\r\n<strong>Bilagor som tidigare l&auml;mnats in till Helsingfors stad</strong><br />\r\nOm de erforderliga bilagorna redan har l&auml;mnats in som bilaga till en annan ans&ouml;kan om underst&ouml;d till Helsingfors stad, beh&ouml;ver samma bilagor inte l&auml;mnas in igen. Samfundets fastst&auml;llda bokslut, verksamhetsber&auml;ttelse, verksamhetsplan och budget f&aring;r inte vara olika i bilagor till de olika ans&ouml;kningarna. Ange i detta fall vid de inl&auml;mnade bilagorna att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
   notification_attachments:
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Innehållet i bilagorna kan inte granskas i efterhand</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Observera att du inte kan öppna bilagorna efter att du har bifogat dem blanketten. Du ser bara bilagans filnamn.</p>\r\n\r\n<p>Även om du inte kan granska innehållet i bilagorna i efterhand skickas bilagorna som bifogats blanketten med övriga uppgifter till personen som behandlar ansökan om understöd.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
+  yhteison_saannot:
+    '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet.</span></span></span>'
+    '#attachmentName__title': ''
+    '#fileStatus__title': ''
+    '#fileType__title': ''
+    '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   vahvistettu_tilinpaatos:
     '#title': 'Fastställt bokslut (för den föregående avslutade räkenskapsperioden)'
     '#help': "&nbsp;Bokslutet ska inneh&aring;lla minst resultatr&auml;kningen och balansr&auml;kningen. Samfundet ska till denna punkt l&auml;gga till bokslutet som godk&auml;nts och undertecknats vid samfundets medlemsm&ouml;te.<br />\r\nSamfundets r&auml;kenskapsperiod kan vara ett kalender&aring;r eller en annan period. Vad g&auml;ller samfund anges det i deras egna stadgar vad samfundets r&auml;kenskapsperiod &auml;r."
@@ -185,6 +155,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   vahvistettu_toimintakertomus:
     '#title': 'Fastställd verksamhetsberättelse (för den föregående avslutade räkenskapsperioden)'
     '#help': "&nbsp;Samfundet ska till denna punkt bifoga verksamhetsber&auml;ttelsen som godk&auml;nts och undertecknats vid samfundets medlemsm&ouml;te.<br />\r\nOm verksamhetsber&auml;ttelsen ing&aring;r i bokslutet och du redan har bifogat den blanketten, beh&ouml;ver den inte bifogas separat. Ange i detta fall vid verksamhetsber&auml;ttelsen att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
@@ -192,6 +163,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   vahvistettu_tilin_tai_toiminnantarkastuskertomus:
     '#title': 'Fastställd revisionsberättelse (för det föregående avslutade räkenskapsåret)'
     '#help': "&nbsp;Bifoga den undertecknade revisionsber&auml;ttelsen f&ouml;r samfundets senaste avslutade r&auml;kenskapsperiod h&auml;r.<br />\r\nOm den undertecknade revisionsber&auml;ttelsen ing&aring;r i samfundets bokslut och du redan bifogat den till blanketten i samband med bokslutet, ange &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo; h&auml;r."
@@ -199,6 +171,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
     '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
@@ -206,6 +179,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   toimintasuunnitelma:
     '#title': 'Verksamhetsplan (för det år du ansöker om understödet)'
     '#help': 'Bifoga verksamhetsplanen f&ouml;r hela f&ouml;r samfundet h&auml;r.'
@@ -213,6 +187,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   talousarvio:
     '#title': 'Budget (för det år du ansöker om understödet)'
     '#help': 'Budget (f&ouml;r det &aring;r du ans&ouml;ker om underst&ouml;det)'
@@ -220,6 +195,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
   extra_info:
     '#title': 'Ytterligare information om bilagorna'
     '#counter_maximum_message': 'Max 5000 tecken.'
@@ -229,6 +205,7 @@ elements: |
     '#fileStatus__title': ''
     '#fileType__title': ''
     '#integrationID__title': ''
+    '#isAttachmentNew__title': ''
 settings:
   preview_label: '5. Bekräfta, förhandsgranska och skicka'
   preview_title: 'Bekräfta, förhandsgranska och skicka'

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -131,3 +131,157 @@ msgstr "Du har inte de nödvändiga behörigheterna för att göra en ansökan."
 
 msgid "Change your role"
 msgstr "Ändra din roll"
+
+msgid "Draft expired"
+msgstr "Luonnos vanhentunut"
+
+msgid "There has been an error in updating application status, please reload the page."
+msgstr "Hakemuksen tilan päivityksessä tapahtui virhe, kokeile ladata sivu uudelleen"
+
+msgid "Make sure that the status of the application changes from “Submitted” to “Received”. The application is only fully received when the status reads “Received”."
+msgstr "Muistathan varmistaa, että hakemuksen tila vaihtuu “Lähetetty - odotetaan vahvistusta” -tilasta “Vastaanotettu” -tilaan. Hakemus on vastaanotettu vasta, kun tila on muodossa: “Vastaanotettu”."
+
+msgid "The status change can take from seconds to few minutes."
+msgstr "Tilan vaihtuminen voi kestää sekunneista muutamaan minuuttiin."
+
+msgid "Application period is closed, no further editing is allowed."
+msgstr "Hakemusaika on päättynyt, lisämuokkaukset on estetty."
+
+msgid "You can copy and use the contents of this application in the new application. The attached files of the original application are not copied."
+msgstr "Voit kopioida ja käyttää tämän hakemuksen tietoja uudessa hakemuksessa. Hakemuksen liitetiedostot eivät kopioidu uuteen hakemukseen."
+
+msgid "You are copying an application"
+msgstr "Olet kopioimassa hakemusta"
+
+msgid "New application"
+msgstr "Uusi hakemus"
+
+msgid "Application is not open"
+msgstr "Hakemus ei ole avoinna"
+
+msgid "Mark as read"
+msgstr "Kuittaa luetuksi"
+
+msgctxt "Webform wizard page status messages"
+msgid "Errors"
+msgstr "Virheitä"
+
+msgctxt "Webform wizard page status messages"
+msgid "Completed"
+msgstr "Täytetty"
+
+msgctxt "Unset Profile Fields"
+msgid "Unknown"
+msgstr "Ei tiedossa"
+
+msgid "You have a new message regarding you application"
+msgstr "Sinulla on uusi viesti koskien hakemustasi"
+
+msgid "You must insert at least one subvention amount"
+msgstr "Sinun on syötettävä vähintään yhdelle avustuslajille summa"
+
+msgid "1 new message"
+msgstr "1 uusi viesti"
+
+msgid "@count new messages"
+msgstr "@count uutta viestiä"
+
+msgid "1 new message"
+msgid_plural "@count new messages"
+msgstr[0] "1 uusi viesti"
+msgstr[1] "@count uutta viestiä"
+
+msgid "Your request was not fulfilled due to network error."
+msgstr "Pyyntösi keskeytyi verkkovirheen takia."
+
+msgid "Are you sure you want to leave? Leave without saving."
+msgstr "Oletko varma että haluat keskeyttää lomakkeen täyttämisen? Poistu tallentamatta."
+
+msgid "Leave the application"
+msgstr "Poistu hakemukselta"
+
+msgid "Back to application"
+msgstr "Takaisin hakemukselle"
+
+msgid "Changes you made may not be saved."
+msgstr "Hakemuksella on tallentamattomia muutoksia."
+
+msgid "Press OK to leave this page or Cancel to stay."
+msgstr "Paina OK poistuaksesi sivulta tai Peruuta jatkaaksesi."
+
+msgid "Saved"
+msgstr "Tallennettu"
+
+msgctxt "Grant Issuers"
+msgid "State"
+msgstr "Valtio"
+
+msgctxt "Grant Issuers"
+msgid "EU"
+msgstr "EU"
+
+msgctxt "Grant Issuers"
+msgid "Other"
+msgstr "Muu"
+
+msgctxt "Grant Issuers"
+msgid "Foundation"
+msgstr "Säätiö"
+
+msgctxt "Grant Issuers"
+msgid "STEA"
+msgstr "STEA"
+
+msgctxt "Grant Print View Boolean"
+msgid "Yes"
+msgstr "Kyllä"
+
+msgctxt "Grant Print View Boolean"
+msgid "No"
+msgstr "Ei"
+
+msgid "Grant application (@number) saving failed. Error has been logged."
+msgstr "Det gick inte att spara bidragsansökan (@number). Ett fel har loggats."
+
+msgid "You must have address saved to your profile."
+msgstr "Du måste ha en adress sparad i din profil."
+
+msgid "You must have bank account saved to your profile."
+msgstr "Du måste ha ett bankkonto sparat i din profil."
+
+msgid "You must have grants profile created."
+msgstr "Du måste ha en Grants-profil skapad."
+
+msgid "User does not have proper mandate."
+msgstr "Användaren har inte korrekt mandat."
+
+msgid "User role is not allowed to use this form."
+msgstr "Användarrollen får inte använda detta formulär."
+
+msgid "You do not have the necessary authorizations to make an application."
+msgstr "Du har inte de nödvändiga behörigheterna för att göra en ansökan."
+
+msgid "Change your role"
+msgstr "Byt roll"
+
+msgid "Fields marked with an asterisk * are required, that need to be filled before saving."
+msgstr "Fält markerade med * är obligatoriska uppgifter som du måste fylla i innan du sparar informationen."
+
+msgid "Some information fetched from personal information"
+msgstr "Viss information hämtad från personlig information"
+
+msgid "Some information fetched from personal information"
+msgstr "Viss information hämtad från personlig information"
+
+msgid "Check the information on the form before sending the application. You can change your own information from personal information section of the site."
+msgstr "Kontrollera informationen på formuläret innan du skickar ansökan. Du kan ändra din egen information från sidan med personlig information."
+
+msgid "Information message"
+msgstr "OBS"
+
+msgid "Subvention amount"
+msgstr "Hjälpmedel belopp"
+
+msgid "Subvention name"
+msgstr "Hjälpmedel namn"
+


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

Apparently lot of missing translations. 

Well, it seems that all strings are translatable and can be done any time.

## What was done
<!-- Describe what was done -->

* Added translations to PO files and to webform configs.
* Webforms can be translated, we just need to ignore those when exporting forms / make sure we import forms via normal `drush cim`

