### PR TITLE
fix: AU-1289: add print button to completion page

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1489,6 +1489,16 @@ function grants_handler_preprocess_grants_handler_completion(&$variables) {
       'label' => t('View Application'),
       'theme_hook_original' => '',
     ]);
+  $variables['printApplicationLink'] = twig_render_template(
+    $theme_path . '/templates/navigation/link-button.html.twig',
+    [
+      'type' => 'secondary',
+      'icon' => TRUE,
+      'icon_type' => 'printer',
+      'url' => Url::fromRoute('grants_webform_print.submission_print', ['submission_id' => $variables["submissionId"]]),
+      'label' => t('Print application'),
+      'theme_hook_original' => '',
+    ]);
 
   try {
     $submissionObject = $variables['submissionObject'];

--- a/public/modules/custom/grants_handler/templates/grants-handler-completion.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-handler-completion.html.twig
@@ -51,6 +51,7 @@
       <div class="grants-handler__completion__button-row">
         {{ ownApplicationsLink }}
         {{ viewApplicationLink }}
+        {{ printApplicationLink }}
       </div>
     </div>
   </div>

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -107,7 +107,7 @@ msgid "Attachment description"
 msgstr "Beskrivning av bilagan"
 
 msgid "Print application"
-msgstr "Visa ansökan"
+msgstr "Skriv ut ansökan"
 
 msgid "Copy application"
 msgstr "Använd som mall"


### PR DESCRIPTION
# [AU-1289](https://helsinkisolutionoffice.atlassian.net/browse/AU-1289)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add print button to completion page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1289-kiitossivu`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this button works for you too

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/13e220ae-9109-494f-974f-a24b5f9f510a)

[AU-1289]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ