### PR TITLE
fix: AU-1233: Save application to ATV before sending it to integration

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1324,6 +1324,19 @@ class ApplicationHandler {
     string $applicationNumber,
     array $submittedFormData
   ): bool {
+
+    /*
+     * Save application data once more as a DRAFT to ATV to make sure we have
+     * the most recent version available even if integration fails
+     * for some reason.
+     */
+    $updatedDocumentATV = $this->handleApplicationUploadToAtv($applicationData, $applicationNumber, $submittedFormData);
+
+    /*
+     * I'm not sure we need to do anything else, but I'll leave this comment
+     * here when we come debugging weird behavior
+     */
+
     $webformSubmission = ApplicationHandler::submissionObjectFromApplicationNumber($applicationNumber);
     $appDocument = $this->atvSchema->typedDataToDocumentContent($applicationData, $webformSubmission, $submittedFormData);
     $myJSON = Json::encode($appDocument);


### PR DESCRIPTION
# [AU-1233](https://helsinkisolutionoffice.atlassian.net/browse/AU-1233)
<!-- What problem does this solve? -->

There may be some situations where integration fails to save application data and it may even not be queued properly and so the data could be lost. This is not acceptable. 

This tries too-easy-to-believe method of just calling the ATV saving method before sending it to integration

So the fix is hopefully this simple, but we must test repercussions of this thoroughly. That's why this is left unmerged for now. 

## What was done
<!-- Describe what was done -->
* Simply save data to ATV before saving it via integration

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1233-sate-first-to-atv`
  * `make fresh` && `make drush gwi`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login and test multiple applications, first save to ATV and then to avus2 and see that everything works.




[AU-1233]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ