### PR TITLE
fix: AU-1369: Fix some toimintaryhma issues

### DIFF
--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -22,10 +22,9 @@ third_party_settings:
     disableCopying: 0
     applicationTypeSelect: '48'
     applicationIndustry: KUVA
-    applicationActingYears:
-      2023: '2023'
-      2024: '2024'
-      2025: '2025'
+    applicationActingYears: {  }
+    applicationActingYearsType: current_and_next_x_years
+    applicationActingYearsNextCount: '1'
 weight: 0
 open: null
 close: null

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -146,7 +146,7 @@ elements: |-
       '#states':
         visible:
           ':input[name="applicant_type"]':
-            'value': registered_community
+            value: registered_community
       contact_markup:
         '#type': webform_markup
         '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
@@ -159,7 +159,7 @@ elements: |-
         '#states':
           required:
             ':input[name="applicant_type"]':
-              'value': registered_community
+              value: registered_community
     contact_person_section:
       '#type': webform_section
       '#title': 'Hakemuksen yhteyshenkilö'
@@ -191,7 +191,7 @@ elements: |-
       '#states':
         visible:
           ':input[name="applicant_type"]':
-            'value': registered_community
+            value: registered_community
       community_address:
         '#type': community_address_composite
         '#title': 'Yhteisön osoite'
@@ -203,7 +203,7 @@ elements: |-
         '#states':
           visible:
             ':input[name="applicant_type"]':
-              'value': registered_community
+              value: registered_community
     tilinumero:
       '#type': webform_section
       '#title': Tilinumero
@@ -675,6 +675,9 @@ elements: |-
         '#free__access': false
         '#isOthersUse__access': false
         '#isOwnedByApplicant__access': false
+        '#isOwnedByCity__title': 'Kyseessä on kaupungin omistama tila'
+        '#citySection__access': false
+        '#premiseSuitability__access': false
     aikataulu:
       '#type': webform_section
       '#title': Aikataulu

--- a/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
+++ b/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
@@ -125,7 +125,7 @@ class ApplicantInfoService {
        * are inside the applicant info component
        */
 
-      if ($arguments["submittedData"]["hakijan_tiedot"]) {
+      if (isset($arguments["submittedData"]["hakijan_tiedot"]) && $arguments["submittedData"]["hakijan_tiedot"]) {
         $addressPath = [
           'compensation',
           'currentAddressInfoArray',

--- a/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
+++ b/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
@@ -46,6 +46,8 @@ class ApplicantInfoService {
    *
    * @return array
    *   Parsed values.
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function processApplicantInfo(ComplexDataInterface $property, array $arguments): array {
 
@@ -125,43 +127,56 @@ class ApplicantInfoService {
        * are inside the applicant info component
        */
 
-      if (isset($arguments["submittedData"]["hakijan_tiedot"]) && $arguments["submittedData"]["hakijan_tiedot"]) {
+      $roleId = $this->grantsProfileService->getSelectedRoleData();
+      $profile = $this->grantsProfileService->getGrantsProfileContent($roleId);
+
+      if ($profile) {
         $addressPath = [
           'compensation',
           'currentAddressInfoArray',
         ];
 
+        $responsibles = array_filter($profile["officials"], fn($item) => $item['role'] == '11');
+        $responsible = reset($responsibles);
+
         $addressElement = [
           [
             'ID' => 'street',
-            'value' => $arguments["submittedData"]["hakijan_tiedot"]["street"],
+            'value' => $profile["addresses"][0]["street"],
             'valueType' => 'string',
             'label' => 'Katuosoite',
           ],
           [
             'ID' => 'city',
-            'value' => $arguments["submittedData"]["hakijan_tiedot"]["city"],
+            'value' => $profile["addresses"][0]["city"],
             'valueType' => 'string',
             'label' => 'Postitoimipaikka',
           ],
           [
             'ID' => 'postCode',
-            'value' => $arguments["submittedData"]["hakijan_tiedot"]["postCode"],
+            'value' => $profile["addresses"][0]["postCode"],
             'valueType' => 'string',
             'label' => 'Postinumero',
           ],
           [
             'ID' => 'country',
-            'value' => $arguments["submittedData"]["hakijan_tiedot"]["country"],
+            'value' => $profile["addresses"][0]["country"],
             'valueType' => 'string',
             'label' => 'Postinumero',
           ],
-          // Add contact person from user data as well.
+          // Add contact person from user data.
           [
             'ID' => 'contactPerson',
-            'value' => $arguments["submittedData"]["hakijan_tiedot"]["firstname"] . ' ' . $arguments["submittedData"]["hakijan_tiedot"]["lastname"],
+            'value' => $responsible["name"] ?? '',
             'valueType' => 'string',
             'label' => 'Yhteyshenkilö',
+          ],
+          // Add phone from user data.
+          [
+            'ID' => 'phoneNumber',
+            'value' => $responsible["phone"] ?? '',
+            'valueType' => 'string',
+            'label' => 'Puhelinnumero',
           ],
         ];
 
@@ -181,7 +196,7 @@ class ApplicantInfoService {
           ],
           [
             'ID' => 'email',
-            'value' => $arguments["submittedData"]["hakijan_tiedot"]["email"],
+            'value' => $responsible["email"],
             'valueType' => 'string',
             'label' => 'Sähköpostiosoite',
           ]);

--- a/public/modules/custom/grants_applicant_info/src/Plugin/WebformElement/ApplicantInfoComposite.php
+++ b/public/modules/custom/grants_applicant_info/src/Plugin/WebformElement/ApplicantInfoComposite.php
@@ -64,7 +64,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       if (isset($element["#webform_composite_elements"][$fieldName])) {
         $webformElement = $element["#webform_composite_elements"][$fieldName];
         if ($webformElement && isset($webformElement['#title'])) {
-          $lines[] = $webformElement['#title']->render();
+          $lines[] = '<strong>' . $webformElement['#title']->render() . '</strong>';
           $lines[] = $fieldValue;
         }
       }

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1520,7 +1520,7 @@ function grants_handler_preprocess_message_list_item(&$variables) {
     $markReadLink = Link::createFromRoute(t('Mark as read'), 'grants_handler.message_read',
       [
         'message_id' => $message['messageId'],
-        'application_number' => $message['caseId'],
+        'submission_id' => $message['caseId'],
       ],
       [
         'query' => [

--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/CommunityOfficialsComposite.php
@@ -40,12 +40,23 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
   protected function formatTextItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []): array {
     $value = $this->getValue($element, $webform_submission, $options);
     $roles = GrantsProfileFormRegisteredCommunity::getOfficialRoles();
-    return [
-      '' . $roles[(int) $value['role']],
-      $value['name'],
-      $value['email'],
-      $value['phone'],
-    ];
+
+    if (array_key_exists((int) $value['role'], $roles)) {
+      return [
+        '' . $roles[(int) $value['role']] ?? '',
+        $value['name'],
+        $value['email'],
+        $value['phone'],
+      ];
+    }
+    else {
+      return [
+        $value['name'],
+        $value['email'],
+        $value['phone'],
+      ];
+    }
+
   }
 
 }

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -464,5 +464,5 @@ msgstr "Tutustuthan ohjeistukseen tällä sivulla ennen hakemukselle siirtymist�
 msgid "Are you applying for a start grant?"
 msgstr "Haetko starttiavustusta?"
 
-msgid "You must apply for the "@subventionType"
+msgid "You must apply for the @subventionType"
 msgstr "@subventionType on määritelty pakolliseksi hakea"

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -451,6 +451,10 @@ class AtvSchema {
         if ($addWebformToCallback) {
           $propertyStructureCallback['arguments']['webform'] = $webform;
         }
+        $addSubmittedDataToCallback2 = $propertyStructureCallback['submittedData'] ?? FALSE;
+        if ($addSubmittedDataToCallback2) {
+          $propertyStructureCallback['arguments']['submittedData'] = $submittedFormData;
+        }
       }
 
       if ($fullItemValueCallback) {

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -29,19 +29,18 @@ trait ApplicationDefinitionTrait {
       ->setSetting('propertyStructureCallback', [
         'service' => 'grants_applicant_info.service',
         'method' => 'processApplicantInfo',
+        'webform' => TRUE,
+        'submittedData' => TRUE,
       ])
       ->setSetting('webformDataExtracter', [
         'service' => 'grants_applicant_info.service',
         'method' => 'extractDataForWebform',
-      ])
-      ->setSetting('fieldsForApplication', [
-        'premiseName',
-        'isOwnedByCity',
-        'postCode',
       ]);
 
-    // Both communities.
-    if ($applicantType === 'registered_community' || $applicantType === 'unregistered_community') {
+    /*
+     * Registered community
+     */
+    if ($applicantType === 'registered_community') {
 
       $info['email'] = DataDefinition::create('email')
         ->setLabel('Sähköpostiosoite')
@@ -130,7 +129,16 @@ trait ApplicationDefinitionTrait {
         ->setSetting('defaultValue', 'Suomi');
     }
 
+    /*
+     * Unregistered community.
+     */
     if ($applicantType === 'unregistered_community') {
+      $info['community_officials'] = ListDataDefinition::create('grants_profile_application_official')
+        // ->setRequired(TRUE)
+        ->setSetting('jsonPath', ['compensation', 'applicantOfficialsArray'])
+        ->setSetting('defaultValue', [])
+        ->setLabel('applicantOfficialsArray');
+
       $info['account_number_owner_name'] = DataDefinition::create('string')
         ->setLabel('accountNumber')
         ->setSetting('jsonPath', [

--- a/public/modules/custom/grants_profile/grants_profile.module
+++ b/public/modules/custom/grants_profile/grants_profile.module
@@ -46,6 +46,7 @@ function grants_profile_theme(): array {
       'userData' => NULL,
       'editProfileLink' => NULL,
       'deleteProfileLink' => NULL,
+      'roles' => NULL,
     ],
   ];
   $theme['own_profile_registered_community'] = [
@@ -332,6 +333,7 @@ function grants_profile_preprocess_own_profile_unregistered_community(&$variable
     '#theme' => 'grants_profile__basic_info__private_person',
     '#myProfile' => $helsinkiProfileContent['myProfile'],
     '#editHelsinkiProfileLink' => $editHelsinkiProfileLink,
+    '#roles' => GrantsProfileFormRegisteredCommunity::getOfficialRoles(),
   ];
 }
 

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -42,6 +42,7 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
       8 => t('Deputy chairperson'),
       9 => t('Chief executive officer'),
       10 => t('Producer'),
+      11 => t('Responsible person'),
     ];
   }
 

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -422,6 +422,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
     }
 
     $this->validateBankAccounts($values, $formState);
+    $this->validateOfficials($values, $formState);
 
     parent::validateForm($form, $formState);
 
@@ -1132,6 +1133,31 @@ rtf, txt, xls, xlsx, zip.'),
       }
     }
     return $values;
+  }
+
+  /**
+   * Validate officials for toimintaryhmä.
+   *
+   * Make sure officials have atleast one responsible person added.
+   *
+   * @param array $values
+   *   Cleaned form values.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   Form state object.
+   */
+  public function validateOfficials(array $values, FormStateInterface $formState): void {
+    // Do we have responsibles?
+    $responsibles = array_filter($values["officialWrapper"], fn($item) => $item['role'] == '11');
+
+    // If no, then show error on every official added.
+    if (empty($responsibles)) {
+      foreach ($values["officialWrapper"] as $key => $element) {
+        $elementName = 'officialWrapper][' . $key . '][official][role';
+        $formState->setErrorByName($elementName, $this->t('@fieldname must have one responsible person selected', [
+          '@fieldname' => 'Official roles',
+        ]));
+      }
+    }
   }
 
   /**

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -704,6 +704,10 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
       $officials = [];
     }
 
+    $roles = [
+      0 => $this->t('Select'),
+    ] + GrantsProfileFormRegisteredCommunity::getOfficialRoles();
+
     $officialValues = $formState->getValue('officialWrapper') ?? $officials;
     unset($officialValues['actions']);
     foreach ($officialValues as $delta => $official) {
@@ -721,6 +725,12 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
           '#required' => TRUE,
           '#title' => $this->t('Name'),
           '#default_value' => $official['name'],
+        ],
+        'role' => [
+          '#type' => 'select',
+          '#options' => $roles,
+          '#title' => $this->t('Role'),
+          '#default_value' => $official['role'],
         ],
         'email' => [
           '#type' => 'textfield',
@@ -764,6 +774,11 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Name'),
+        ],
+        'role' => [
+          '#type' => 'select',
+          '#options' => $roles,
+          '#title' => $this->t('Role'),
         ],
         'email' => [
           '#type' => 'textfield',

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -584,13 +584,14 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
     ];
 
     $addressValues = $formState->getValue('addressWrapper') ?? $addresses;
+
     unset($addressValues['actions']);
     foreach ($addressValues as $delta => $address) {
       if (array_key_exists('address', $address)) {
         $address = $address['address'];
       }
       // Make sure we have proper UUID as address id.
-      if (!$this->isValidUuid($address['address_id'])) {
+      if (!isset($address['address_id']) || !$this->isValidUuid($address['address_id'])) {
         $address['address_id'] = Uuid::uuid4()->toString();
       }
 
@@ -730,7 +731,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
           '#type' => 'select',
           '#options' => $roles,
           '#title' => $this->t('Role'),
-          '#default_value' => $official['role'],
+          '#default_value' => $official['role'] ?? 11,
         ],
         'email' => [
           '#type' => 'textfield',

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -457,6 +457,8 @@ class GrantsProfileService {
    *
    * @return array
    *   Profile content with required fields.
+   *
+   * @throws \Drupal\helfi_helsinki_profiili\TokenExpiredException
    */
   public function initGrantsProfileUnRegisteredCommunity(array $selectedCompanyData, array $profileContent): array {
 
@@ -465,7 +467,24 @@ class GrantsProfileService {
     }
 
     if (!isset($profileContent['addresses'])) {
-      $profileContent['addresses'] = [];
+
+      $hpData = $this->helsinkiProfiili->getUserProfileData();
+
+      $newAddress = [];
+      if ($hpData["myProfile"]["primaryAddress"]) {
+        $profileContent['addresses'][] = $hpData["myProfile"]["primaryAddress"];
+      }
+      elseif ($hpData["myProfile"]["verifiedPersonalInformation"]["permanentAddress"]) {
+        $profileContent['addresses'][] = [
+          'street' => $hpData["myProfile"]["verifiedPersonalInformation"]["permanentAddress"]["streetAddress"],
+          'postCode' => $hpData["myProfile"]["verifiedPersonalInformation"]["permanentAddress"]["postalCode"],
+          'city' => $hpData["myProfile"]["verifiedPersonalInformation"]["permanentAddress"]["postOffice"],
+          'country' => 'Suomi',
+        ];
+      }
+      else {
+        $profileContent['addresses'] = [];
+      }
     }
     if (!isset($profileContent['officials'])) {
       $profileContent['officials'] = [];

--- a/public/modules/custom/grants_profile/templates/own-profile-unregistered-community.html.twig
+++ b/public/modules/custom/grants_profile/templates/own-profile-unregistered-community.html.twig
@@ -33,6 +33,7 @@
             <dd class="grants-profile--officials-item">
               <span>
                 <strong>{{ official.name }}</strong><br>
+                {{ roles[official.role] }}<br>
                 {{ official.phone }}<br>
                 {{ official.email }}
               </span>

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -595,3 +595,6 @@ msgstr "Osoitteen tulee olla sinun virallinen osoitteesi. Yksi osoite on pakolli
 
 msgid "You can only fill in your own bank account information."
 msgstr "Voit antaa vain oman tilisi tiedot."
+
+msgid "Responsible person"
+msgstr "Vastuuhenkilö"

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -357,3 +357,6 @@ msgstr "Adressen måste vara din officiella adress. En adress är obligatorisk i
 
 msgid "You can only fill in your own bank account information."
 msgstr "Du kan bara fylla i dina egna bankkontouppgifter."
+
+msgid "Responsible person"
+msgstr "Ansvarsfull person"


### PR DESCRIPTION
# [AU-1369](https://helsinkisolutionoffice.atlassian.net/browse/AU-1369)
<!-- What problem does this solve? -->

After toimintaryhmä changes, address data was left off from the JSON, this adds it back plus some other small fixes.

## What was done
<!-- Describe what was done -->

* Address info is taken from default address in profile
* ContactPerson is set to user details from communtiy officials. From "responsible person role"
* Grants profile for toimintaryhmä must include one "responsible person" role
* Email & phone number for application are taken from this responsible person

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1369-toimintaryhma-ongelmat`
  * `make fresh` && `drush gwi`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login & authorize toimintaryhmä
* [ ] Create new KUVA projekti application & save as a draft
* [ ] See that address is set correctly from user. Maybe use printing for this?
* [ ] Check that code follows our standards



[AU-1369]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ