### PR TITLE
fix: AU-1232: Add access checks to custom endpoints.

### DIFF
--- a/public/modules/custom/grants_attachments/grants_attachments.routing.yml
+++ b/public/modules/custom/grants_attachments/grants_attachments.routing.yml
@@ -4,4 +4,4 @@ grants_attachments.delete_attachment:
     _title: 'Delete attachment'
     _controller: '\Drupal\grants_attachments\Controller\GrantsAttachmentsController::deleteAttachment'
   requirements:
-    _permission: 'edit own webform submission'
+    _custom_access: '\Drupal\grants_handler\Controller\ApplicationController::accessByApplicationNumber'

--- a/public/modules/custom/grants_handler/grants_handler.routing.yml
+++ b/public/modules/custom/grants_handler/grants_handler.routing.yml
@@ -38,12 +38,12 @@ grants_handler.new_application:
     _permission: 'access grants_oma_asiointi'
 
 grants_handler.message_read:
-  path: '/hakemus/{application_number}/viesti/{message_id}/luettu'
+  path: '/hakemus/{submission_id}/viesti/{message_id}/luettu'
   defaults:
     _title: 'Mark message read'
     _controller: '\Drupal\grants_handler\Controller\MessageController::markMessageRead'
   requirements:
-    _permission: 'edit own webform submission'
+    _custom_access: '\Drupal\grants_handler\Controller\ApplicationController::accessByApplicationNumber'
 
 grants_handler.copy_application:
   path: '/hakemus/{submission_id}/kopioi'

--- a/public/modules/custom/grants_handler/src/Controller/MessageController.php
+++ b/public/modules/custom/grants_handler/src/Controller/MessageController.php
@@ -106,11 +106,11 @@ class MessageController extends ControllerBase {
   /**
    * Builds the response.
    */
-  public function markMessageRead(string $application_number, string $message_id) {
+  public function markMessageRead(string $submission_id, string $message_id) {
 
     $destination = $this->request->getMainRequest()->get('destination');
 
-    $submission = ApplicationHandler::submissionObjectFromApplicationNumber($application_number, NULL, FALSE);
+    $submission = ApplicationHandler::submissionObjectFromApplicationNumber($submission_id, NULL, FALSE);
     $submissionData = $submission->getData();
     $thisEvent = array_filter($submissionData['events'], function ($event) use ($message_id) {
       if (isset($event['eventTarget']) && $event['eventTarget'] == $message_id && $event['eventType'] == EventsService::$eventTypes['MESSAGE_READ']) {
@@ -122,13 +122,13 @@ class MessageController extends ControllerBase {
     if (empty($thisEvent)) {
       try {
         $this->eventsService->logEvent(
-          $application_number,
+          $submission_id,
           EventsService::$eventTypes['MESSAGE_READ'],
           $this->t('Message marked as read'),
           $message_id
         );
         $this->messenger()->addStatus($this->t('Message marked as read'));
-        $this->atvService->clearCache($application_number);
+        $this->atvService->clearCache($submission_id);
       }
       catch (EventException $ee) {
         $this->getLogger('message_controller')->error('Error: %error', [

--- a/public/modules/custom/grants_metadata/grants_metadata.routing.yml
+++ b/public/modules/custom/grants_metadata/grants_metadata.routing.yml
@@ -4,7 +4,7 @@ grants_metadata.application_status_check:
     _title: 'Check application status'
     _controller: '\Drupal\grants_metadata\Controller\ApplicationStatusCheckController::build'
   requirements:
-    _permission: 'view own webform submission'
+    _custom_access: '\Drupal\grants_handler\Controller\ApplicationController::accessByApplicationNumber'
 
 hdbt_admin_tools.webform:
   path: '/admin/structure/webform'

--- a/public/modules/custom/grants_webform_print/grants_webform_print.routing.yml
+++ b/public/modules/custom/grants_webform_print/grants_webform_print.routing.yml
@@ -6,7 +6,7 @@ grants_webform_print.submission_print:
     _title: 'Print Application'
     _controller: '\Drupal\grants_webform_print\Controller\GrantsWebformSubmissionPrintController::build'
   requirements:
-    _permission: 'edit own webform submission'
+    _custom_access: '\Drupal\grants_handler\Controller\ApplicationController::accessByApplicationNumber'
 
 grants_webform_print.print_webform:
   path: '/tietoja-avustuksista/{webform}/tulosta'


### PR DESCRIPTION
# [AU-1232](https://helsinkisolutionoffice.atlassian.net/browse/AU-1232)
<!-- What problem does this solve? -->

There was some endpoints with inadequate access checking. This adds access checks to those endpoints.

## What was done
<!-- Describe what was done -->

* Some routing.yml files was changed
* Only one endpoint needed changing.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1232-access-hook-check`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Click around in system, try endpoints that are changed
* [ ] Check that code follows our standards



[AU-1232]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ