### PR TITLE
feat: AU-1235, AU-1237, AU-1238: Yleisavustuslomake changes

### DIFF
--- a/conf/cmi/grants_handler.settings.yml
+++ b/conf/cmi/grants_handler.settings.yml
@@ -5,9 +5,9 @@ statusStrings:
     SUBMITTED: Submitted
     RECEIVED: Received
     PENDING: Pending
-    PROCESSING: Processing
+    PROCESSING: In Progress
     READY: Ready
-    DONE: Done
+    DONE: Solved
     REJECTED: Rejected
     DELETED: Deleted
     CANCELED: Canceled
@@ -21,12 +21,12 @@ statusStrings:
     PENDING: Odottaa
     PROCESSING: Käsittelyssä
     READY: Valmiina
-    DONE: Käsitelty
+    DONE: Ratkaistu
     REJECTED: Hylätty
     DELETED: Poistettu
     CANCELED: Peruttu
     CANCELLED: Peruttu
-    CLOSED: Ratkaistu
+    CLOSED: Suljettu
   sv:
     DRAFT: Utkast
     SENT: Skickas

--- a/conf/cmi/grants_handler.settings.yml
+++ b/conf/cmi/grants_handler.settings.yml
@@ -28,17 +28,17 @@ statusStrings:
     CANCELLED: Peruttu
     CLOSED: Ratkaistu
   sv:
-    DRAFT: Draft
-    SENT: Sent
-    SUBMITTED: Submitted
+    DRAFT: Utkast
+    SENT: Skickas
+    SUBMITTED: Lämnats
     RECEIVED: Mottagits
-    PENDING: Pending
-    PROCESSING: Processing
-    READY: Ready
-    DONE: Done
-    REJECTED: Rejected
-    DELETED: Deleted
-    CANCELED: Canceled
-    CANCELLED: Canceled
-    CLOSED: Closed
+    PENDING: I väntan på
+    PROCESSING: Behandlas
+    READY: Redo
+    DONE: Avgjort
+    REJECTED: Avvisade
+    DELETED: Raderade
+    CANCELED: Annulerad
+    CANCELLED: Inställt
+    CLOSED: Stängd
 langcode: fi

--- a/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
@@ -262,6 +262,7 @@ elements: |
     '#isAttachmentNew__title': ''
   extra_info:
     '#title': 'Further clarification on attachments'
+    '#counter_maximum_message': '%d/5000 characters remaining'
   muu_liite:
     '#title': 'Other attachment'
     '#multiple__add_more_button_label': 'Add attachment'

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -263,7 +263,7 @@ elements: |
     '#isAttachmentNew__title': ''
   extra_info:
     '#title': 'Ytterligare information om bilagorna'
-    '#counter_maximum_message': 'Max 5000 tecken.'
+    '#counter_maximum_message': '%d/5000 tecken kvar'
   muu_liite:
     '#title': 'Annan bilaga'
     '#multiple__add_more_button_label': 'Lägg till en bilaga'

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -629,8 +629,6 @@ elements: |-
         '#markup': |-
           Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
           <br />
-          Tuetut tiedostomuodot xx xx xx. Tiedoston maksimikoko on x Mt. Tiedostojen maksimikoko voi olla yhteens&auml; x Gt.<br />
-          <br />
           <strong>Vaaditut liitteet</strong><br />
           Avustushakemuksen k&auml;sittely&auml; varten tarvitaan vahvistettuja, yhteis&ouml;n kokouksessaan hyv&auml;ksymi&auml; ja allekirjoittamia, liitteit&auml; edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilikaudelta sek&auml; liitteit&auml; sille toimintavuodelle, jolle avustusta haetaan. Edellist&auml; tilikautta koskevat liitteet ovat: tilinp&auml;&auml;t&ouml;s, toimintakertomus ja tilin- tai toiminnantarkastuskertomus sek&auml; vuosikokouksen p&ouml;yt&auml;kirja. Liitteet vuodelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.&nbsp;<br />
           <br />
@@ -725,7 +723,7 @@ elements: |-
             - webform--large
         '#maxlength': 5000
         '#counter_maximum': 5000
-        '#counter_maximum_message': 'Max 5000 characters.'
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
         '#cols': 63
       muu_liite:
         '#type': grants_attachments

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -222,3 +222,6 @@ msgstr 'Det gick inte att ta bort utkastet. Fel har loggats, kontakta supporten.
 
 msgid 'Deleting draft failed. This form is currently locked for another person.'
 msgstr 'Det gick inte att ta bort utkastet. Detta formulär är för närvarande låst för en annan person.'
+
+msgid "Application"
+msgstr "Ansökan"


### PR DESCRIPTION
# AU-1235, AU-1237, AU-1238
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* KH Yleisavustus changes:
* [Removed unnecessary text bit](https://helsinkisolutionoffice.atlassian.net/browse/AU-1235)
* [Changed the way character counter was displayed on page 4](https://helsinkisolutionoffice.atlassian.net/browse/AU-1237)
* [Fixed translations of states and state display](https://helsinkisolutionoffice.atlassian.net/browse/AU-1238)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1235-1237-1238-yleisavustus-changes`
  * `make fresh`
  * Disable config ignore for webform.webform.*
  * `make drush-cim`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the changes mentioned in the tickets above are fixed
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
