### PR TITLE
AU-1068: Handle bank account owner info metadata

### DIFF
--- a/public/modules/custom/grants_handler/src/Element/BankAccountComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/BankAccountComposite.php
@@ -53,9 +53,11 @@ class BankAccountComposite extends WebformCompositeBase {
       '#type' => 'hidden',
     ];
     $elements['account_number_owner_name'] = [
+      '#title' => t('Bank account owner name'),
       '#type' => 'hidden',
     ];
     $elements['account_number_ssn'] = [
+      '#title' => t('Bank account owner SSN'),
       '#type' => 'hidden',
     ];
 

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -424,11 +424,15 @@ class AtvSchema {
         $propertyName == 'community_post_code' ||
         $propertyName == 'community_country';
 
+      $isBankAccountField =
+        $propertyName == 'account_number_owner_name' ||
+        $propertyName == 'account_number_ssn';
+
       $isRegularField = $propertyName !== 'form_update' &&
         $propertyName !== 'messages' &&
         $propertyName !== 'status_updates' &&
         $propertyName !== 'events' &&
-        ($webformElement !== NULL || $isAddressField);
+        ($webformElement !== NULL || $isAddressField | $isBankAccountField);
 
       if ($jsonPath == NULL && $isRegularField) {
         continue;
@@ -442,6 +446,10 @@ class AtvSchema {
           $webformMainElement = $webform->getElement('community_address');
           $webformLabelElement = $webformMainElement['#webform_composite_elements'][$propertyName];
           $propertyName = 'community_address';
+        } else if ($propertyName == 'account_number_owner_name' || $propertyName == 'account_number_ssn') {
+          $webformMainElement = $webform->getElement('bank_account');
+          $webformLabelElement = $webformMainElement['#webform_composite_elements'][$propertyName];
+          $propertyName = 'bank_account';
         }
         else {
           $webformMainElement = $webformElement;


### PR DESCRIPTION
# [AU-1068](https://helsinkisolutionoffice.atlassian.net/browse/AU-1068)
<!-- What problem does this solve? -->

Bank account owner info (name, ssn) did not have metadata attached to them.

## What was done
<!-- Describe what was done -->

* Added additional logic in `AtvSchema` to handle bank account owner info
* Added titles to bank account owner info, for displaying in metadata

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Edit and save an application as an unregistered community
* [ ] Check the metadata in ATV
* [ ] Check that ATV metadata tests run `vendor/bin/phpunit -c public/core public/modules/custom/grants_metadata`

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

[AU-1068]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ