### PR TITLE
AU-1213: Missing webform print translations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6179,16 +6179,16 @@
         },
         {
             "name": "drupal/helfi_audit_log",
-            "version": "0.9.5",
+            "version": "0.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log.git",
-                "reference": "c0839e16b0635eaec21761c8802eac3cd860a415"
+                "reference": "4c738477445edce9e417b1ca0ca2ced25546bcc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/c0839e16b0635eaec21761c8802eac3cd860a415",
-                "reference": "c0839e16b0635eaec21761c8802eac3cd860a415",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/4c738477445edce9e417b1ca0ca2ced25546bcc2",
+                "reference": "4c738477445edce9e417b1ca0ca2ced25546bcc2",
                 "shasum": ""
             },
             "require-dev": {
@@ -6201,10 +6201,10 @@
             ],
             "description": "Helfi - Audit log",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/0.9.5",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/0.9.3",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/issues"
             },
-            "time": "2023-06-29T07:41:14+00:00"
+            "time": "2023-06-14T05:33:56+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -732,7 +732,10 @@ class AtvSchema {
                 foreach ($itemValueDefinitions as $itemName => $itemValueDefinition) {
                   // Backup label.
                   $label = $itemValueDefinition->getLabel();
-                  if (isset($webformMainElement['#webform_composite_elements'][$itemName]['#title'])) {
+                  if (
+                    isset($webformMainElement['#webform_composite_elements'][$itemName]['#title']) &&
+                    !is_string($webformMainElement['#webform_composite_elements'][$itemName]['#title'])
+                  ) {
                     $label = $webformMainElement['#webform_composite_elements'][$itemName]['#title']->render();
                   }
                   $hidden = in_array($itemName, $hiddenFields);

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -164,7 +164,7 @@ class GrantsWebformPrintController extends ControllerBase {
       // Premises as hidden textfield.
       if ($element['#type'] === 'premises_composite') {
         $element['#type'] = 'markup';
-        $element['#markup'] = '<p><strong>' . $element['#title'] . '</strong><br>';
+        $element['#markup'] = '<p><strong>' . $this->getTranslatedTitle($element, $translatedFields) . '</strong><br>';
         $element['#markup'] .= t('Premise name');
         $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
         $element['#markup'] .= t('Postal Code');
@@ -191,22 +191,22 @@ class GrantsWebformPrintController extends ControllerBase {
       }
       if ($element['#type'] === 'textarea') {
         $element['#type'] = 'markup';
-        $element['#markup'] = '<p><strong>' . $element['#title'] . '</strong><br>';
+        $element['#markup'] = '<p><strong>' . $this->getTranslatedTitle($element, $translatedFields) . '</strong><br>';
         $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input hds-text-input__textarea webform_large" type="text">&nbsp;</div></div>';
         if (isset($element['#description'])) {
           $element['#markup'] .= '<div>
- <div id="talousarvio--description" class="webform-element-description"><span>' . $element['#description'] . '</span></div>
+ <div id="talousarvio--description" class="webform-element-description"><span>' . $this->getTranslatedDescription($element, $translatedFields) . '</span></div>
     </div>';
           unset($element['#description']);
         }
       }
       if ($element['#type'] === 'textfield') {
         $element['#type'] = 'markup';
-        $element['#markup'] = '<p><strong>' . $element['#title'] . '</strong><br>';
+        $element['#markup'] = '<p><strong>' . $this->getTranslatedTitle($element, $translatedFields) . '</strong><br>';
         $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
         if (isset($element['#description'])) {
           $element['#markup'] .= '<div>
- <div id="talousarvio--description" class="webform-element-description"><span>' . $element['#description'] . '</span></div>
+ <div id="talousarvio--description" class="webform-element-description"><span>' . $this->getTranslatedDescription($element, $translatedFields) . '</span></div>
     </div>';
           unset($element['#description']);
         }
@@ -216,7 +216,7 @@ class GrantsWebformPrintController extends ControllerBase {
       }
       if ($element['#type'] === 'select' || $element['#type'] === 'checkboxes' || $element['#type'] === 'radios') {
         $element['#type'] = 'markup';
-        $element['#markup'] = '<p><strong>' . $element['#title'] . '</strong><br>';
+        $element['#markup'] = '<p><strong>' . $this->getTranslatedTitle($element, $translatedFields) . '</strong><br>';
         foreach ($element['#options'] as $key => $value) {
           $element['#markup'] .= '▢ ' . $value . '<br>';
         }
@@ -236,6 +236,36 @@ class GrantsWebformPrintController extends ControllerBase {
       }
     }
     return $element;
+  }
+
+  /**
+   * Checks if a translated title field exists and returns it.
+   *
+   * @param $element
+   * @param $translatedFields
+   *
+   * @return string
+   */
+  function getTranslatedTitle($element, $translatedFields) {
+    if (!empty($translatedFields[$element['#id']]) && isset($translatedFields[$element['#id']]['#title'])) {
+      return $translatedFields[$element['#id']]['#title'];
+    }
+    return $element['#title'];
+  }
+
+  /**
+   * Checks if a translated description field exists and returns it.
+   *
+   * @param $element
+   * @param $translatedFields
+   *
+   * @return string
+   */
+  function getTranslatedDescription($element, $translatedFields) {
+    if (!empty($translatedFields[$element['#id']]) && isset($translatedFields[$element['#id']]['#help'])) {
+      return $translatedFields[$element['#id']]['#help'];
+    }
+    return $element['#description'];
   }
 
 }


### PR DESCRIPTION
# [AU-1213](https://helsinkisolutionoffice.atlassian.net/browse/AU-1213)
<!-- What problem does this solve? -->

Some fields were not translated in webform print view.

## What was done
<!-- Describe what was done -->

* Added custom logic to apply translations to title and descriptions

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that webform print previews have all translations

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[AU-1213]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ