### PR TITLE
fix: AU-XX: Fix typo in definition

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -491,7 +491,7 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
           'jsonType' => 'int',
         ]);
 
-      $info['toeutuneet_ensi_iltojen_maara_helsingissa'] = DataDefinition::create('integer')
+      $info['toteutuneet_ensi_iltojen_maara_helsingissa'] = DataDefinition::create('integer')
         ->setLabel('Ensi-iltojen määrä Helsingissä.')
         ->setSetting('jsonPath', [
           'compensation',


### PR DESCRIPTION
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/892920/01aa4b19-314f-4a89-849c-442e0c9e582d)

had been changed in form specs.