### PR TITLE
fix: AU-1241: change text in Oma asiointi tabs

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Derivative/DynamicLocalTasks.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Derivative/DynamicLocalTasks.php
@@ -21,7 +21,7 @@ class DynamicLocalTasks extends DeriverBase {
      */
 
     $this->derivatives['grants_oma_asiointi.front'] = $base_plugin_definition;
-    $this->derivatives['grants_oma_asiointi.front']['title'] = $this->t("My Services");
+    $this->derivatives['grants_oma_asiointi.front']['title'] = $this->t("My applications and communication");
     $this->derivatives['grants_oma_asiointi.front']['route_name'] = 'grants_oma_asiointi.front';
     $this->derivatives['grants_oma_asiointi.front']['base_route'] = 'grants_oma_asiointi.front';
 

--- a/public/modules/custom/grants_oma_asiointi/translations/fi.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/fi.po
@@ -54,6 +54,9 @@ msgstr "Oma asiointi"
 msgid "Go to My Services"
 msgstr "Siirry omaan asiointikansioon"
 
+msgid "My applications and communication"
+msgstr "Omat hakemukset ja viestintä"
+
 msgid "My data"
 msgstr "Omat tiedot"
 

--- a/public/modules/custom/grants_oma_asiointi/translations/sv.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/sv.po
@@ -6,6 +6,9 @@ msgstr ""
 msgid "My data"
 msgstr "Mina uppgifter"
 
+msgid "My applications and communication"
+msgstr "Mina applikationer och kommunikation"
+
 msgid "My applications"
 msgstr "Mina ansökningar"
 


### PR DESCRIPTION
# [AU-1241](https://helsinkisolutionoffice.atlassian.net/browse/AU-1241)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change text in oma asiointi tabs
* Changed menu links in production

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1241-omat-tiedot`
  * `make fresh`
* Run `make drush-cr`

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/be027c5d-7313-44ea-82ef-dd7c8a1f2a95)


[AU-1241]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ