### PR TITLE
fix: AU-1263: Remove duplicate title from drafts

### DIFF
--- a/public/modules/custom/grants_handler/templates/application-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list.html.twig
@@ -45,11 +45,6 @@
           </div>
         </div>
       </div>
-
-    {% else %}
-      <div class="application-list__information-row">
-        <div class="application-list__count"><span class="application-list__count-value">&nbsp;</span> {{ 'Applications'|t }}</div>
-      </div>
     {% endif %}
     <ul class="list application-list">
       {% for item in items %}


### PR DESCRIPTION
# [AU-1263](https://helsinkisolutionoffice.atlassian.net/browse/AU-1263)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove duplicate title from drafts

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1263-double-title`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to oma asiointi and check that there is no duplicate title in Drafts-list


[AU-1263]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ