### PR TITLE
feat: AU-1077: Hide fields in print

### DIFF
--- a/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
@@ -356,7 +356,7 @@ class ApplicationController extends ControllerBase {
   private function transformField($field, &$pages, &$isSubventionType, &$subventionType, $langcode) {
     if (isset($field['ID'])) {
       $labelData = json_decode($field['meta'], TRUE);
-      if (!$labelData) {
+      if (!$labelData || $labelData['element']['hidden']) {
         return;
       }
       // Handle application type field.

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -816,6 +816,15 @@ class AtvSchema {
     return $documentStructure;
   }
 
+  /**
+   * Check if the given field should be hidden from end users.
+   *
+   * @param Drupal\Core\TypedData\TypedDataInterface $property
+   *   Field to check.
+   *
+   * @return bool
+   *   Should the field be hidden
+   */
   public static function isFieldHidden($property) {
     $definition = $property->getDataDefinition();
     $propertyName = $property->getName();

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -204,7 +204,6 @@ class AtvSchema {
     }
 
     $typedDataValues['muu_liite'] = $other_attachments;
-
     $typedDataValues['metadata'] = $metadata;
     return $typedDataValues;
 
@@ -352,7 +351,6 @@ class AtvSchema {
   public function typedDataToDocumentContent(
     TypedDataInterface $typedData,
     WebformSubmission $webformSubmission): array {
-
     $webform = $webformSubmission->getWebform();
     $pages = $webform->getPages('edit', $webformSubmission);
     return $this->typedDataToDocumentContentWithWebform($typedData, $webform, $pages);
@@ -414,6 +412,11 @@ class AtvSchema {
       if ($propertyName == 'account_number') {
         $propertyName = 'bank_account';
       }
+
+      // Should we hide the data.
+      $hidden = $this->isFieldHidden($property);
+      // Which field to hide in list fields.
+      $hiddenFields = $definition->getSetting('hiddenFields') ?? [];
 
       /* Try to get element from webform. This tells usif we can try to get
       metadata from webform. If not, field is not printable. */
@@ -481,6 +484,7 @@ class AtvSchema {
               // Finally the element itself.
               $label = $property['label'];
               $weight = array_search($name, $elementKeys);
+              $hidden = in_array($name, $hiddenFields);
               $page = [
                 'id' => $pageId,
                 'label' => $pageLabel,
@@ -494,6 +498,7 @@ class AtvSchema {
               $element = [
                 'label' => $label,
                 'weight' => $elementWeight,
+                'hidden' => $hidden,
               ];
               $elementWeight++;
               $metaData = self::getMetaData($page, $section, $element);
@@ -548,6 +553,7 @@ class AtvSchema {
         $element = [
           'label' => $label,
           'weight' => $weight,
+          'hidden' => $hidden,
         ];
         $metaData = self::getMetaData($page, $section, $element);
       }
@@ -659,10 +665,6 @@ class AtvSchema {
                         $label = $titleElement->render();
                       }
                     }
-                    $element = [
-                      'weight' => $weight,
-                      'label' => $label,
-                    ];
 
                     if (isset($propertyItem[$itemName])) {
                       $itemValue = $propertyItem[$itemName];
@@ -670,6 +672,12 @@ class AtvSchema {
                       $itemValue = $this->getItemValue($itemTypes, $itemValue, $defaultValue, $valueCallback);
 
                       $idValue = $itemName;
+                      $hidden = in_array($itemName, $hiddenFields);
+                      $element = [
+                        'weight' => $weight,
+                        'label' => $label,
+                        'hidden' => $hidden,
+                      ];
                       $metaData = self::getMetaData($page, $section, $element);
                       $valueArray = [
                         'ID' => $idValue,
@@ -727,9 +735,11 @@ class AtvSchema {
                   if (isset($webformMainElement['#webform_composite_elements'][$itemName]['#title'])) {
                     $label = $webformMainElement['#webform_composite_elements'][$itemName]['#title']->render();
                   }
+                  $hidden = in_array($itemName, $hiddenFields);
                   $element = [
                     'weight' => $weight,
                     'label' => $label,
+                    'hidden' => $hidden,
                   ];
                   $itemTypes = self::getJsonTypeForDataType($itemValueDefinition);
                   if (isset($propertyItem[$itemName])) {
@@ -806,6 +816,25 @@ class AtvSchema {
     return $documentStructure;
   }
 
+  public static function isFieldHidden($property) {
+    $definition = $property->getDataDefinition();
+    $propertyName = $property->getName();
+    $hide = $definition->getSetting('hidden') || FALSE;
+    if ($hide) {
+      return TRUE;
+    }
+    $parent = $property->getParent();
+    if (!$parent) {
+      return FALSE;
+    }
+    $parentDefinition = $parent->getDataDefinition();
+    $hiddenFields = $definition->getSetting('hiddenFields');
+    if (is_array($hiddenFields) && in_array($propertyName, $hiddenFields)) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
   /**
    * Get metadata array for JSON schema meta field.
    *
@@ -837,6 +866,7 @@ class AtvSchema {
       'element' => [
         'weight' => $element['weight'] ?? -1,
         'label' => $element['label'] ?? 'Element',
+        'hidden' => $element['hidden'] ?? FALSE,
       ],
     ];
     return $metaData;

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -394,7 +394,8 @@ trait ApplicationDefinitionTrait {
     // Attachments.
     $info['attachments'] = ListDataDefinition::create('grants_metadata_attachment')
       ->setLabel('Attachments')
-      ->setSetting('jsonPath', ['attachmentsInfo', 'attachmentsArray']);
+      ->setSetting('jsonPath', ['attachmentsInfo', 'attachmentsArray'])
+      ->setSetting('hiddenFields', ['integrationID', 'fileType']);
 
     $info['extra_info'] = DataDefinition::create('string')
       ->setLabel('Extra Info')

--- a/public/modules/custom/grants_metadata/tests/data/yleisavustushakemus.data.json
+++ b/public/modules/custom/grants_metadata/tests/data/yleisavustushakemus.data.json
@@ -64,7 +64,16 @@
     "sender_person_id": null,
     "sender_user_id": null,
     "sender_email": null,
-    "attachments": [],
+    "attachments": [
+        {
+            "description": "Yhteisön säännöt (uusi hakija tai säännöt muuttuneet)",
+            "fileName": "truck_clipart_15144.jpg",
+            "fileType": "7",
+            "integrationID": "/LOCAL/v1/documents/4f3d41b8-e133-4ac7-b31a-9ece0aeba114/attachments/7657/",
+            "isDeliveredLater": "false",
+            "isIncludedInOtherFile": "false"
+        }
+    ],
     "extra_info": "",
     "form_update": false,
     "status_updates": [],

--- a/public/modules/custom/grants_metadata/tests/src/Kernel/AtvSchemaTest.php
+++ b/public/modules/custom/grants_metadata/tests/src/Kernel/AtvSchemaTest.php
@@ -180,6 +180,7 @@ class AtvSchemaTest extends KernelTestBase {
     $this->assertArrayHasKey('page', $meta);
     $this->assertArrayHasKey('section', $meta);
     $this->assertArrayHasKey('element', $meta);
+    $this->assertTrue(isset($meta['element']['hidden']));
 
   }
 
@@ -369,4 +370,71 @@ class AtvSchemaTest extends KernelTestBase {
     $this->assertDocumentField($document, 'applicantInfoArray', 7, 'communityOfficialNameShort', 'AE');
   }
 
+    /**
+   * @covers \Drupal\grants_metadata\AtvSchema::typedDataToDocumentContentWithWebform
+   */
+  public function testAttachments() : void {
+    $this->initSession();
+    $dataDefinition = YleisavustusHakemusDefinition::create('grants_metadata_yleisavustushakemus');
+    $submissionData = self::loadSubmissionData('yleisavustushakemus');
+    $typeManager = $dataDefinition->getTypedDataManager();
+    $applicationData = $typeManager->create($dataDefinition);
+
+    $applicationData->setValue($submissionData);
+
+    foreach ($applicationData as $field) {
+        $definition = $field->getDataDefinition();
+        $name = $field->getName();
+        if ($name !== 'attachments') {
+          continue;
+        }
+        $defaultValue = $definition->getSetting('defaultValue');
+        $valueCallback = $definition->getSetting('valueCallback');
+        $propertyType = $definition->getDataType();
+        $hiddenFields = $definition->getSetting('hiddenFields');
+        foreach ($field as $itemIndex => $item) {
+          $fieldValues = [];
+          $propertyItem = $item->getValue();
+          $itemDataDefinition = $item->getDataDefinition();
+          $itemValueDefinitions = $itemDataDefinition->getPropertyDefinitions();
+          foreach ($itemValueDefinitions as $itemName => $itemValueDefinition) {
+            // Backup label.
+            $label = $itemValueDefinition->getLabel();
+            $hidden = in_array($itemName, $hiddenFields);
+            $element = [
+              'weight' => 1,
+              'label' => $label,
+              'hidden' => $hidden,
+            ];
+            $itemTypes = ATVSchema::getJsonTypeForDataType($itemValueDefinition);
+            if (isset($propertyItem[$itemName])) {
+              // What to do with empty values.
+              $itemSkipEmpty = $itemValueDefinition->getSetting('skipEmptyValue');
+
+              $itemValue = $propertyItem[$itemName];
+              $itemValue = ATVSchema::getItemValue($itemTypes, $itemValue, $defaultValue, $valueCallback);
+              // If no value and skip is setting, then skip.
+              if (empty($itemValue) && $itemSkipEmpty === TRUE) {
+                continue;
+              }
+              $metaData = ATVSchema::getMetaData(NULL, NULL, $element);
+
+              $idValue = $itemName;
+              $valueArray = [
+                'ID' => $idValue,
+                'value' => $itemValue,
+                'valueType' => $itemTypes['jsonType'],
+                'label' => $label,
+                'meta' => json_encode($metaData),
+              ];
+              if ($itemName == 'integrationID' || $itemName == 'fileType') {
+                $this->assertEquals(TRUE, $metaData['element']['hidden']);
+              } else {
+                $this->assertEquals(FALSE, $metaData['element']['hidden']);
+              }
+            }
+          }
+        }
+    }
+  }
 }


### PR DESCRIPTION
# [AU-1077](https://helsinkisolutionoffice.atlassian.net/browse/AU-1077)
<!-- What problem does this solve? -->

Hide unnecessary/confusing data from end users.

## What was done
<!-- Describe what was done -->

Include hidden status in metadata sent to ATV.
Take that into account in print phase
Update tests

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1077]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ