### PR TITLE
fix: AU-1276: Use relative path for tietoliikenne schema in ATV tests

### DIFF
--- a/public/modules/custom/grants_metadata/tests/src/Kernel/AtvSchemaTest.php
+++ b/public/modules/custom/grants_metadata/tests/src/Kernel/AtvSchemaTest.php
@@ -74,7 +74,9 @@ class AtvSchemaTest extends KernelTestBase {
     $logger = \Drupal::service('logger.factory');
     $manager = \Drupal::typedDataManager();
     $schema = new AtvSchema($manager, $logger);
-    $schema->setSchema('/app/conf/tietoliikennesanoma_schema.json');
+    // Use relative path. It works in all environments.
+    $schemaPath = __DIR__ . "/../../../../../../../conf/tietoliikennesanoma_schema.json";
+    $schema->setSchema($schemaPath);
     return $schema;
   }
 


### PR DESCRIPTION
# [AU-1276](https://helsinkisolutionoffice.atlassian.net/browseAU-1276)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Use relative path.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Check that tests are run properly in server environments

[AU-1276]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ