### PR TITLE
AU-1198: fix: AU-1198: Add missing roles back to submission display

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
@@ -41,7 +41,7 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
     $value = $this->getValue($element, $webform_submission, $options);
     $roles = GrantsProfileFormRegisteredCommunity::getOfficialRoles();
     return [
-      ''.$roles[(int) $value['role']],
+      '' . $roles[(int) $value['role']],
       $value['name'],
       $value['email'],
       $value['phone'],

--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\grants_handler\Plugin\WebformElement;
 
+use Drupal\grants_profile\Form\GrantsProfileFormRegisteredCommunity;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\webform\WebformSubmissionInterface;
 
@@ -38,8 +39,9 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
    */
   protected function formatTextItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []): array {
     $value = $this->getValue($element, $webform_submission, $options);
-
+    $roles = GrantsProfileFormRegisteredCommunity::getOfficialRoles();
     return [
+      ''.$roles[(int) $value['role']],
       $value['name'],
       $value['email'],
       $value['phone'],


### PR DESCRIPTION
# [AU-1198](https://helsinkisolutionoffice.atlassian.net/browse/AU-1198)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add roles back to yhteenveto
## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1198-fix-missing-roles`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill first page of form
* [ ] save
* [ ] see that yhteenveto has correct role displayed
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1198]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ