### PR TITLE
fix: AU-1135: remove extra € from subventions in preview

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/CompensationsComposite.php
@@ -119,7 +119,7 @@ class CompensationsComposite extends WebformCompositeBase {
     $types = self::getOptionsForTypes();
 
     return [
-      $types[$value['subventionType']] . ': ' . $value['amount'] . '€',
+      $types[$value['subventionType']] . ': ' . $value['amount'],
 
     ];
   }


### PR DESCRIPTION
# [AU-1135](https://helsinkisolutionoffice.atlassian.net/browse/AU-1135)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove extra € from subventions in preview

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1135-duplicate-euro`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go fill an application
* [ ] Add subvention amount
* [ ] Go to preview page and see that there is only € after the amount

[AU-1135]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ