### PR TITLE
AU-1162: fix: AU-1162: Fix printing label text in html elements class…

### DIFF
--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -66,7 +66,7 @@ class GrantsAttachments extends WebformCompositeBase {
 
     if (isset($storage['errors'][$arrayKey])) {
       $errors = $storage['errors'][$arrayKey];
-      $element['#attributes']['class'][] = $errors['label'];
+      $element['#attributes']['class'][] = $errors['class'];
       $element['#attributes']['error_label'] = $errors['label'];
     }
 


### PR DESCRIPTION
… attribute

# [AU-1162](https://helsinkisolutionoffice.atlassian.net/browse/AU-1162)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix error label being added to html elements class attribute.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1162-fix-attachement-label-in-class`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that error label is not in the class element, and that the element has `has-errors` class


[AU-1162]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ