### PR TITLE
AU-1163: Change static budget components to non multivalue

### DIFF
--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -860,7 +860,7 @@ elements: |-
       budget_static_income:
         '#type': grants_budget_income_static
         '#title': '<empty>'
-        '#multiple': true
+        '#multiple': false
         '#incomeGroup': general
         '#multiple__min_items': 1
         '#multiple__empty_items': 0
@@ -869,21 +869,21 @@ elements: |-
         '#multiple__add': false
         '#multiple__add_more': false
         '#multiple__add_more_input': false
-        '#customerFees__access': false
-        '#donations__access': false
-        '#otherCompensations__access': false
-        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
-        '#compensationFromCulturalAffairs__access': false
-        '#otherCompensationFromCity__access': false
-        '#otherCompensationType__access': false
-        '#incomeWithoutCompensations__access': false
         '#plannedStateOperativeSubvention__access': false
+        '#otherCompensationFromCity__access': false
+        '#stateOperativeSubvention__access': false
         '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#financialFundingAndInterests__access': false
+        '#customerFees__access': false
+        '#donations__access': false
+        '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationType__access': false
+        '#incomeWithoutCompensations__access': false
         '#plannedTotalIncome__access': false
+        '#otherCompensations__access': false
+        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#plannedTotalIncomeWithoutSubventions__access': false
         '#plannedShareOfIncomeWithoutSubventions__access': false
-        '#stateOperativeSubvention__access': false
         '#shareOfIncomeWithoutSubventions__access': false
         '#totalIncomeWithoutSubventions__access': false
         '#totalIncome__access': false
@@ -893,7 +893,7 @@ elements: |-
       budget_static_cost:
         '#type': grants_budget_cost_static
         '#title': '<empty>'
-        '#multiple': true
+        '#multiple': false
         '#incomeGroup': general
         '#multiple__min_items': 1
         '#multiple__empty_items': 0

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -1066,27 +1066,27 @@ elements: |-
       budget_static_income:
         '#type': grants_budget_income_static
         '#title': '<empty>'
-        '#multiple': true
+        '#multiple': false
         '#incomeGroup': general
         '#multiple__min_items': 1
         '#multiple__empty_items': 0
         '#multiple__sorting': false
         '#multiple__operations': false
         '#multiple__add_more': false
+        '#plannedStateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#otherCompensationFromCity__access': false
+        '#stateOperativeSubvention__access': false
+        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#customerFees__access': false
         '#donations__access': false
-        '#otherCompensations__access': false
         '#compensationFromCulturalAffairs__access': false
-        '#otherCompensationFromCity__access': false
         '#otherCompensationType__access': false
         '#incomeWithoutCompensations__access': false
-        '#plannedStateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
-        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#ownFunding__access': false
         '#plannedTotalIncome__access': false
+        '#otherCompensations__access': false
         '#plannedTotalIncomeWithoutSubventions__access': false
         '#plannedShareOfIncomeWithoutSubventions__access': false
-        '#stateOperativeSubvention__access': false
         '#shareOfIncomeWithoutSubventions__access': false
         '#totalIncomeWithoutSubventions__access': false
         '#totalIncome__access': false
@@ -1096,7 +1096,7 @@ elements: |-
       suunnitellut_menot:
         '#type': grants_budget_cost_static
         '#title': '<empty>'
-        '#multiple': true
+        '#multiple': false
         '#incomeGroup': general
         '#multiple__min_items': 1
         '#multiple__empty_items': 0
@@ -1134,15 +1134,15 @@ elements: |-
         '#generalCosts__access': false
         '#permits__access': false
         '#setsAndCostumes__access': false
-        '#equipment__access': false
-        '#premises__access': false
         '#security__access': false
-        '#marketing__access': false
         '#costsWithoutDeferredItems__access': false
         '#generalCostsTotal__access': false
         '#showCosts__access': false
         '#travelCosts__access': false
         '#transportCosts__access': false
+        '#equipment__access': false
+        '#premises__access': false
+        '#marketing__access': false
         '#totalCosts__access': false
         '#allCostsTotal__access': false
     muu_huomioitava_panostus:
@@ -1171,7 +1171,7 @@ elements: |-
       toteutuneet_tulot_data:
         '#type': grants_budget_income_static
         '#title': '<empty>'
-        '#multiple': true
+        '#multiple': false
         '#incomeGroup': general
         '#multiple__min_items': 1
         '#multiple__empty_items': 0
@@ -1179,24 +1179,24 @@ elements: |-
         '#multiple__operations': false
         '#multiple__add_more': false
         '#compensation__access': false
+        '#plannedStateOperativeSubvention__access': false
+        '#otherCompensationFromCity__help': 'Samaan toimitaan edelliselle päättyneelle tilivuodelle myönnetty avustus. '
+        '#stateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#plannedOtherCompensations__access': false
+        '#sponsorships__access': false
+        '#entryFees__access': false
+        '#sales__access': false
+        '#financialFundingAndInterests__access': false
         '#customerFees__access': false
         '#donations__access': false
-        '#entryFees__access': false
-        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
-        '#sponsorships__access': false
-        '#sales__access': false
         '#compensationFromCulturalAffairs__access': false
-        '#otherCompensationFromCity__help': 'Samaan toimitaan edelliselle päättyneelle tilivuodelle myönnetty avustus. '
         '#otherCompensationType__access': false
         '#incomeWithoutCompensations__access': false
-        '#plannedStateOperativeSubvention__access': false
-        '#plannedOtherCompensations__access': false
         '#ownFunding__access': false
-        '#financialFundingAndInterests__access': false
         '#plannedTotalIncome__access': false
+        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
         '#plannedTotalIncomeWithoutSubventions__access': false
         '#plannedShareOfIncomeWithoutSubventions__access': false
-        '#stateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
         '#shareOfIncomeWithoutSubventions__access': false
         '#totalIncomeWithoutSubventions__access': false
         '#totalIncome__help': 'Kirjaa tähän kaikki tulot yhteensä, sisältäen myös jo aiemmissa kohdissa kirjatut avustukset.'
@@ -1206,7 +1206,7 @@ elements: |-
       menot_yhteensa:
         '#type': grants_budget_cost_static
         '#title': '<empty>'
-        '#multiple': true
+        '#multiple': false
         '#incomeGroup': general
         '#multiple__min_items': 1
         '#multiple__empty_items': 0
@@ -1244,15 +1244,15 @@ elements: |-
         '#generalCosts__access': false
         '#permits__access': false
         '#setsAndCostumes__access': false
-        '#equipment__access': false
-        '#premises__access': false
         '#security__access': false
-        '#marketing__access': false
         '#costsWithoutDeferredItems__access': false
         '#generalCostsTotal__access': false
         '#showCosts__access': false
         '#travelCosts__access': false
         '#transportCosts__access': false
+        '#equipment__access': false
+        '#premises__access': false
+        '#marketing__access': false
         '#allCostsTotal__access': false
         '#plannedTotalCosts__access': false
   lisatiedot_ja_liitteet:

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -657,7 +657,7 @@ elements: |-
       budget_static_income:
         '#type': grants_budget_income_static
         '#title': '<empty>'
-        '#multiple': true
+        '#multiple': false
         '#incomeGroup': general
         '#multiple__min_items': 1
         '#multiple__empty_items': 0
@@ -666,22 +666,22 @@ elements: |-
         '#multiple__add': false
         '#multiple__add_more': false
         '#multiple__add_more_input': false
+        '#plannedStateOperativeSubvention__access': false
+        '#otherCompensationFromCity__access': false
+        '#stateOperativeSubvention__access': false
+        '#financialFundingAndInterests__access': false
         '#customerFees__access': false
         '#donations__access': false
         '#compensationFromCulturalAffairs__access': false
-        '#otherCompensationFromCity__access': false
         '#otherCompensationType__access': false
-        '#totalIncome__access': false
         '#incomeWithoutCompensations__access': false
-        '#plannedStateOperativeSubvention__access': false
-        '#otherCompensations__access': false
-        '#financialFundingAndInterests__access': false
         '#plannedTotalIncome__access': false
+        '#otherCompensations__access': false
         '#plannedTotalIncomeWithoutSubventions__access': false
         '#plannedShareOfIncomeWithoutSubventions__access': false
-        '#stateOperativeSubvention__access': false
-        '#totalIncomeWithoutSubventions__access': false
         '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__access': false
     menot:
       '#type': webform_section
       '#title': 'Suunnitellut menot'

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -76,7 +76,7 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
     }
 
     $appEnv = ApplicationHandler::getAppEnv();
-    if ($appEnv === 'DEV' || strpos($appEnv, 'LOCAL') !== FALSE) {
+    if ($appEnv === 'DEV' || strpos($appEnv, 'LOCALA') !== FALSE) {
       $element['debugging'] = [
         '#type' => 'details',
         '#title' => 'Dev DEBUG:',

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -3,7 +3,6 @@
 namespace Drupal\grants_budget_components\Element;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\grants_handler\ApplicationHandler;
 use Drupal\grants_handler\Processor\NumberProcessor;
 use Drupal\webform\Element\WebformCompositeBase;
 
@@ -75,8 +74,7 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
       $element['costGroupName']['#value'] = $element['#incomeGroup'];
     }
 
-    $appEnv = ApplicationHandler::getAppEnv();
-    if ($appEnv === 'DEV' || strpos($appEnv, 'LOCALA') !== FALSE) {
+    if (getenv('PRINT_DEVELOPMENT_DEBUG_FIELDS') == '1') {
       $element['debugging'] = [
         '#type' => 'details',
         '#title' => 'Dev DEBUG:',

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -3,7 +3,6 @@
 namespace Drupal\grants_budget_components\Element;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\grants_handler\ApplicationHandler;
 use Drupal\grants_handler\Processor\NumberProcessor;
 use Drupal\webform\Element\WebformCompositeBase;
 
@@ -75,8 +74,7 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
       $element['incomeGroupName']['#value'] = $element['#incomeGroup'];
     }
 
-    $appEnv = ApplicationHandler::getAppEnv();
-    if ($appEnv === 'DEV' || strpos($appEnv, 'LOCALA') !== FALSE) {
+    if (getenv('PRINT_DEVELOPMENT_DEBUG_FIELDS') == '1') {
       $element['debugging'] = [
         '#type' => 'details',
         '#title' => 'Dev DEBUG:',

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -76,7 +76,7 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
     }
 
     $appEnv = ApplicationHandler::getAppEnv();
-    if ($appEnv === 'DEV' || strpos($appEnv, 'LOCAL') !== FALSE) {
+    if ($appEnv === 'DEV' || strpos($appEnv, 'LOCALA') !== FALSE) {
       $element['debugging'] = [
         '#type' => 'details',
         '#title' => 'Dev DEBUG:',

--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -26,32 +26,31 @@ class GrantsBudgetComponentService {
    * @return array
    *   Processed items.
    */
-  public static function processBudgetStaticValues(ListInterface $property): array {
+  public static function processBudgetStaticValues($property): array {
     $items = [];
+    $tets = $property->getValue();
 
-    foreach ($property as $p) {
-      foreach ($p as $item) {
-        $itemName = $item->getName();
+    foreach ($property as $item) {
+      $itemName = $item->getName();
 
-        // Get item value types from item definition.
-        $itemDefinition = $item->getDataDefinition();
-        $valueTypes = AtvSchema::getJsonTypeForDataType($itemDefinition);
+      // Get item value types from item definition.
+      $itemDefinition = $item->getDataDefinition();
+      $valueTypes = AtvSchema::getJsonTypeForDataType($itemDefinition);
 
-        if (!in_array($itemName, self::IGNORED_FIELDS)) {
+      if (!in_array($itemName, self::IGNORED_FIELDS)) {
 
-          $value = GrantsHandler::convertToFloat($item->getValue()) ?? NULL;
+        $value = GrantsHandler::convertToFloat($item->getValue()) ?? NULL;
 
-          if (!$value) {
-            continue;
-          }
-
-          $items[] = [
-            'ID' => $itemName,
-            'label' => $itemDefinition->getLabel(),
-            'value' => (string) $value,
-            'valueType' => $valueTypes['jsonType'],
-          ];
+        if (!$value) {
+          continue;
         }
+
+        $items[] = [
+          'ID' => $itemName,
+          'label' => $itemDefinition->getLabel(),
+          'value' => (string) $value,
+          'valueType' => $valueTypes['jsonType'],
+        ];
       }
     }
     return $items;
@@ -242,26 +241,37 @@ class GrantsBudgetComponentService {
       $arrayKeys = array_keys($retVal);
       $propertyType = $property->getDataType();
       // No need to check "default budget components".
-      if ($propertyType !== 'list' || in_array($propertyKey, $arrayKeys)) {
+      if (
+        !in_array(
+          $propertyType,
+          ['list', 'grants_budget_income_static', 'grants_budget_cost_static']) ||
+          in_array($propertyKey, $arrayKeys)) {
         continue;
       }
 
-      $propertyDef = $property->getItemDefinition();
-      $propertyDataType = $propertyDef->getDataType();
-      $fieldsForAppilication = $property->getSetting('fieldsForApplication') ?? [];
-      $keysToExtract = array_flip($fieldsForAppilication);
+      if ($propertyType === 'list') {
+        $propertyDef = $property->getItemDefinition();
+        $propertyDataType = $propertyDef->getDataType();
+        $fieldsForAppilication = $property->getSetting('fieldsForApplication') ?? [];
+        $keysToExtract = array_flip($fieldsForAppilication);
+      }
+      else {
+        $propertyDataType = $property->getDataType();
+        $fieldsForAppilication = $property->getSetting('fieldsForApplication') ?? [];
+        $keysToExtract = array_flip($fieldsForAppilication);
+      }
 
       // If found, copy from default component values.
       switch ($propertyDataType) {
         case 'grants_budget_income_static';
-          $retVal[$propertyKey][] = array_intersect_key(
+          $retVal[$propertyKey] = array_intersect_key(
             $dataFromDocument['incomeRowsArrayStatic'][0] ?? [],
             $keysToExtract,
           );
           break;
 
         case 'grants_budget_cost_static';
-          $retVal[$propertyKey][] = array_intersect_key(
+          $retVal[$propertyKey] = array_intersect_key(
             $dataFromDocument['costRowsArrayStatic'][0] ?? [],
             $keysToExtract,
           );

--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -28,7 +28,6 @@ class GrantsBudgetComponentService {
    */
   public static function processBudgetStaticValues($property): array {
     $items = [];
-    $tets = $property->getValue();
 
     foreach ($property as $item) {
       $itemName = $item->getName();

--- a/public/modules/custom/grants_budget_components/src/TypedData/Definition/GrantsBudgetInfoDefinition.php
+++ b/public/modules/custom/grants_budget_components/src/TypedData/Definition/GrantsBudgetInfoDefinition.php
@@ -96,11 +96,11 @@ class GrantsBudgetInfoDefinition extends MapDataDefinition {
   /**
    * Helper function to get basic static income definition.
    *
-   * @return \Drupal\Core\TypedData\ListDataDefinition
+   * @return \Drupal\grants_budget_components\TypedData\Definition\GrantsBudgetIncomeStaticDefinition
    *   Ready to use income static definition
    */
   public static function getStaticIncomeDefinition() {
-    return ListDataDefinition::create('grants_budget_income_static')
+    return GrantsBudgetIncomeStaticDefinition::create('grants_budget_income_static')
       ->setSetting('fullItemValueCallback', [
         'service' => 'grants_budget_components.service',
         'method' => 'processBudgetStaticValues',
@@ -117,11 +117,11 @@ class GrantsBudgetInfoDefinition extends MapDataDefinition {
   /**
    * Helper function to get basic static cost definition.
    *
-   * @return \Drupal\Core\TypedData\ListDataDefinition
+   * @return \Drupal\grants_budget_components\TypedData\Definition\GrantsBudgetCostStaticDefinition
    *   Ready to use cost static definition
    */
   public static function getStaticCostDefinition() {
-    return ListDataDefinition::create('grants_budget_cost_static')
+    return GrantsBudgetCostStaticDefinition::create('grants_budget_cost_static')
       ->setSetting('fullItemValueCallback', [
         'service' => 'grants_budget_components.service',
         'method' => 'processBudgetStaticValues',

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -356,7 +356,11 @@ class GrantsHandler extends WebformHandlerBase {
     }
 
     $budgetFields = NestedArray::filter($values, function ($i) {
-      if (is_array($i) && !empty(reset($i))) {
+
+      if (is_array($i) && (isset($i['costGroupName']) || isset($i['incomeGroupName']))) {
+        return TRUE;
+      }
+      elseif (is_array($i) && !empty(reset($i))) {
         $elem = reset($i);
         return isset($elem['costGroupName']) || isset($elem['incomeGroupName']);
       }


### PR DESCRIPTION
# [AU-1163](https://helsinkisolutionoffice.atlassian.net/browse/AU-1163)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed static budget components from multivalue -> single
* This fixes huge margins on budget components

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1163-static-budget-components-to-non-multivalue`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go through KUVA applications and check that there is no large margin gaps on budget components
* [ ] Check that data is saved correctly, as minor refactor was needed to static value handling.


[AU-1163]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ