### PR TITLE
fix: AU-1298: translate webform titles

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -1,4 +1,4 @@
-title: 'Grants for culture: Project grants for culture'
+title: 'Arts and culture, project grant'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'
@@ -41,7 +41,6 @@ elements: |
   community_officials:
     '#help': 'If you want to add, delete or change people, save the application as a draft and go to maintain the people&#39;s information in your own data.'
     '#title': 'Persons responsible for operations'
-    '#multiple__no_items_message': 'No persons responsible for the operation. Add a new person below.'
     '#multiple__add_more_button_label': 'Add person'
     '#community_officials_select__title': 'Select official'
   2_avustustiedot:

--- a/conf/cmi/language/en/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_yleisavustushakemus.yml
@@ -1,4 +1,4 @@
-title: 'EN: Liikunta, yleisavustushakemus'
+title: 'Sports, general grant application'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'
@@ -41,7 +41,6 @@ elements: |
   community_officials:
     '#help': 'If you want to add, delete or change people, save the application as a draft and go to maintain the people&#39;s information in your own data.'
     '#title': 'Persons responsible for operations'
-    '#multiple__no_items_message': 'No persons responsible for the operation. Add a new person below.'
     '#multiple__add_more_button_label': 'Add person'
     '#community_officials_select__title': 'Select official'
   2_avustustiedot:

--- a/conf/cmi/language/en/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/language/en/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -1,4 +1,4 @@
-title: 'EN: Nuorisopalvelut, toiminta- ja palkkausavustus ennakkohakemus'
+title: 'Youth service, operations and employment grant advance application'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'
@@ -41,7 +41,6 @@ elements: |
   community_officials:
     '#help': 'If you want to add, delete or change people, save the application as a draft and go to maintain the people&#39;s information in your own data.'
     '#title': 'Persons responsible for operations'
-    '#multiple__no_items_message': 'No persons responsible for the operation. Add a new person below.'
     '#multiple__add_more_button_label': 'Add person'
     '#community_officials_select__title': 'Select official'
   2_avustustiedot:

--- a/conf/cmi/language/en/webform.webform.nuorlomaleir.yml
+++ b/conf/cmi/language/en/webform.webform.nuorlomaleir.yml
@@ -1,4 +1,4 @@
-title: 'EN Loma-aikojen leiriavustushakemus'
+title: 'Holiday camp grants for youth activities'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'
@@ -39,7 +39,6 @@ elements: |
   community_officials:
     '#help': 'If you want to add, delete or change people, save the application as a draft and go to maintain the people&#39;s information in your own data.'
     '#title': 'Persons responsible for operations'
-    '#multiple__no_items_message': 'No persons responsible for the operation. Add a new person below.'
     '#multiple__add_more_button_label': 'Add person'
     '#community_officials_select__title': 'Select official'
   2_avustustiedot:

--- a/conf/cmi/language/en/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/language/en/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1,4 +1,4 @@
-title: 'EN Taide- ja kulttuuriavustukset, taiteen perusopetus'
+title: 'Arts and culture: Basic arts education grants'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'
@@ -41,7 +41,6 @@ elements: |
   community_officials:
     '#help': 'If you want to add, delete or change people, save the application as a draft and go to maintain the people&#39;s information in your own data.'
     '#title': 'Persons responsible for operations'
-    '#multiple__no_items_message': 'No persons responsible for the operation. Add a new person below.'
     '#multiple__add_more_button_label': 'Add person'
     '#community_officials_select__title': 'Select official'
   2_avustustiedot:
@@ -62,13 +61,10 @@ elements: |
     '#options':
       'Design ja käsityö': 'Design and craftsmanship'
       'Elokuva, valokuva ja media': 'Film, photography and media'
-      Kaupunkikulttuuri: 'Urban culture'
       Kirjallisuus: Literature
       'Kuvataide ': 'Visual arts and comics'
       Monitaide: Multi-arts
-      Museo: Museum
       Musiikki: Music
-      Muu: Other
       Sirkus: Circus
       Tanssi: Dance
       Teatteri: Theater

--- a/conf/cmi/language/en/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/language/en/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1,4 +1,4 @@
-title: 'Arts and culture: Basic arts education grants'
+title: 'Arts and culture, basic arts education grants'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -1,4 +1,4 @@
-title: 'Fostrans- och utbildningssektorn, ansökan om allmänt understöd'
+title: 'Fostran och utbildning, allmän bidragsansökan'
 description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -1,4 +1,4 @@
-title: 'Understöd för konst och kultur: Projektstöd'
+title: 'Konst och kultur, projektstöd'
 description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:

--- a/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
@@ -1,4 +1,4 @@
-title: 'SV: Liikunta, yleisavustushakemus'
+title: 'Idrott, allmän bidragsansökan'
 description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:

--- a/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -1,4 +1,4 @@
-title: 'SV Nuorisopalvelut, toiminta- ja palkkausavustus ennakkohakemus'
+title: 'Ungdomstjänst, förskottsansökan om verksamhets- och anställningsbidrag'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'

--- a/conf/cmi/language/sv/webform.webform.nuorlomaleir.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorlomaleir.yml
@@ -1,4 +1,4 @@
-title: 'Nuorisotoiminnan Lägerunderstöd under'
+title: 'Ungdomsverksamhet, lägerunderstöd under skollovstider'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1,4 +1,4 @@
-title: 'Understöd för konst och kultur: Verksamhetsunderstöd'
+title: 'Understöd för konst och kultur: Stöd för grundläggande konstundervisning'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'
@@ -64,13 +64,10 @@ elements: |
     '#options':
       'Design ja käsityö': 'Design och hantverk'
       'Elokuva, valokuva ja media': 'Film, foto och media'
-      Kaupunkikulttuuri: 'Urban kultur'
       Kirjallisuus: Litteratur
       'Kuvataide ': 'Bildkonst och serier'
       Monitaide: Multikonst
-      Museo: Museum
       Musiikki: Musik
-      Muu: Övrig
       Sirkus: Cirkus
       Tanssi: Dansa
       Teatteri: Teater

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1,4 +1,4 @@
-title: 'Understöd för konst och kultur: Stöd för grundläggande konstundervisning'
+title: 'Konst och kultur, stöd för grundläggande konstundervisning'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -1,4 +1,4 @@
-title: 'Ansökan om stadsstyrelsens allmänna understöd'
+title: 'Stadsstyrelsen, allmän bidragsansökan'
 description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
@@ -469,7 +469,7 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
         ->setSetting('fullItemValueCallback', [
           'service' => 'grants_premises.service',
           'method' => 'processPremises',
-          'webform' => TRUE
+          'webform' => TRUE,
         ])
         ->setSetting('webformDataExtracter', [
           'service' => 'grants_premises.service',
@@ -483,7 +483,7 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
           'postCode',
           'isOwnedByCity',
           'citySection',
-          'premiseSuitability'
+          'premiseSuitability',
         ]);
 
       // 5. Toiminnan lähtökohdat.


### PR DESCRIPTION
# [AU-1298](https://helsinkisolutionoffice.atlassian.net/browse/AU-1298)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Translate webform titles

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1298-title-translations`
  * `make fresh`
* Run `make drush-cr`


[AU-1298]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ