### PR TITLE
AU-1177: KUVA Toiminta: Budget fields as required. Fixes to static bu…

### DIFF
--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -1077,10 +1077,17 @@ elements: |-
         '#multiple__sorting': false
         '#multiple__operations': false
         '#multiple__add_more': false
+        '#compensation__required': true
         '#plannedStateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#plannedStateOperativeSubvention__required': true
         '#otherCompensationFromCity__access': false
         '#stateOperativeSubvention__access': false
         '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#plannedOtherCompensations__required': true
+        '#sponsorships__required': true
+        '#entryFees__required': true
+        '#sales__required': true
+        '#financialFundingAndInterests__required': true
         '#customerFees__access': false
         '#donations__access': false
         '#compensationFromCulturalAffairs__access': false
@@ -1149,6 +1156,7 @@ elements: |-
         '#marketing__access': false
         '#totalCosts__access': false
         '#allCostsTotal__access': false
+        '#plannedTotalCosts__required': true
     muu_huomioitava_panostus:
       '#type': webform_section
       '#title': 'Muu huomioitava panostus'
@@ -1185,7 +1193,9 @@ elements: |-
         '#compensation__access': false
         '#plannedStateOperativeSubvention__access': false
         '#otherCompensationFromCity__help': 'Samaan toimitaan edelliselle päättyneelle tilivuodelle myönnetty avustus. '
+        '#otherCompensationFromCity__required': true
         '#stateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#stateOperativeSubvention__required': true
         '#plannedOtherCompensations__access': false
         '#sponsorships__access': false
         '#entryFees__access': false
@@ -1199,11 +1209,13 @@ elements: |-
         '#ownFunding__access': false
         '#plannedTotalIncome__access': false
         '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#otherCompensations__required': true
         '#plannedTotalIncomeWithoutSubventions__access': false
         '#plannedShareOfIncomeWithoutSubventions__access': false
         '#shareOfIncomeWithoutSubventions__access': false
         '#totalIncomeWithoutSubventions__access': false
         '#totalIncome__help': 'Kirjaa tähän kaikki tulot yhteensä, sisältäen myös jo aiemmissa kohdissa kirjatut avustukset.'
+        '#totalIncome__required': true
     toteutuneet_menot_osio:
       '#type': webform_section
       '#title': 'Toteutuneet menot'
@@ -1257,6 +1269,7 @@ elements: |-
         '#equipment__access': false
         '#premises__access': false
         '#marketing__access': false
+        '#totalCosts__required': true
         '#allCostsTotal__access': false
         '#plannedTotalCosts__access': false
   lisatiedot_ja_liitteet:

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -51,7 +51,14 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
-    _grants_handler_process_multivalue_errors($element, $form_state);
+    $storage = $form_state->getStorage();
+    $errors = $storage['errors'][$element['#webform_key']] ?? [];
+
+    $element_errors = $errors['errors'] ?? [];
+    foreach ($element_errors as $errorKey => $erroValue) {
+      $element[$errorKey]['#attributes']['class'][] = $erroValue['class'];
+      $element[$errorKey]['#attributes']['error_label'] = $erroValue['label'];
+    }
 
     $fieldKeys = array_keys(self::getFieldNames());
 

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -51,7 +51,14 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
-    _grants_handler_process_multivalue_errors($element, $form_state);
+    $storage = $form_state->getStorage();
+    $errors = $storage['errors'][$element['#webform_key']] ?? [];
+
+    $element_errors = $errors['errors'] ?? [];
+    foreach ($element_errors as $errorKey => $erroValue) {
+      $element[$errorKey]['#attributes']['class'][] = $erroValue['class'];
+      $element[$errorKey]['#attributes']['error_label'] = $erroValue['label'];
+    }
 
     $fieldKeys = array_keys(self::getFieldNames());
 

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1771,6 +1771,10 @@ function _grants_handler_process_multivalue_errors(&$element, $form_state) {
 
   if ($relevantErrors) {
     foreach ($relevantErrors as $key => $error) {
+      if (!is_array($error)) {
+        continue;
+      }
+
       $element[$key]['#attributes']['class'][] = $error['class'];
       $element[$key]['#attributes']['error_label'] = $error['label'];
     }

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -635,6 +635,10 @@ class GrantsHandler extends WebformHandlerBase {
               elseif (isset($form['elements'][$pageName][$fieldName][$errorName]['#webform_composite_elements'][$errorSelectValue])) {
                 $errors[$errorName]['class'] = 'has-errors';
                 $errors[$errorName]['label'] = $error;
+                $errors[$errorName]['errors'][$errorSelectValue] = [
+                  'class' => 'has-errors',
+                  'label' => $error,
+                ];
               }
               elseif (isset($form['elements'][$pageName][$fieldName][$errorName])) {
                 $form['elements'][$pageName][$fieldName][$errorName]['#attributes']['class'][] = 'has-error';


### PR DESCRIPTION
…dget component error labels

# [AU-1177](https://helsinkisolutionoffice.atlassian.net/browse/AU-1177)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* KUVA TOIM required budget fields
* Fixed error labels in static budget components, as these weren't caught when we refactored it.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1177-budget-required-fields`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check KUVA TOIM, that budget fields are marked as required
* [ ] Check that required / invalid format validation messages are shown below the field.


[AU-1177]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ