### PR TITLE
fix: AU-1361, AU-1362: fix liikunnan yleisavustus

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_yleisavustushakemus.yml
@@ -56,13 +56,12 @@ elements: |
     '#title': 'Types of grant'
   subventions:
     '#title': Grants
-  markup_01:
-    '#markup': '<p>Only apply for one grant type at a time with each application.</p>'
   kayttotarkoitus:
     '#title': 'Purpose of use'
   compensation_purpose:
     '#title': 'Brief description of the purpose(s) of the grant(s) applied for'
-    '#help': 'Indicate the purpose for which the grant is applied for. If necessary, specify the different uses. For a targeted grant application, detailed information is provided with a separate Webropol form (a mandatory appendix).'
+    '#description': 'Indicate the purpose for which the grant is applied for. If necessary, specify the different uses.'
+    '#help': 'For a targeted grant application, detailed information is provided with a separate Webropol form (a mandatory appendix).'
     '#counter_maximum_message': '%d/5000 characters remaining'
   lisatiedot_ja_liitteet:
     '#title': '3. Additional information and appendices'

--- a/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
@@ -60,13 +60,12 @@ elements: |
     '#title': Understödskategorier
   subventions:
     '#title': Understöd
-  markup_01:
-    '#markup': '<p>Ans&ouml;k alltid endast om en typ av underst&ouml;d &aring;t g&aring;ngen.</p>'
   kayttotarkoitus:
     '#title': Användningsändamål
   compensation_purpose:
     '#title': 'En kort beskrivning av användningsändamålet för det/de understöd som ansöks'
-    '#help': 'Ange f&ouml;r vilket &auml;ndam&aring;l underst&ouml;det ans&ouml;ks och vid behov specificera de olika &auml;ndam&aring;len. Med ans&ouml;kan om riktat underst&ouml;d, ska den mer detaljerade informationen avges med en separat Webropol-blankett (en erforderlig bilaga).'
+    '#description': 'Ange f&ouml;r vilket &auml;ndam&aring;l underst&ouml;det ans&ouml;ks och vid behov specificera de olika &auml;ndam&aring;len.'
+    '#help': 'Med ans&ouml;kan om riktat underst&ouml;d, ska den mer detaljerade informationen avges med en separat Webropol-blankett (en erforderlig bilaga).'
     '#counter_maximum_message': '%d/5000 tecken kvar'
   lisatiedot_ja_liitteet:
     '#title': '3. Ytterligare information och bilagor'

--- a/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
@@ -152,7 +152,7 @@ elements: |-
       '#states':
         visible:
           ':input[name="applicant_type"]':
-            'value': registered_community
+            value: registered_community
       community_address:
         '#type': community_address_composite
         '#title': 'Yhteisön osoite'
@@ -164,7 +164,7 @@ elements: |-
         '#states':
           visible:
             ':input[name="applicant_type"]':
-              'value': registered_community
+              value: registered_community
     tilinumero:
       '#type': webform_section
       '#title': Tilinumero
@@ -249,16 +249,14 @@ elements: |-
         '#subvention_type_id__access': false
         '#subvention_type__title': Avustuslaji
         '#subvention_amount__title': 'Avustuksen summa'
-      markup_01:
-        '#type': webform_markup
-        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
     kayttotarkoitus:
       '#type': webform_section
       '#title': Käyttötarkoitus
       compensation_purpose:
         '#type': textarea
         '#title': 'Lyhyt kuvaus haettavan avustuksen käyttötarkoituksista'
-        '#help': 'Kerro mit&auml; tarkoitusta varten avustusta haetaan, erittele tarvittaessa eri k&auml;ytt&ouml;kohteet. Kohdeavustuksen osalta tarkemmat tiedot kysyt&auml;&auml;n Webropol-lomakkeella (pakollinen liite)'
+        '#description': 'Kerro mit&auml; tarkoitusta varten avustusta haetaan, erittele tarvittaessa eri k&auml;ytt&ouml;kohteet.'
+        '#help': 'Kohdeavustuksen osalta tarkemmat tiedot kysyt&auml;&auml;n Webropol-lomakkeella (pakollinen liite)'
         '#maxlength': 5000
         '#required': true
         '#counter_type': character

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -40,9 +40,6 @@ msgstr "Yhteisön viralliset tiedot"
 msgid "Company name"
 msgstr "Yhteisön nimi"
 
-msgid "Name"
-msgstr "Nimi"
-
 msgid "Name of association"
 msgstr "Yhteisön nimi"
 

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -40,6 +40,9 @@ msgstr "Yhteisön viralliset tiedot"
 msgid "Company name"
 msgstr "Yhteisön nimi"
 
+msgid "Name"
+msgstr "Nimi"
+
 msgid "Name of association"
 msgstr "Yhteisön nimi"
 

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -21,6 +21,9 @@ msgstr "Grundläggande information"
 msgid "Name of association"
 msgstr "Sammanslutningens namn"
 
+msgid "Name"
+msgstr "Namn"
+
 msgid "Business ID"
 msgstr "FO-nummer"
 

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -138,9 +138,6 @@ msgstr "Ta bort profilen"
 msgid "Edit community information"
 msgstr "Redigera gemenskaps uppgifter"
 
-msgid "Name"
-msgstr "Namn"
-
 msgid "Role"
 msgstr "Roll"
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* [AU-1361](https://helsinkisolutionoffice.atlassian.net/browse/AU-1361): Remove extra info text from grants
* [AU-1362](https://helsinkisolutionoffice.atlassian.net/browse/AU-1362): Move text from description to tooltip

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-liikunnan-yleis`
  * `make fresh`
* Run `make drush-cr`


[AU-1361]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1362]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ