### PR TITLE
fix: AU-1173: Update node values from webform when saving node

### DIFF
--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -5,6 +5,7 @@
  * Module hooks.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormStateInterface;
@@ -58,12 +59,47 @@ function grants_metadata__validate_third_party_settings(array &$form, FormStateI
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function grants_metadata_node_presave(EntityInterface $entity) {
+
+  if ($entity->bundle() == 'service') {
+
+
+    /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $referenceItem */
+    $referenceItem = $entity->get('field_webform')->first();
+
+    /** @var \Drupal\Core\Entity\Plugin\DataType\EntityReference $entityReference */
+    $entityReference = $referenceItem->get('entity');
+
+    /** @var \Drupal\Core\Entity\Plugin\DataType\EntityAdapter $entityAdapter */
+    $entityAdapter = $entityReference->getTarget();
+
+    /** @var \Drupal\Core\Entity\EntityInterface $referencedEntity */
+    $referencedEntity = $entityAdapter->getValue();
+
+    if ($referencedEntity) {
+
+      // Get entity status.
+      $status = $referencedEntity->isOpen();
+      $thirdPartySettings = $referencedEntity->getThirdPartySettings('grants_metadata');
+
+      // Update node values from 3rd party settings.
+      grants_metadata_set_node_values($entity, $status, $thirdPartySettings);
+    }
+
+  }
+}
+
+/**
  * Implements hook_webform_presave().
  */
 function grants_metadata_webform_presave(Webform $entity) {
 
   // Get third aprty settings.
   $thirdPartySettings = $entity->getThirdPartySettings('grants_metadata');
+
+  $entity->setThirdPartySetting('grants_metadata','updated_timestamp', time());
 
   // Get nodes that have attached this webform.
   try {
@@ -107,14 +143,14 @@ function grants_metadata_webform_presave(Webform $entity) {
 /**
  * Add configurations from webform to given node.
  *
- * @param \Drupal\node\Entity\Node $page
+ * @param EntityInterface $page
  *   Node to be edited.
  * @param bool $status
  *   Status of the webform.
  * @param mixed $thirdPartySettings
  *   Webform third party settings.
  */
-function grants_metadata_set_node_values(Node &$page, bool $status, mixed $thirdPartySettings): void {
+function grants_metadata_set_node_values(EntityInterface &$page, bool $status, mixed $thirdPartySettings): void {
 
   Drupal::messenger()
     ->addStatus(t('Updating service @nodetype from webform values', ['@nodetype' => $page->getTitle()]));


### PR DESCRIPTION
# [AU-1173](https://helsinkisolutionoffice.atlassian.net/browse/AU-1173)
<!-- What problem does this solve? -->

Fetch webform specific fields from referenced webform also when saving service page nodes. This will cause sometimes nodes being saved multiple times when importing configs, but it ay be lesser issue than the values not updating.



## What was done
<!-- Describe what was done -->

* Node presave hook was added to do the savin

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`




[AU-1173]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ