### PR TITLE
fix: AU-1281: Change Unregistered community to unregistered community or group

### DIFF
--- a/conf/cmi/field.storage.node.field_hakijatyyppi.yml
+++ b/conf/cmi/field.storage.node.field_hakijatyyppi.yml
@@ -16,7 +16,7 @@ settings:
       label: 'Rekisteröity yhdistys'
     -
       value: unregistered_community
-      label: 'Rekisteröimätön yhdistys'
+      label: 'Rekisteröitymätön yhteisö tai ryhmä'
     -
       value: private_person
       label: Yksityishenkilö

--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -8,7 +8,7 @@ third_party_options:
     KASKO: KASKO
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
-    unregistered_community: 'Rekisteröimätön yhdistys'
+    unregistered_community: 'Rekisteröitymätön yhteisö tai ryhmä'
     private_person: Yksityishenkilö
   application_types:
     29:

--- a/conf/cmi/language/fi/grants_metadata.settings.yml
+++ b/conf/cmi/language/fi/grants_metadata.settings.yml
@@ -8,7 +8,7 @@ third_party_options:
     KASKO: KASKO
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
-    unregistered_community: 'Rekisteröimätön yhdistys'
+    unregistered_community: 'Rekisteröitymätön yhteisö tai ryhmä'
     private_person: Yksityishenkilö
   application_types:
     29:

--- a/conf/cmi/language/sv/grants_metadata.settings.yml
+++ b/conf/cmi/language/sv/grants_metadata.settings.yml
@@ -8,7 +8,7 @@ third_party_options:
     KASKO: KASKO
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
-    unregistered_community: 'Rekisteröimätön yhdistys'
+    unregistered_community: 'Icke-registrerad förening eller verksamhetsgrupp'
     private_person: Privatperson
   application_types:
     29:

--- a/public/modules/custom/grants_handler/config/install/field.storage.node.field_hakijatyyppi.yml
+++ b/public/modules/custom/grants_handler/config/install/field.storage.node.field_hakijatyyppi.yml
@@ -16,7 +16,7 @@ settings:
       label: 'Rekisteröity yhdistys'
     -
       value: unregistered_community
-      label: 'Rekisteröimätön yhdistys'
+      label: 'Rekisteröitymätön yhdistys tai ryhmä'
     -
       value: private_person
       label: Yksityishenkilö

--- a/public/modules/custom/grants_mandate/js/disable-mandate-submit.js
+++ b/public/modules/custom/grants_mandate/js/disable-mandate-submit.js
@@ -15,9 +15,9 @@
         }
 
         if (selectedValue === 'new') {
-          submitButton.html('<span class="hds-button__label">' + Drupal.t('Add new Unregistered community') + '</span>');
+          submitButton.html('<span class="hds-button__label">' + Drupal.t('Add new Unregistered community or group') + '</span>');
         } else {
-          submitButton.html('<span class="hds-button__label">' + Drupal.t('Select Unregistered community role') + '</span>');
+          submitButton.html('<span class="hds-button__label">' + Drupal.t('Select Unregistered community or group role') + '</span>');
         }
      });
     }

--- a/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
+++ b/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
@@ -135,8 +135,8 @@ class ApplicantMandateForm extends FormBase {
     $form['actions']['unregistered_community']['info'] = [
       '#theme' => 'select_applicant_role',
       '#icon' => 'group',
-      '#role' => $this->t('Unregistered community'),
-      '#role_description' => $this->t('Apply for grant on behalf of your unregistered community'),
+      '#role' => $this->t('Unregistered community or group'),
+      '#role_description' => $this->t('Apply for grant on behalf of your unregistered community or group'),
     ];
 
     $form['actions']['unregistered_community']['unregistered_community_selection'] = [
@@ -211,7 +211,7 @@ class ApplicantMandateForm extends FormBase {
 
         if ($selectedCommunity == 'new') {
           $selectedProfileData['identifier'] = $this->grantsProfileService->getUuid();
-          $selectedProfileData['name'] = $this->t('New Unregistered Community')
+          $selectedProfileData['name'] = $this->t('New Unregistered Community or group')
             ->render();
           $selectedProfileData['complete'] = FALSE;
 

--- a/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
+++ b/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
@@ -76,7 +76,7 @@ class ApplicantMandateForm extends FormBase {
     $userData = $this->helsinkiProfiiliUserData->getUserData();
 
     $profileOptions = [
-      'new' => $this->t('Add new Unregistered community'),
+      'new' => $this->t('Add new Unregistered community or group'),
     ];
     $profiles = [];
     try {
@@ -149,7 +149,7 @@ class ApplicantMandateForm extends FormBase {
     $form['actions']['unregistered_community']['submit'] = [
       '#type' => 'submit',
       '#name' => 'unregistered_community',
-      '#value' => $this->t('Select Unregistered community role'),
+      '#value' => $this->t('Select Unregistered community or group role'),
       '#attached' => [
         'library' => [
           'grants_mandate/disable-mandate-submit',

--- a/public/modules/custom/grants_mandate/translations/fi.po
+++ b/public/modules/custom/grants_mandate/translations/fi.po
@@ -18,8 +18,8 @@ msgstr "Valitse hakijarooli"
 msgid "Registered community"
 msgstr "Rekisteröity yhteisö"
 
-msgid "Unregistered community"
-msgstr "Rekisteröimätön yhteisö"
+msgid "Unregistered community or group"
+msgstr "Rekisteröitymätön yhteisö tai ryhmä"
 
 msgid "Private person"
 msgstr "Yksityishenkilö"
@@ -57,8 +57,8 @@ msgstr "Ennen kuin siirryt avustushakemukselle, sinun tulee valita asiointirooli
 msgid "Registered community is, for example, a company, non-profit organization, organization or association"
 msgstr "Rekisteröity yhteisö on esimerkiksi yritys, voittoa tavoittelematon organisaatio, järjestö tai yhdistys"
 
-msgid "Apply for grant on behalf of your unregistered community"
-msgstr "Hae avustusta rekisteröimättömän yhteisösi puolesta"
+msgid "Apply for grant on behalf of your unregistered community or group"
+msgstr "Hae avustusta rekisteröitymättömän yhteisösi tai ryhmäsi puolesta"
 
 msgid "Apply for grant as a private person"
 msgstr "Hae avustusta yksityishenkilönä"

--- a/public/modules/custom/grants_mandate/translations/fi.po
+++ b/public/modules/custom/grants_mandate/translations/fi.po
@@ -21,6 +21,9 @@ msgstr "Rekisteröity yhteisö"
 msgid "Unregistered community or group"
 msgstr "Rekisteröitymätön yhteisö tai ryhmä"
 
+msgid "New Unregistered Community or group"
+msgstr "Uusi rekisteröitymätön yhteisö tai ryhmä"
+
 msgid "Private person"
 msgstr "Yksityishenkilö"
 

--- a/public/modules/custom/grants_mandate/translations/sv.po
+++ b/public/modules/custom/grants_mandate/translations/sv.po
@@ -21,6 +21,9 @@ msgstr "Registrerad gemenskap"
 msgid "Unregistered community or group"
 msgstr "Icke-registrerad förening eller verksamhetsgrupp"
 
+msgid "New Unregistered Community or group"
+msgstr "Ny icke-registrerad förening eller verksamhetsgrupp"
+
 msgid "Private person"
 msgstr "Privatperson"
 

--- a/public/modules/custom/grants_mandate/translations/sv.po
+++ b/public/modules/custom/grants_mandate/translations/sv.po
@@ -18,8 +18,8 @@ msgstr "Välj sökandetyp"
 msgid "Registered community"
 msgstr "Registrerad gemenskap"
 
-msgid "Unregistered community"
-msgstr "Oregistrerad gemenskap"
+msgid "Unregistered community or group"
+msgstr "Icke-registrerad förening eller verksamhetsgrupp"
 
 msgid "Private person"
 msgstr "Privatperson"
@@ -57,8 +57,8 @@ msgstr "Innan du går vidare till bidragsansökan bör du välja en sökanderoll
 msgid "Registered community is, for example, a company, non-profit organization, organization or association"
 msgstr "Registrerad gemenskap är till exempel ett företag, ideell organisation, organisation eller förening"
 
-msgid "Apply for grant on behalf of your unregistered community"
-msgstr "Ansök om bidrag på uppdrag av din oregistrerade grupp"
+msgid "Apply for grant on behalf of your unregistered community or group"
+msgstr "Ansök om bidrag på uppdrag av din icke-registrerad förening eller verksamhetsgrupp"
 
 msgid "Apply for grant as a private person"
 msgstr "Ansök om bidrag som privatperson"

--- a/public/modules/custom/grants_metadata/config/install/grants_metadata.settings.yml
+++ b/public/modules/custom/grants_metadata/config/install/grants_metadata.settings.yml
@@ -8,7 +8,7 @@ third_party_options:
     KASKO: KASKO
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
-    unregistered_community: 'Rekisteröimätön yhdistys'
+    unregistered_community: 'Rekisteröitymätön yhdistys tai ryhmä'
     private_person: 'Yksityishenkilö'
   application_types:
     29:

--- a/public/modules/custom/grants_profile/js/profile_dialog.js
+++ b/public/modules/custom/grants_profile/js/profile_dialog.js
@@ -22,7 +22,7 @@
         }
         if (unset_name) {
           event.preventDefault();
-          event.returnValue = Drupal.t('You need to have a name for your unregistered community. Are you sure you want to leave the form?');
+          event.returnValue = Drupal.t('You need to have a name for your unregistered community or group. Are you sure you want to leave the form?');
         }
         if (current_name != initial_name) {
           event.preventDefault();
@@ -43,7 +43,7 @@
             `<div></div>`,
           ).appendTo('body');
           Drupal.dialog($previewDialog, {
-            title: Drupal.t('You need to have a name for your unregistered community. Please add a name and save or cancel them.'),
+            title: Drupal.t('You need to have a name for your unregistered community or group. Please add a name and save or cancel them.'),
             width: '33%',
             buttons: [
               {

--- a/public/modules/custom/grants_profile/src/TypedData/Definition/GrantsProfileUnregisteredCommunityDefinition.php
+++ b/public/modules/custom/grants_profile/src/TypedData/Definition/GrantsProfileUnregisteredCommunityDefinition.php
@@ -30,7 +30,7 @@ class GrantsProfileUnregisteredCommunityDefinition extends ComplexDataDefinition
       $info['officials'] = ListDataDefinition::create('grants_profile_application_official')
         ->setRequired(FALSE)
         ->setSetting('jsonPath', ['grantsProfile', 'officialsArray'])
-        ->setLabel('Officials of the unregistered community');
+        ->setLabel('Officials of the unregistered community or group');
 
       $info['addresses'] = ListDataDefinition::create('grants_profile_address')
         ->setRequired(TRUE)

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -569,7 +569,7 @@ msgstr 'Sinulla on tallentamattomia muutoksia profiilissasi. Ole hyvä ja tallen
 msgid 'You have unsaved changes in your profile. Are you sure you want to leave the form?'
 msgstr 'Sinulla on tallentamattomia muutoksia profiilissasi. Oletko varma, että haluat lähteä lomakkeelta?'
 
-msgid 'You need to have a name for your unregistered community group. Are you sure you want to leave the form?'
+msgid 'You need to have a name for your unregistered community or group. Are you sure you want to leave the form?'
 msgstr 'Sinulla täytyy olla nimi rekisteröitymättömälle yhteisöllesi tai ryhmällesi. Oletko varma, että haluat lähteä lomakkeelta?'
 
 msgid 'Back to profile'

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -515,11 +515,11 @@ msgstr "Omat yhteystiedot"
 msgid "Select Private person role"
 msgstr "Valitse rooli Yksityishenkilö"
 
-msgid "Select Unregistered community role"
-msgstr "Valitse rooli Rekisteröimätön yhteisö"
+msgid "Select Unregistered community or group role"
+msgstr "Valitse rooli Rekisteröitymätön yhteisö tai ryhmä"
 
-msgid "Add new Unregistered community"
-msgstr "Lisää uusi Rekisteröimätön yhteisö"
+msgid "Add new Unregistered community or group"
+msgstr "Lisää uusi Rekisteröitymätön yhteisö tai ryhmä"
 
 msgid "Select Registered community role and authorize mandate"
 msgstr "Valitse rooli Rekisteröity yhteisö ja tee valtuutus"
@@ -560,8 +560,8 @@ msgstr "Yhteisöllä on avustuksia käsittelyssä."
 msgid "Connection error"
 msgstr "Yhteysvirhe"
 
-msgid 'You need to have a name for your unregistered community. Please add a name and save or cancel them.'
-msgstr 'Sinulla täytyy olla nimi rekisteröimättömälle yhteisöllesi. Lisää nimi ja tallenna tai peruuta ne.'
+msgid 'You need to have a name for your unregistered community or group. Please add a name and save or cancel them.'
+msgstr 'Sinulla täytyy olla nimi rekisteröitymättömälle yhteisöllesi tai ryhmällesi. Lisää nimi ja tallenna tai peruuta ne.'
 
 msgid 'You have unsaved changes in your profile. Please save or cancel them.'
 msgstr 'Sinulla on tallentamattomia muutoksia profiilissasi. Ole hyvä ja tallenna tai peruuta ne.'
@@ -569,8 +569,8 @@ msgstr 'Sinulla on tallentamattomia muutoksia profiilissasi. Ole hyvä ja tallen
 msgid 'You have unsaved changes in your profile. Are you sure you want to leave the form?'
 msgstr 'Sinulla on tallentamattomia muutoksia profiilissasi. Oletko varma, että haluat lähteä lomakkeelta?'
 
-msgid 'You need to have a name for your unregistered community. Are you sure you want to leave the form?'
-msgstr 'Sinulla täytyy olla nimi rekisteröimättömälle yhteisöllesi. Oletko varma, että haluat lähteä lomakkeelta?'
+msgid 'You need to have a name for your unregistered community group. Are you sure you want to leave the form?'
+msgstr 'Sinulla täytyy olla nimi rekisteröitymättömälle yhteisöllesi tai ryhmällesi. Oletko varma, että haluat lähteä lomakkeelta?'
 
 msgid 'Back to profile'
 msgstr 'Takaisin profiiliin'

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -261,11 +261,11 @@ msgstr "Egna kontaktuppgifter"
 msgid "Select Private person role"
 msgstr "Välj rollen som Privatperson"
 
-msgid "Select Unregistered community role"
-msgstr "Välj rollen som Oregistrerad gemenskap"
+msgid "Select Unregistered community role or group"
+msgstr "Välj rollen som Icke-registrerad förening eller verksamhetsgrupp"
 
-msgid "Add new Unregistered community"
-msgstr "Lägg till ny oregistrerad gemenskap"
+msgid "Add new Unregistered community or group"
+msgstr "Lägg till ny Icke-registrerad förening eller verksamhetsgrupp"
 
 msgid "Select Registered community role and authorize mandate"
 msgstr "Välj rollen som Registrerad gemenskap och auktorisera fullmakt"
@@ -322,8 +322,8 @@ msgstr "Föreningen har pågående ansökningar."
 msgid "Connection error"
 msgstr "Anslutningsfel"
 
-msgid 'You need to have a name for your unregistered community. Please add a name and save or cancel them.'
-msgstr 'Du måste ha ett namn för din oregistrerade gemenskap. Vänligen lägg till ett namn och spara eller avbryt dem.'
+msgid 'You need to have a name for your unregistered community or group. Please add a name and save or cancel them.'
+msgstr 'Du måste ha ett namn för din icke-registrerad förening eller verksamhetsgrupp. Vänligen lägg till ett namn och spara eller avbryt dem.'
 
 msgid 'You have unsaved changes in your profile. Please save or cancel them.'
 msgstr 'Du har osparade ändringar i din profil. Spara eller avbryt dem.'
@@ -331,8 +331,8 @@ msgstr 'Du har osparade ändringar i din profil. Spara eller avbryt dem.'
 msgid 'You have unsaved changes in your profile. Are you sure you want to leave the form?'
 msgstr 'Du har osparade ändringar i din profil. Är du säker på att du vill lämna formuläret?'
 
-msgid 'You need to have a name for your unregistered community. Are you sure you want to leave the form?'
-msgstr 'Du måste ha ett namn för din oregistrerade gemenskap. Är du säker på att du vill lämna formuläret?'
+msgid 'You need to have a name for your unregistered community or group. Are you sure you want to leave the form?'
+msgstr 'Du måste ha ett namn för din icke-registrerad förening eller verksamhetsgrupp. Är du säker på att du vill lämna formuläret?'
 
 msgid 'Back to profile'
 msgstr 'Tillbaka till profilen'

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -261,7 +261,7 @@ msgstr "Egna kontaktuppgifter"
 msgid "Select Private person role"
 msgstr "Välj rollen som Privatperson"
 
-msgid "Select Unregistered community role or group"
+msgid "Select Unregistered community or group role"
 msgstr "Välj rollen som Icke-registrerad förening eller verksamhetsgrupp"
 
 msgid "Add new Unregistered community or group"


### PR DESCRIPTION
# [AU-1281](https://helsinkisolutionoffice.atlassian.net/browse/AU-1281)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change the way unregistered company is written on site in all three languages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1281-unregistered-community-text`
  * `make fresh`
  * `make drush-gwi`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Switch language to English
* [ ] Log in, select unregistered community or group as role.
* [ ] Go through the site, see that all instance of "Unregistered community" are now "Unregistered community or group"
* [ ] Switch language to Finnish
* [ ] Log out, log in, select "Rekisteröitymätön yhdistys tai ryhmä" as role
* [ ] Go through the site, see that all instance of "Rekisteröimätön yhdistys" are now "Rekisteröitymätön yhdistys tai ryhmä"
* [ ] Switch language to Swedish
* [ ] Log out, log in, select "Icke-registrerad förening eller verksamhetsgrupp" as role
* [ ] Go through the site, see that all instance of "Oregistrerad gemenskap" are now "Icke-registrerad förening eller verksamhetsgrupp"
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1281]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ