### PR TITLE
fix: AU-1120: Fix empty profile errors

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
@@ -308,7 +308,7 @@ abstract class GrantsProfileFormBase extends FormBase {
     /** @var \Drupal\helfi_atv\AtvDocument $profileDocument */
     $profileDocument = $storage['profileDocument'];
 
-    if ($profileDocument->getTransactionId() == 'initialSave') {
+    if ($profileDocument->getTransactionId() == GrantsProfileService::DOCUMENT_TRANSACTION_ID_INITIAL) {
       /** @var \Drupal\helfi_atv\AtvService $atvService */
       $atvService = \Drupal::service('helfi_atv.atv_service');
 

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
@@ -288,6 +288,7 @@ abstract class GrantsProfileFormBase extends FormBase {
       '#value' => $this->t('Cancel'),
       '#attributes' => ['class' => ['button', 'hds-button--secondary']],
       '#weight' => 10,
+      '#limit_validation_errors' => [],
       '#submit' => ['Drupal\grants_profile\Form\GrantsProfileFormBase::formCancelCallback'],
     ];
     return $form;
@@ -302,7 +303,28 @@ abstract class GrantsProfileFormBase extends FormBase {
    *   Form state.
    */
   public static function formCancelCallback(array &$form, FormStateInterface &$form_state) {
-    $route_name = 'grants_profile.show';
+
+    $storage = $form_state->getStorage();
+    /** @var \Drupal\helfi_atv\AtvDocument $profileDocument */
+    $profileDocument = $storage['profileDocument'];
+
+    if ($profileDocument->getTransactionId() == 'initialSave') {
+      /** @var \Drupal\helfi_atv\AtvService $atvService */
+      $atvService = \Drupal::service('helfi_atv.atv_service');
+
+      try {
+        $atvService->deleteDocument($profileDocument);
+        \Drupal::messenger()->addStatus('Grants profile creation canceled.');
+      }
+      catch (\Throwable $e) {
+        \Drupal::logger('grants_profile')
+          ->error('Grants Profile deletion failed. Profile Document ID: @id', ['@id' => $profileDocument->getId()]);
+      }
+      $route_name = 'grants_mandate.mandateform';
+    }
+    else {
+      $route_name = 'grants_profile.show';
+    }
     $form_state->setRedirect($route_name);
   }
 

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -665,7 +665,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
         'phone' => [
           '#type' => 'textfield',
           '#title' => $this->t('Telephone'),
-          '#default_value' => $official['phone'],
+          '#default_value' => $official['phone'] ?? '',
         ],
         'official_id' => [
           '#type' => 'hidden',

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -32,6 +32,8 @@ class GrantsProfileService {
 
   const DOCUMENT_STATUS_SAVED = 'READY';
 
+  const DOCUMENT_TRANSACTION_ID_INITIAL = 'initialSave';
+
   /**
    * The helfi_atv service.
    *
@@ -200,6 +202,8 @@ class GrantsProfileService {
     $newProfileData['tos_record_id'] = $this->newProfileTosRecordId();
     $newProfileData['tos_function_id'] = $this->newProfileTosFunctionId();
 
+    $newProfileData['transaction_id'] = 'initialSave';
+
     $newProfileData['metadata'] = [
       'profile_type' => $selectedCompanyArray['type'],
       'profile_id' => $selectedCompany,
@@ -219,8 +223,8 @@ class GrantsProfileService {
    *
    * @todo This can probaably be hardcoded.
    */
-  protected function newTransactionId($transactionId): string {
-    return md5($transactionId);
+  protected function newTransactionId(): string {
+    return Uuid::uuid4()->toString();
   }
 
   /**
@@ -267,12 +271,12 @@ class GrantsProfileService {
     // Make sure business id is saved.
     $documentContent['businessId'] = $selectedCompany['identifier'];
 
-    $transactionId = $this->newTransactionId(time());
+    $transactionId = $this->newTransactionId();
 
     if ($grantsProfileDocument == NULL) {
       $newGrantsProfileDocument = $this->newProfileDocument($documentContent);
       $newGrantsProfileDocument->setStatus(self::DOCUMENT_STATUS_SAVED);
-      $newGrantsProfileDocument->setTransactionId($transactionId);
+      $newGrantsProfileDocument->setTransactionId(self::DOCUMENT_TRANSACTION_ID_INITIAL);
 
       $this->logger->info('Grants profile POSTed, transactionID: %transId', ['%transId' => $transactionId]);
       return $this->atvService->postDocument($newGrantsProfileDocument);


### PR DESCRIPTION
# [AU-1120](https://helsinkisolutionoffice.atlassian.net/browse/AU-1120)
<!-- What problem does this solve? -->

Initially saved document got left hanging around if users cancels form. This is fixed here.

## What was done
<!-- Describe what was done -->

* Add initial save transaction id
* Delete document if transactionid is initially added one
* Redirect to mandate page
* Also limit validation errors on cancel button

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1120-empty-profile-errors`
  * `make drush-rebuild`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Create new unregistered community
* [ ] Cancel form before saving anything.



[AU-1120]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ