### PR TITLE
Feature/AU-1272: Webform translations import

### DIFF
--- a/public/modules/custom/grants_webform_import/src/Commands/WebformImportCommands.php
+++ b/public/modules/custom/grants_webform_import/src/Commands/WebformImportCommands.php
@@ -270,6 +270,7 @@ class WebformImportCommands extends DrushCommands {
    * translations from to configuration directory.
    *
    * @throws \Exception
+   *   Exception on import fail.
    */
   private function importWebformTranslations() {
     $directory = Settings::get('config_sync_directory');

--- a/public/modules/custom/grants_webform_import/src/Commands/WebformImportCommands.php
+++ b/public/modules/custom/grants_webform_import/src/Commands/WebformImportCommands.php
@@ -164,6 +164,7 @@ class WebformImportCommands extends DrushCommands {
   public function webformImport() {
     $directory = Settings::get('config_sync_directory');
     $webformFiles = glob($directory . '/webform.webform.*');
+
     if (!$webformFiles) {
       return;
     }
@@ -179,11 +180,11 @@ class WebformImportCommands extends DrushCommands {
    * @throws \Exception
    */
   public function import(array $files) {
-
     $ymlFile = new Parser();
     $source_storage = new StorageReplaceDataWrapper(
       $this->storage
     );
+
     foreach ($files as $file) {
       $name = Path::getFilenameWithoutExtension($file);
       $value = $ymlFile->parse(file_get_contents($file));
@@ -198,6 +199,7 @@ class WebformImportCommands extends DrushCommands {
     if ($this->configImport($storageComparer)) {
       $names = implode(', ', $files);
       $this->output()->writeln("Successfully imported $names");
+      $this->importWebformTranslations();
     }
     else {
       throw new \Exception("Failed importing files");
@@ -258,6 +260,46 @@ class WebformImportCommands extends DrushCommands {
       catch (ConfigImporterException $e) {
         return FALSE;
       }
+    }
+  }
+
+  /**
+   * The importWebformTranslations method.
+   *
+   * This method imports English and Swedish Webform
+   * translations from to configuration directory.
+   *
+   * @throws \Exception
+   */
+  private function importWebformTranslations() {
+    $directory = Settings::get('config_sync_directory');
+    $parser = new Parser();
+
+    $webformTranslationFiles = [
+      'en' => glob($directory . '/language/en/webform.webform.*'),
+      'sv' => glob($directory . '/language/sv/webform.webform.*'),
+    ];
+
+    try {
+      foreach ($webformTranslationFiles as $language => $files) {
+        foreach ($files as $file) {
+          $name = Path::getFilenameWithoutExtension($file);
+          $configFileValue = $parser->parse(file_get_contents($file));
+
+          /** @var \Drupal\language\Config\LanguageConfigOverride $languageOverride */
+          $languageOverride = \Drupal::languageManager()->getLanguageConfigOverride($language, $name);
+          $languageOverrideValue = $languageOverride->get();
+
+          if ($configFileValue && $languageOverrideValue) {
+            $languageOverride->setData($configFileValue);
+            $languageOverride->save();
+            $this->output()->writeln("Successfully imported the following translation: $file");
+          }
+        }
+      }
+    }
+    catch (\Exception $e) {
+      throw new \Exception("Failed importing translations.");
     }
   }
 


### PR DESCRIPTION
# [AU-1271](https://helsinkisolutionoffice.atlassian.net/browse/AU-1272)

## What was done
This pull request implements changes to the `WebformImportCommands.php` file. These changes make it possible to import both English and Swedish Webform translations.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout feature/AU-1272-webform-translations-import`
  * `make fresh`
  * `make drush-cr`

## How to test
After your environment is up and running, go and make changes to any `webform.webform.*` files in either the `/cmi/language/en` or `/cmi/language/sv` directory. These changes should simulate a change in the translations. 

For example, change the values in `/cmi/language/en/webform.webform.kuva_projekti.yml`

from
```
elements: |
  1_hakijan_tiedot:
    '#title': '1. Applicant details'
    '#prev_button_label': '< Previous'
    '#next_button_label': 'Next >'
```

to
```
elements: |
  1_hakijan_tiedot:
    '#title': '1. Applicant details come here'
    '#prev_button_label': '< Go back'
    '#next_button_label': 'Next page >'
```

Now run `drush gwi`. Check that the modified translations have been imported through the Webform admin UI.

## Things to note
I tried to inject the `\Drupal::languageManager()` as a dependency for the class, but got an error every time i tried it. If you can get it to work, then be my guest!



[AU-1271]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ