### PR TITLE
AU-1161: Fix attachment checkbox updating

### DIFF
--- a/public/modules/custom/grants_attachments/src/AttachmentHandler.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentHandler.php
@@ -885,13 +885,8 @@ class AttachmentHandler {
           $retval['isNewAttachment'] = FALSE;
           break;
 
-        case 'otherFile':
-          $retval['isDeliveredLater'] = FALSE;
-          $retval['isIncludedInOtherFile'] = TRUE;
-          $retval['isNewAttachment'] = FALSE;
-          break;
-
         case 'deliveredLater':
+        case 'otherFile':
           if (isset($field['isDeliveredLater'])) {
             $retval['isDeliveredLater'] = $field['isDeliveredLater'] === "1";
             $retval['isNewAttachment'] = FALSE;

--- a/public/modules/custom/grants_metadata/src/Plugin/DataType/GrantsAttachmentData.php
+++ b/public/modules/custom/grants_metadata/src/Plugin/DataType/GrantsAttachmentData.php
@@ -38,29 +38,25 @@ class GrantsAttachmentData extends Map {
    * {@inheritdoc}
    */
   public function setValue($values, $notify = TRUE) {
-    if (!isset($values['attachmentIsNew'])) {
-      $values['attachmentIsNew'] = TRUE;
+    if (isset($values['attachmentIsNew'])) {
+      unset($values['attachmentIsNew']);
+    }
+    if (isset($values['isNewAttachment'])) {
+      unset($values['isNewAttachment']);
     }
 
-    if ($values["isDeliveredLater"] == 'true') {
+    if ($values["isDeliveredLater"] === 'true') {
       $values["isDeliveredLater"] = TRUE;
     }
-    if ($values["isDeliveredLater"] == 'false' || $values["isDeliveredLater"] == '') {
+    if ($values["isDeliveredLater"] === 'false' || $values["isDeliveredLater"] === '') {
       $values["isDeliveredLater"] = FALSE;
     }
 
-    if ($values["isIncludedInOtherFile"] == 'true') {
+    if ($values["isIncludedInOtherFile"] === 'true') {
       $values["isIncludedInOtherFile"] = TRUE;
     }
-    if ($values["isIncludedInOtherFile"] == 'false' || $values["isIncludedInOtherFile"] == '') {
+    if ($values["isIncludedInOtherFile"] === 'false' || $values["isIncludedInOtherFile"] === '') {
       $values["isIncludedInOtherFile"] = FALSE;
-    }
-
-    if ($values["isNewAttachment"] == 'true') {
-      $values["isNewAttachment"] = TRUE;
-    }
-    if ($values["isNewAttachment"] == 'false' || $values["isNewAttachment"] == '') {
-      $values["isNewAttachment"] = FALSE;
     }
 
     parent::setValue($values, $notify);


### PR DESCRIPTION
# [AU-1161](https://helsinkisolutionoffice.atlassian.net/browse/AU-1161)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix checkbox update selection not updating, if user changes this after draft saving.

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1161-fix-attachment-checkvalues-saving`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Start an application and go to attachment page
* [ ] Check the checkboxes (and try to remember what did you choose)
* [ ] Save as draft
* [ ] Edit the application and select the opposite selection
* [ ] Save as draft
* [ ] Check that values saved correctly
* [ ] Repeat few times for good measure.




[AU-1161]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ