### PR TITLE
fix: AU-1029: format date in preview

### DIFF
--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -16,7 +16,7 @@ third_party_settings:
     applicationTypeTerms:
       47: '47'
     applicationOpen: '2022-10-02T11:08:26'
-    applicationClose: '2023-06-14T11:19:00'
+    applicationClose: '2023-07-31T11:19:00'
     applicationContinuous: 0
     applicationTargetGroup: '22'
     disableCopying: 0

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -14,7 +14,7 @@ third_party_settings:
     applicationTypeTerms:
       45: '45'
     applicationOpen: '2022-10-02T11:08:26'
-    applicationClose: '2023-06-14T11:19:00'
+    applicationClose: '2023-07-31T11:19:00'
     applicationContinuous: 0
     applicationTargetGroup: '22'
     disableCopying: 0

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -17,7 +17,7 @@ third_party_settings:
       58: '58'
     applicationTargetGroup: '22'
     applicationOpen: '2022-10-02T11:08:26'
-    applicationClose: '2023-06-14T11:19:00'
+    applicationClose: '2023-07-30T11:19:00'
     applicationContinuous: 0
     disableCopying: 0
     applicationActingYears:

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -14,7 +14,7 @@ third_party_settings:
     applicationTypeTerms:
       49: '49'
     applicationOpen: '2022-10-03T11:08:26'
-    applicationClose: '2023-06-14T11:19:00'
+    applicationClose: '2023-07-30T11:19:00'
     applicationContinuous: 0
     applicationTargetGroup: '12'
     disableCopying: 0

--- a/public/themes/custom/hdbt_subtheme/templates/webform/webform-element-base-html--date.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/webform/webform-element-base-html--date.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a webform base element as html.
+ *
+ * Available variables:
+ * - element: The element.
+ * - title: The label for the element.
+ * - value: The content for the element.
+ * - item: The form item used to display the element.
+ * - options Associative array of options for element.
+ *   - multiline: Flag to determine if value spans multiple lines.
+ *   - email: Flag to determine if element is for an email.
+ */
+#}
+{% if options.email %}
+  {% if title %}<b>{{ title }}</b><br />{% endif %}{{ value }}<br /><br />
+{% else %}
+  {% if title %}<label>{{ title }}</label>{% endif %}{{ item.value['#plain_text']|date('d.m.Y') }}<br /><br />
+{% endif %}
+


### PR DESCRIPTION
# [AU-1029](https://helsinkisolutionoffice.atlassian.net/browse/AU-1029)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added Twig-file to format dates in application preview

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1029-date-format`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go fill an application (t. ex. Projektiavustus), and fill dates in page 4. Move to next page and then go to the last page, and check that dates look correct.

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/0bf40b58-0d41-4bda-8cc4-59e80c3d81ab)


[AU-1029]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ