### PR TITLE
fix: AU-1243 add info in beginning of profile forms

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -129,7 +129,10 @@ class GrantsProfileFormPrivatePerson extends GrantsProfileFormBase {
     $form['#tree'] = TRUE;
 
     $form['#after_build'] = ['Drupal\grants_profile\Form\GrantsProfileFormPrivatePerson::afterBuild'];
-
+    $form['profileform_info'] = [
+      '#type' => 'markup',
+      '#markup' => '<p class="grants-profile--infotext">' . t('Fill all fields, check that the information is correct and save in the end.') . '</p>',
+    ];
     $form['newItem'] = [
       '#type' => 'hidden',
       '#value' => NULL,

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -87,7 +87,10 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
     $form['#tree'] = TRUE;
 
     $form['#after_build'] = ['Drupal\grants_profile\Form\GrantsProfileFormRegisteredCommunity::afterBuild'];
-
+    $form['profileform_info'] = [
+      '#type' => 'markup',
+      '#markup' => '<p class="grants-profile--infotext">' . t('Fill all fields, check that the information is correct and save in the end.') . '</p>',
+    ];
     $form['foundingYearWrapper'] = [
       '#type' => 'webform_section',
       '#title' => $this->t('Year of establishment'),

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -59,7 +59,10 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
     $form['#tree'] = TRUE;
 
     $form['#after_build'] = ['Drupal\grants_profile\Form\GrantsProfileFormUnregisteredCommunity::afterBuild'];
-
+    $form['profileform_info'] = [
+      '#type' => 'markup',
+      '#markup' => '<p class="grants-profile--infotext">' . t('Fill all fields, check that the information is correct and save in the end.') . '</p>',
+    ];
     $form['companyNameWrapper'] = [
       '#type' => 'webform_section',
       '#title' => $this->t('Community name'),

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -553,3 +553,6 @@ msgstr "Yhteisöllä on avustuksia käsittelyssä."
 
 msgid "Connection error"
 msgstr "Yhteysvirhe"
+
+msgid "Fill all fields, check that the information is correct and save in the end."
+msgstr "Täytä kaikki kentät, tarkista tietojen oikeellisuus ja tallenna lopuksi."

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -315,3 +315,6 @@ msgstr "Föreningen har pågående ansökningar."
 
 msgid "Connection error"
 msgstr "Anslutningsfel"
+
+msgid "Fill all fields, check that the information is correct and save in the end."
+msgstr "Fyll i alla fält, kontrollera att uppgifterna stämmer och spara till sist."


### PR DESCRIPTION
# [AU-1243](https://helsinkisolutionoffice.atlassian.net/browse/AU-1243)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Lisätään ohjeistus hakuprofiililomakkeen alkuun: Täytä kaikki kentät, tarkista tietojen oikeellisuus ja tallenna lopuksi.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1243-info-for-profile-form`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in, go to profiili. Edit profiili. See that the message is visible at the start of editable fields.
* [ ] Change asiointirooli, see that the message is there for all three.
* [ ] Change languages. See that the message works with all languages.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR has been visually reviewed by a designer (Heikki)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1243]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ