### PR TITLE
AU-1133: Disable form actions during ajax call

### DIFF
--- a/public/modules/custom/grants_handler/js/webform-additions.js
+++ b/public/modules/custom/grants_handler/js/webform-additions.js
@@ -102,6 +102,22 @@
           box2.prop('disabled', false)
         }
       });
+
+      const fieldsToDisable = [
+        '.webform-button--draft',
+        '.webform-button--preview',
+        '.webform-button--previous',
+      ];
+
+      $(document).ajaxStart(function () {
+        // Disable buttons or perform any other actions before the request.
+        $(fieldsToDisable.join(',')).prop('disabled', true);
+      });
+
+      $(document).ajaxComplete(function () {
+        // Enable buttons or perform any other actions after the request.
+        $(fieldsToDisable.join(',')).prop('disabled', false);
+      });
     }
   };
 })(jQuery, Drupal, drupalSettings);


### PR DESCRIPTION
# [AU-1133](https://helsinkisolutionoffice.atlassian.net/browse/AU-1133
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* DIsable form actions during ajax call.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1133-disable-form-actions-during-ajax`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Start an application process
* [ ] While adding new items or uploading attachment, check that form action buttons (bottom) are disabled during the call.



[AU-1133]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ