### PR TITLE
fix: AU-1267: Add correct sv traslation to kasko in info banner

### DIFF
--- a/public/modules/custom/grants_frontpage_info_block/translations/sv.po
+++ b/public/modules/custom/grants_frontpage_info_block/translations/sv.po
@@ -25,4 +25,4 @@ msgid "Updated"
 msgstr "Uppdaterad"
 
 msgid "Education Division, general grant application"
-msgstr "Ansökan om stadsstyrelsens allmänna understöd"
+msgstr "Fostrans- och utbildningssektorn, ansökan om allmänt understöd"


### PR DESCRIPTION
# [AU-1267](https://helsinkisolutionoffice.atlassian.net/browse/AU-1267)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add correct sv traslation to kasko in info banner

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1267-sv-kasko`
  * `make fresh`
* Run `make drush-cr`


[AU-1267]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ