### PR TITLE
fix: AU-1165: fix Avustuslaji in application search

### DIFF
--- a/conf/cmi/language/en/views.view.application_search.yml
+++ b/conf/cmi/language/en/views.view.application_search.yml
@@ -14,15 +14,15 @@ display:
           expose:
             label: Keyword
             placeholder: 'Search by name or keyword'
-        field_avustuslaji_target_id_entityreference_filter:
-          expose:
-            label: 'What kind of activity are you applying grant for?'
         field_hakijatyyppi_value:
           expose:
             label: Applicant
         field_application_open_value:
           group_info:
             label: 'Show only the grants that can be applied for'
+        field_avustuslaji_target_id:
+          expose:
+            label: 'What kind of activity are you applying grant for?'
       footer:
         result:
           content: '<strong>@total</strong> results'

--- a/conf/cmi/language/sv/views.view.application_search.yml
+++ b/conf/cmi/language/sv/views.view.application_search.yml
@@ -15,15 +15,15 @@ display:
           expose:
             label: Nyckelord
             placeholder: 'Sök på namn eller sökterm, till exempel verksamhetsunderstöd'
-        field_avustuslaji_target_id_entityreference_filter:
-          expose:
-            label: 'Vilken typ av verksamhet ansöker du om understöd?'
         field_hakijatyyppi_value:
           expose:
             label: Sökande
         field_application_open_value:
           group_info:
             label: 'Visa endast de undersök som kan sökas'
+        field_avustuslaji_target_id:
+          expose:
+            label: 'Vilken typ av verksamhet ansöker du om understöd?'
       pager:
         options:
           expose:

--- a/conf/cmi/views.view.application_search.yml
+++ b/conf/cmi/views.view.application_search.yml
@@ -14,14 +14,14 @@ dependencies:
     - field.storage.node.field_webform
     - node.type.service
     - system.menu.main
-    - views.view.avustuslajit
+    - taxonomy.vocabulary.avustuslaji
   module:
     - better_exposed_filters
     - datetime_range
-    - entityreference_filter
     - node
     - options
     - paragraphs
+    - taxonomy
     - user
     - webform
 id: application_search
@@ -896,24 +896,24 @@ display:
             title: title
             field_errand_service: field_errand_service
             field_webform: field_webform
-        field_avustuslaji_target_id_entityreference_filter:
-          id: field_avustuslaji_target_id_entityreference_filter
+        field_avustuslaji_target_id:
+          id: field_avustuslaji_target_id
           table: node__field_avustuslaji
-          field: field_avustuslaji_target_id_entityreference_filter
+          field: field_avustuslaji_target_id
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: entityreference_filter_view_result
+          plugin_id: taxonomy_index_tid
           operator: or
-          value: null
+          value: {  }
           group: 1
           exposed: true
           expose:
-            operator_id: field_avustuslaji_target_id_entityreference_filter_op
+            operator_id: field_avustuslaji_target_id_op
             label: 'Millaiseen toimintaan haet avustusta?'
             description: ''
             use_operator: false
-            operator: field_avustuslaji_target_id_entityreference_filter_op
+            operator: field_avustuslaji_target_id_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: avustuslaji
@@ -923,10 +923,14 @@ display:
             remember_roles:
               authenticated: authenticated
               anonymous: '0'
-              admin: '0'
-              content_producer: '0'
               read_only: '0'
               helsinkiprofiili: '0'
+              content_producer_industry: '0'
+              content_producer: '0'
+              grants_producer: '0'
+              ad_user: '0'
+              grants_admin: '0'
+              admin: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -940,11 +944,12 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
+          vid: avustuslaji
           type: select
-          reference_display: 'avustuslajit:entity_reference_1'
-          reference_arguments: ''
-          hide_empty_filter: true
+          hierarchy: false
+          limit: true
+          error_message: true
         field_hakijatyyppi_value:
           id: field_hakijatyyppi_value
           table: node__field_hakijatyyppi
@@ -1142,7 +1147,6 @@ display:
         - 'config:field.storage.node.field_hakijatyyppi'
         - 'config:field.storage.node.field_target_group'
         - 'config:field.storage.node.field_webform'
-        - taxonomy_term_list
   page_1:
     id: page_1
     display_title: Page
@@ -1183,4 +1187,3 @@ display:
         - 'config:field.storage.node.field_hakijatyyppi'
         - 'config:field.storage.node.field_target_group'
         - 'config:field.storage.node.field_webform'
-        - taxonomy_term_list


### PR DESCRIPTION
# [AU-1165](https://helsinkisolutionoffice.atlassian.net/browse/AU-1165)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change avustuslaji from entity reference filter to regular filter

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1165-dropdown`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that "Millaiseen toimintaan haet avustusta" works in Etsi avustusta -page

[AU-1165]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ