### PR TITLE
fix: AU-1364, AU-1365: fix nuoriso palkkaennakko

### DIFF
--- a/conf/cmi/language/en/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/language/en/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -54,7 +54,7 @@ elements: |
   subventions:
     '#title': Grants
   markup:
-    '#markup': '<p>Only apply for one grant type at a time with each application.</p>'
+    '#markup': "<p>&nbsp;</p>\r\n\r\n<p>Choose the type of grant you are applying for. You can also choose both if you apply for both. Also state here how much you are applying for a grant. Enter the application amount as a whole number and in euros. The application amount is announced separately for both grant types.</p>"
   edellisen_avustuksen_kayttoselvitys:
     '#title': 'Report on the use of the previous grant'
   yhdistyksen_kuluvan_vuoden_toiminta_avustus:

--- a/conf/cmi/language/en/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/language/en/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -70,7 +70,8 @@ elements: |
     '#title': 'Statement on the use of the salary allowance for the current year'
     '#help': 'Indicate here how much the association has used and will use in the current year&#39;s salary subsidy. The announced number is always partly an estimate, because the year is still in progress.'
   sanallinen_selvitys_avustuksen_kaytosta:
-    '#title': ' A verbal explanation of the use of the grant'
+    '#title': ' Description of the use of the current year''s grant'
+    '#help': 'If you wish, please tell us in more detail about the use of the current year&#39;s operating and salary grant or start-up grant and the estimates for the rest of the year.'
   lisatiedot_ja_liitteet:
     '#title': '7. Additional information and appendices'
   lisatietoja_hakemukseen_liittyen:

--- a/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -57,7 +57,7 @@ elements: |
   subventions:
     '#title': Understöd
   markup:
-    '#markup': '<p>Ans&ouml;k alltid endast om en typ av underst&ouml;d &aring;t g&aring;ngen.</p>'
+    '#markup': "<p>&nbsp;</p>\r\n\r\n<p>V&auml;lj vilken typ av hj&auml;lpmedel du ans&ouml;ker om. Du kan ocks&aring; v&auml;lja b&aring;da om du ans&ouml;ker om b&aring;da. Ange &auml;ven h&auml;r hur mycket du ans&ouml;ker om assistans. Ange ans&ouml;kningsbeloppet som ett heltal och i euro. Ans&ouml;kningsbeloppet meddelas separat f&ouml;r b&aring;da bidragstyperna.</p>"
   edellisen_avustuksen_kayttoselvitys:
     '#title': 'Redogörelse för användning av det tidigare bidraget'
   yhdistyksen_kuluvan_vuoden_toiminta_avustus:
@@ -73,7 +73,8 @@ elements: |
     '#title': 'Utlåtande över utnyttjandet av lönebidraget för innevarande år'
     '#help': 'Ange h&auml;r hur mycket f&ouml;reningen har anv&auml;nt och kommer att anv&auml;nda i innevarande &aring;rs l&ouml;nebidrag. Det aviserade antalet &auml;r alltid delvis en uppskattning, eftersom &aring;ret fortfarande p&aring;g&aring;r.'
   sanallinen_selvitys_avustuksen_kaytosta:
-    '#title': 'En muntlig förklaring av användningen av bidraget'
+    '#title': ' Beskrivning av användningen av innevarande års bidrag'
+    '#help': 'Ber&auml;tta om du &ouml;nskar mer utf&ouml;rligt om anv&auml;ndningen av innevarande &aring;rs drift- och l&ouml;nebidrag eller startbidrag samt uppskattningarna f&ouml;r resten av &aring;ret.'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:

--- a/conf/cmi/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -189,7 +189,7 @@ elements: |-
       '#states':
         visible:
           ':input[name="applicant_type"]':
-            'value': registered_community
+            value: registered_community
       community_address:
         '#type': community_address_composite
         '#title': 'Yhteisön osoite'
@@ -201,7 +201,7 @@ elements: |-
         '#states':
           visible:
             ':input[name="applicant_type"]':
-              'value': registered_community
+              value: registered_community
     tilinumero:
       '#type': webform_section
       '#title': Tilinumero
@@ -281,7 +281,7 @@ elements: |-
         '#subvention_amount__title': 'Avustuksen summa'
       markup:
         '#type': webform_markup
-        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
+        '#markup': '<p>Valitse se avustuslaji jota haette. Voit valita my&ouml;s molemmat, jos haette molempia. Kerro t&auml;ss&auml; my&ouml;s, kuinka paljon haette avustusta. Ilmoita hakusumma kokonaislukuna ja euroissa. Hakusumma ilmoitetaan molemmille avustuslajeille erikseen.</p>'
     edellisen_avustuksen_kayttoselvitys:
       '#type': webform_section
       '#title': 'Edellisen avustuksen käyttöselvitys'
@@ -292,7 +292,7 @@ elements: |-
       selvitys_kuluvan_vuoden_toiminta_avustuksen_kaytosta:
         '#type': number
         '#title': 'Selvitys kuluvan vuoden toiminta-avustuksen käytöstä'
-        '#help': 'Ilmoita t&auml;ss&auml;, kuinka paljon yhdistys on k&auml;ytt&auml;nyt ja k&auml;ytt&auml;&auml; kuluvan vuoden toiminta-avustusta. Ilmoitettu luku on aina osittain arvio, koska vuosi on viel&auml; kesken.&nbsp;&nbsp;'
+        '#help': 'Ilmoita t&auml;ss&auml; euroina yhteens&auml;, kuinka paljon yhdistys on k&auml;ytt&auml;nyt ja k&auml;ytt&auml;&auml; kuluvan vuoden toiminta-avustusta. Ilmoitettu luku on aina osittain arvio, koska vuosi on viel&auml; kesken.&nbsp;&nbsp;'
       yhdistyksen_kuluvan_vuoden_palkkausavustus_:
         '#type': number
         '#title': 'Yhdistyksen kuluvan vuoden palkkausavustus '
@@ -300,10 +300,11 @@ elements: |-
       selvitys_kuluvan_vuoden_palkkausavustuksen_kaytosta:
         '#type': number
         '#title': 'Selvitys kuluvan vuoden palkkausavustuksen käytöstä'
-        '#help': 'Ilmoita t&auml;ss&auml;, kuinka paljon yhdistys on k&auml;ytt&auml;nyt ja k&auml;ytt&auml;&auml; kuluvan vuoden palkkausavustusta. Ilmoitettu luku on aina osittain arvio, koska vuosi on viel&auml; kesken.&nbsp;&nbsp;'
+        '#help': 'Ilmoita t&auml;ss&auml; euroina yhteens&auml;, kuinka paljon yhdistys on k&auml;ytt&auml;nyt ja k&auml;ytt&auml;&auml; kuluvan vuoden palkkausavustusta. Ilmoitettu luku on aina osittain arvio, koska vuosi on viel&auml; kesken.&nbsp;&nbsp;'
       sanallinen_selvitys_avustuksen_kaytosta:
         '#type': textarea
-        '#title': 'Sanallinen selvitys avustuksen käytöstä'
+        '#title': 'Kuvaus kuluvan vuoden avustuksen käytöstä'
+        '#help': 'Kerro t&auml;ss&auml; halutessasi tarkemmin kuluvan vuoden toiminta- ja palkkausavustuksen tai starttiavustuksen k&auml;yt&ouml;st&auml; ja arvioista loppuvuoden osalta.'
   lisatiedot_ja_liitteet:
     '#type': webform_wizard_page
     '#title': '3. Lisätiedot ja liitteet'
@@ -313,14 +314,14 @@ elements: |-
       additional_information:
         '#type': textarea
         '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen.'
+        '#maxlength': 5000
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
         '#attributes':
           class:
             - webform--large
-        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
-        '#counter_type': character
-        '#maxlength': 5000
-        '#counter_maximum': 5000
-        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
         '#cols': 63
     liitteet:
       '#type': webform_section


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* [AU-1364](https://helsinkisolutionoffice.atlassian.net/browse/AU-1364): fix grant text
* [AU-1365](https://helsinkisolutionoffice.atlassian.net/browse/AU-1365): fix text in verbal explanation field

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-nuoriso-palkkaus`
  * `make fresh`
* Run `make drush-cr`


[AU-1364]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1365]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ