### PR TITLE
fix: AU-1372: Fix subventions values multiplying 100 fold.

### DIFF
--- a/public/modules/custom/grants_handler/config/install/webform.settings.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.settings.yml
@@ -1,0 +1,423 @@
+_core:
+  default_config_hash: 1h6WrTweY39OdbNz3JJz6sgq5TAQ6HxtuNLIHMJR1tE
+langcode: fi
+settings:
+  default_status: open
+  default_page: true
+  default_page_base_path: /form
+  default_ajax: false
+  default_ajax_progress_type: throbber
+  default_ajax_effect: fade
+  default_ajax_speed: 500
+  default_submit_button_label: Lähetä
+  default_reset_button_label: Palauta
+  default_delete_button_label: Poista
+  default_form_submit_once: false
+  default_form_open_message: 'Tätä lomaketta ei ole vielä avattu lähetyksille.'
+  default_form_close_message: 'Sorry… This form is closed to new submissions.'
+  default_form_exception_message: 'Unable to display this webform. Please contact the site administrator.'
+  default_form_confidential_message: 'Tämä lomake on luottamuksellinen. Sinun täytyy <a href="[site:login-url]/logout?destination=[current-page:url:relative]">kirjautua ulos</a> lähettääksesi se.'
+  default_form_access_denied_message: 'Please login to access this form.'
+  default_form_disable_remote_addr: false
+  default_form_novalidate: false
+  default_form_disable_inline_errors: false
+  default_form_required: false
+  default_form_required_label: 'Indicates required field'
+  default_form_unsaved: false
+  default_form_disable_back: false
+  default_form_submit_back: false
+  default_form_details_toggle: true
+  default_form_file_limit: ''
+  default_wizard_prev_button_label: '< Previous'
+  default_wizard_next_button_label: 'Next >'
+  default_wizard_start_label: Alkaa
+  default_wizard_confirmation_label: Valmis
+  default_wizard_toggle_show_label: 'Näytä kaikki'
+  default_wizard_toggle_hide_label: 'Piilota kaikki'
+  default_preview_next_button_label: Preview
+  default_preview_prev_button_label: '< Previous'
+  default_preview_label: Preview
+  default_preview_title: '[webform:title]: Preview'
+  default_preview_message: 'Please review your submission. Your submission is not complete until you press the "Submit" button!'
+  default_draft_button_label: 'Tallenna keskeneräinen'
+  default_draft_saved_message: 'Tiedot tallennettu. Voit palata tähän lomakkeeseen myöhemmin ja palauttaa nykyiset tiedot.'
+  default_draft_loaded_message: 'A partially-completed form was found. Please complete the remaining portions.'
+  default_draft_pending_single_message: 'You have a pending draft for this webform. <a href="#">Load your pending draft</a>.'
+  default_draft_pending_multiple_message: 'You have pending drafts for this webform. <a href="#">View your pending drafts</a>.'
+  default_confirmation_message: 'Lisätty uusi lähetys lomakkeelle [webform:title].'
+  default_confirmation_back_label: 'Back to form'
+  default_limit_total_message: 'No more submissions are permitted.'
+  default_limit_user_message: 'No more submissions are permitted.'
+  default_submission_label: '[webform_submission:submitted-to]: Submission #[webform_submission:serial]'
+  default_submission_log: false
+  default_submission_views: {  }
+  default_submission_views_replace:
+    global_routes:
+      - entity.webform_submission.collection
+      - entity.webform_submission.user
+    webform_routes:
+      - entity.webform.results_submissions
+      - entity.webform.user.drafts
+      - entity.webform.user.submissions
+    node_routes:
+      - entity.node.webform.results_submissions
+      - entity.node.webform.user.drafts
+      - entity.node.webform.user.submissions
+  default_results_customize: false
+  default_submission_access_denied_message: 'Please login to access this submission.'
+  default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
+  default_submission_locked_message: 'This submission has been locked.'
+  default_previous_submission_message: 'You have already submitted this webform. <a href="#">View your previous submission</a>.'
+  default_previous_submissions_message: 'You have already submitted this webform. <a href="#">View your previous submissions</a>.'
+  default_autofill_message: 'This submission has been autofilled with your previous submission.'
+  form_classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  button_classes: ''
+  preview_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  confirmation_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  confirmation_back_classes: |
+    button
+  default_share: false
+  default_share_node: false
+  default_share_theme_name: ''
+  webform_bulk_form: true
+  webform_bulk_form_actions:
+    - webform_open_action
+    - webform_close_action
+    - webform_archive_action
+    - webform_unarchive_action
+    - webform_delete_action
+  webform_submission_bulk_form: true
+  webform_submission_bulk_form_actions:
+    - webform_submission_make_sticky_action
+    - webform_submission_make_unsticky_action
+    - webform_submission_make_lock_action
+    - webform_submission_make_unlock_action
+    - webform_submission_delete_action
+  dialog: false
+  dialog_options:
+    narrow:
+      title: Kapea
+      width: 600
+    normal:
+      title: Normaali
+      width: 800
+    wide:
+      title: Leveä
+      width: 1000
+assets:
+  css: ''
+  javascript: |2
+      // @see http://api.jqueryui.com/datepicker/
+    var langCode = drupalSettings.path.currentLanguage;
+      Drupal.webform = Drupal.webform || {};
+      Drupal.webform.datePicker = Drupal.webform.datePicker || {};
+      Drupal.webform.datePicker.regional = Drupal.webform.datePicker.regional || [];
+      Drupal.webform.datePicker.regional['en-US'] = {
+        closeText: "Done", // Display text for close link
+        prevText: "Prev", // Display text for previous month link
+        nextText: "Next", // Display text for next month link
+        currentText: "Today", // Display text for current month link
+        monthNames: [ "January", "February", "March", "April", "May", "June",
+                     "July", "August", "September", "October", "November", "December" ], // Names of months for drop-down and formatting
+        monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ], // For formatting
+        dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ], // For formatting
+        dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ], // For formatting
+        dayNamesMin: [ "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa" ], // Column headings for days starting at Sunday
+        weekHeader: "Wk", // Column header for week of the year
+        dateFormat: "mm/dd/yy", // See format options on parseDate
+        firstDay: 0, // The first day of the week, Sun = 0, Mon = 1, ...
+        isRTL: false, // True if right-to-left language, false if left-to-right
+        showMonthAfterYear: false, // True if the year select precedes month, false for month then year
+        yearSuffix: "", // Additional text to append to the year in the month headers,
+        selectMonthLabel: "Select month", // Invisible label for month selector
+        selectYearLabel: "Select year" // Invisible label for year selector
+      };
+      Drupal.webform.datePicker.regional['fi'] = { // Default regional settings
+    		closeText: "Sulje", // Display text for close link
+    		prevText: "Edelllinen", // Display text for previous month link
+    		nextText: "Seuraava", // Display text for next month link
+    		currentText: "Tänään", // Display text for current month link
+    		monthNames: [ "Tammikuu", "Helmikuu", "Maaliskuu", "Huhtikuu", "Toukokuu", "Kesäkuu",
+    			"Heinäkuu", "Elokuu", "Syyskuu", "Lokakuu", "Marraskuu", "Joulukuu" ], // Names of months for drop-down and formatting
+    		monthNamesShort: [ "Tam", "Hel", "Maa", "Huh", "Tou", "Kes", "Hei", "Elo", "Syys", "Lok", "Mar", "Jou" ], // For formatting
+    		dayNames: [ "Sunnuntai", "Maanantai", "Tiistai", "Keskiviikko", "Torstai", "Perjantai", "Lauantai" ], // For formatting
+    		dayNamesShort: [ "Sun", "Maa", "Tii", "Kes", "Tor", "Per", "Lau" ], // For formatting
+    		dayNamesMin: [ "Su", "Ma", "Ti", "Ke", "To", "Pe", "La" ], // Column headings for days starting at Sunday
+    		weekHeader: "Viik.", // Column header for week of the year
+    		dateFormat: "dd.mm.yy", // See format options on parseDate
+    		firstDay: 1, // The first day of the week, Sun = 0, Mon = 1, ...
+    		isRTL: false, // True if right-to-left language, false if left-to-right
+    		showMonthAfterYear: false, // True if the year select precedes month, false for month then year
+    		yearSuffix: "", // Additional text to append to the year in the month headers,
+    		selectMonthLabel: "Valitse kuukausi", // Invisible label for month selector
+    		selectYearLabel: "Valitse vuosi" // Invisible label for year selector
+    	};;
+      Drupal.webform.datePicker.regional['sv'] = { // Default regional settings
+    		closeText: "Stäng", // Display text for close link
+    		prevText: "Tidigare", // Display text for previous month link
+    		nextText: "Nästa", // Display text for next month link
+    		currentText: "I dag", // Display text for current month link
+            monthNames: [ "Januari", "Februari", "Mars", "April", "Maj", "Juni",
+                     "Juli", "Augusti", "September", "Oktober", "November", "December" ], // Names of months for drop-down and formatting
+            monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "Maj", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dec" ], // For formatting
+            dayNames: [ "Söndag", "Måndag", "Tisdag", "Onsdag", "Torsdag", "Fredag", "Lördag" ], // For formatting
+            dayNamesShort: [ "Sön", "Mån", "Tis", "Ons", "Tor", "Fre", "Lör" ], // For formatting
+            dayNamesMin: [ "Sö", "Må", "Ti", "On", "To", "Fr", "Lö" ], // Column headings for days starting at Sunday
+            weekHeader: "V", // Column header for week of the year
+            dateFormat: "dd.mm.yy", // See format options on parseDate
+    		firstDay: 1, // The first day of the week, Sun = 0, Mon = 1, ...
+    		isRTL: false, // True if right-to-left language, false if left-to-right
+    		showMonthAfterYear: false, // True if the year select precedes month, false for month then year
+    		yearSuffix: "", // Additional text to append to the year in the month headers,
+            selectMonthLabel: "Välj månad", // Invisible label for month selector
+            selectYearLabel: "Välj år" // Invisible label for year selector
+    	};;
+
+      Drupal.webform.datePicker.options = Drupal.webform.datePicker.regional[langCode] || {
+        closeText: "Done", // Display text for close link
+        prevText: "Prev", // Display text for previous month link
+        nextText: "Next", // Display text for next month link
+        currentText: "Today", // Display text for current month link
+        monthNames: [ "January", "February", "March", "April", "May", "June",
+                     "July", "August", "September", "October", "November", "December" ], // Names of months for drop-down and formatting
+        monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ], // For formatting
+        dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ], // For formatting
+        dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ], // For formatting
+        dayNamesMin: [ "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa" ], // Column headings for days starting at Sunday
+        weekHeader: "Wk", // Column header for week of the year
+        dateFormat: "mm/dd/yy", // See format options on parseDate
+        firstDay: 0, // The first day of the week, Sun = 0, Mon = 1, ...
+        isRTL: false, // True if right-to-left language, false if left-to-right
+        showMonthAfterYear: false, // True if the year select precedes month, false for month then year
+        yearSuffix: "", // Additional text to append to the year in the month headers,
+        selectMonthLabel: "Select month", // Invisible label for month selector
+        selectYearLabel: "Select year" // Invisible label for year selector
+      };
+form:
+  limit: 50
+  filter_category: ''
+  filter_state: ''
+element:
+  machine_name_pattern: a-z0-9_
+  empty_message: '-'
+  allowed_tags: admin
+  wrapper_classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  horizontal_rule_classes: |
+    webform-horizontal-rule--solid
+    webform-horizontal-rule--dashed
+    webform-horizontal-rule--dotted
+    webform-horizontal-rule--gradient
+    webform-horizontal-rule--thin
+    webform-horizontal-rule--medium
+    webform-horizontal-rule--thick
+    webform-horizontal-rule--flaired
+    webform-horizontal-rule--glyph
+  default_description_display: ''
+  default_more_title: Lisää
+  default_section_title_tag: h2
+  default_empty_option: true
+  default_empty_option_required: ''
+  default_empty_option_optional: ''
+  default_algolia_places_app_id: ''
+  default_algolia_places_api_key: ''
+  excluded_elements:
+    password: password
+    password_confirm: password_confirm
+html_editor:
+  disabled: false
+  element_format: ''
+  mail_format: ''
+  tidy: true
+  make_unused_managed_files_temporary: true
+file:
+  file_public: false
+  file_private_redirect: true
+  file_private_redirect_message: 'Please login to access the uploaded file.'
+  default_max_filesize: ''
+  default_managed_file_extensions: 'gif jpg jpeg png bmp eps tif pict psd txt rtf html odf pdf doc docx ppt pptx xls xlsx xml avi mov mp3 mp4 ogg wav bz2 dmg gz jar rar sit svg tar zip'
+  default_image_file_extensions: 'gif jpg jpeg png'
+  default_video_file_extensions: 'avi mov mp4 ogg wav webm'
+  default_audio_file_extensions: 'mp3 ogg wav'
+  default_document_file_extensions: 'txt rtf pdf doc docx odt ppt pptx odp xls xlsx ods'
+  make_unused_managed_files_temporary: true
+  delete_temporary_managed_files: true
+format: {  }
+mail:
+  default_to_mail: '[site:mail]'
+  default_from_mail: '[site:mail]'
+  default_from_name: '[site:name]'
+  default_reply_to: ''
+  default_return_path: ''
+  default_sender_mail: ''
+  default_sender_name: ''
+  default_subject: 'Webform submission from: [webform_submission:source-title]'
+  default_body_text: |
+    Submitted on [webform_submission:created]
+    Submitted by: [webform_submission:user]
+
+    Submitted values are:
+    [webform_submission:values]
+  default_body_html: |
+    <p>Submitted on [webform_submission:created]</p>
+    <p>Submitted by: [webform_submission:user]</p>
+    <p>Submitted values are:</p>
+    [webform_submission:values]
+  roles: {  }
+export:
+  temp_directory: ''
+  exporter: delimited
+  delimiter: ','
+  multiple_delimiter: ;
+  excel: false
+  archive_type: tar
+  header_format: label
+  header_prefix: true
+  header_prefix_key_delimiter: __
+  header_prefix_label_delimiter: ': '
+  entity_reference_items:
+    - id
+    - title
+    - url
+  options_single_format: compact
+  options_multiple_format: compact
+  options_item_format: label
+  likert_answers_format: label
+  signature_format: status
+  composite_element_item_format: label
+  excluded_exporters: {  }
+handler:
+  excluded_handlers: {  }
+variant:
+  excluded_variants: {  }
+batch:
+  default_batch_export_size: 500
+  default_batch_import_size: 100
+  default_batch_update_size: 500
+  default_batch_delete_size: 500
+  default_batch_email_size: 500
+purge:
+  cron_size: 100
+test:
+  types: |
+    checkbox:
+      - true
+    color:
+      - '#ffffcc'
+      - '#ffffcc'
+      - '#ccffff'
+    email:
+      - 'example@example.com'
+      - 'test@test.com'
+      - 'random@random.com'
+    language_select:
+      - en
+    machine_name:
+      - 'loremipsum'
+      - 'oratione'
+      - 'dixisset'
+    tel:
+      - '123-456-7890'
+      - '098-765-4321'
+    textarea:
+      - 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.'
+      - 'Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;'
+      - 'Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.'
+    text_format:
+      - value: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.</p>'
+      - value: '<p>Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;</p>'
+      - value: '<p>Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.</p>'
+    url:
+      - 'http://example.com'
+      - 'http://test.com'
+    webform_email_confirm:
+      - 'example@example.com'
+      - 'test@test.com'
+      - 'random@random.com'
+    webform_email_multiple:
+      - 'example@example.com, test@test.com, random@random.com'
+    webform_time:
+      - '09:00'
+      - '17:00'
+  names: |
+    first_name:
+      - 'John'
+      - 'Paul'
+      - 'Ringo'
+      - 'George'
+    last_name:
+      - 'Lennon'
+      - 'McCartney'
+      - 'Starr'
+      - 'Harrison'
+    address:
+      - '10 Main Street'
+      - '11 Brook Alley Road. APT 1'
+    zip:
+      - '11111'
+      - '12345'
+      - '12345-6789'
+    postal_code:
+      - '11111'
+      - '12345'
+      - '12345-6789'
+    phone:
+      - '123-456-7890'
+      - '098-765-4321'
+    fax:
+      - '123-456-7890'
+      - '098-765-4321'
+    city:
+      - 'Springfield'
+      - 'Pleasantville'
+      - 'Hill Valley'
+    url:
+      - 'http://example.com'
+      - 'http://test.com'
+    default:
+      - '12345'
+      - '23456'
+      - '23423'
+ui:
+  video_display: dialog
+  help_disabled: false
+  dialog_disabled: false
+  offcanvas_disabled: false
+  promotions_disabled: false
+  support_disabled: false
+  details_save: true
+  description_help: true
+  toolbar_item: false
+libraries:
+  excluded_libraries:
+    - choices
+    - jquery.chosen
+requirements:
+  cdn: true
+  clientside_validation: true
+  bootstrap: true
+  spam: true
+third_party_settings:
+  captcha:
+    replace_administration_mode: true

--- a/public/modules/custom/grants_handler/config/install/webform.webform.grants_handler.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.grants_handler.yml
@@ -127,6 +127,8 @@ settings:
   wizard_toggle: false
   wizard_toggle_show_label: ''
   wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
   preview: 0
   preview_label: ''
   preview_title: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kasko_ip_lisa.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kasko_ip_lisa.yml
@@ -1,0 +1,576 @@
+uuid: 5c6b411d-3f60-40c7-9f92-91afaeceba1f
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationTypeSelect: '53'
+    applicationType: KASKOIPLISA
+    applicationTypeID: '53'
+    applicationIndustry: KASKO
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      56: '56'
+    applicationTargetGroup: '21'
+    applicationOpen: '2023-06-16T08:30:52'
+    applicationClose: '2023-08-19T08:36:07'
+    applicationActingYears: {  }
+    applicationContinuous: 0
+    disableCopying: 0
+    applicationActingYearsType: current_and_next_x_years
+    applicationActingYearsNextCount: '1'
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: kasko_ip_lisa
+title: 'Kasvatus ja koulutus: Iltapäivätoiminnan harkinnanvarainen lisäavustushakemus'
+description: KASKOIPLISA
+category: ''
+elements: |-
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      applicant_type: 0
+      application_number: 0
+      status: 0
+      hakijan_tiedot: 0
+      email: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+      ensisijainen_taiteen_ala: 0
+      hankkeen_nimi: 0
+      kyseessa_on_festivaali_tai_tapahtuma: 0
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti: 0
+      olemme_saaneet_muita_avustuksia: 0
+      myonnetty_avustus: 0
+      members_applicant_person_global: 0
+      members_applicant_person_local: 0
+      members_applicant_community_global: 0
+      members_applicant_community_local: 0
+      kokoaikainen_henkilosto: 0
+      kokoaikainen_henkilotyovuosia: 0
+      osa_aikainen_henkilosto: 0
+      osa_aikainen_henkilotyovuosia: 0
+      vapaaehtoinen_henkilosto: 0
+      tapahtuma_tai_esityspaivien_maara_helsingissa: 0
+      esitykset_maara_helsingissa: 0
+      nayttelyt_maara_helsingissa: 0
+      tyopaja_maara_helsingissa: 0
+      esitykset_maara_kaikkiaan: 0
+      nayttelyt_maara_kaikkiaan: 0
+      tyopaja_maara_kaikkiaan: 0
+      esitykset_kavijamaara_helsingissa: 0
+      nayttelyt_kavijamaara_helsingissa: 0
+      tyopaja_kavijamaara_helsingissa: 0
+      esitykset_kavijamaara_kaikkiaan: 0
+      nayttelyt_kavijamaara_kaikkiaan: 0
+      tyopaja_kavijamaara_kaikkiaan: 0
+      kantaesitysten_maara: 0
+      ensi_iltojen_maara_helsingissa: 0
+      ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa: 0
+      postinumero: 0
+      kyseessa_on_kaupungin_omistama_tila: 0
+      tila: 0
+      ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara: 0
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat: 0
+      hanke_alkaa: 0
+      hanke_loppuu: 0
+      laajempi_hankekuvaus: 0
+      toiminta_taiteelliset_lahtokohdat: 0
+      toiminta_tasa_arvo: 0
+      toiminta_saavutettavuus: 0
+      toiminta_yhteisollisyys: 0
+      toiminta_kohderyhmat: 0
+      toiminta_ammattimaisuus: 0
+      toiminta_ekologisuus: 0
+      toiminta_yhteistyokumppanit: 0
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_: 0
+      budget_static_income: 0
+      budget_static_cost: 0
+      budget_other_cost: 0
+      muu_huomioitava_panostus: 0
+      additional_information: 0
+      extra_info: 0
+      muu_liite: 0
+    '#data_type': euro
+    '#form_item': hidden
+  applicant_type:
+    '#type': hidden
+    '#title': 'Hakijan tyyppi'
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    hakemusprofiili:
+      '#type': webform_section
+      '#title': 'Hakijan tiedot'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': Sähköpostiosoite
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#states':
+          required:
+            ':input[name="applicant_type"]':
+              '!value': private_person
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#required': true
+        '#attributes':
+          class:
+            - webform--large
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#title': Puhelinnumero
+        '#required': true
+        '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--medium
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            'value': registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              'value': registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2023: '2023'
+          2024: '2024'
+        '#required': true
+    avustuslajit:
+      '#type': webform_section
+      '#title': Avustuslajit
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          14: '14'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+          6: '6'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+      markup:
+        '#type': webform_markup
+        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
+    kayttotarkoitus:
+      '#type': webform_section
+      '#title': Käyttötarkoitus
+      lyhyt_kuvaus_haettavan_haettavien_avustusten_kayttotarkoituksist:
+        '#type': textarea
+        '#title': 'Lyhyt kuvaus haettavan / haettavien avustusten käyttötarkoituksista'
+        '#help': 'Kerro mit&auml; tarkoitusta varten avustusta haetaan, erittele tarvittaessa eri k&auml;ytt&ouml;kohteet. Kerro my&ouml;s mit&auml; avustuksella on tarkoitus saada aikaiseksi ja millaisia tavoitteita avustettavaan toimintaan liittyy.'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+    ajalle_alkaen:
+      '#type': webform_section
+      '#title': 'Ajalle, alkaen'
+      alkaen:
+        '#type': date
+        '#title': Alkaen
+        '#required': true
+    ajalle_paattyy:
+      '#type': webform_section
+      '#title': 'Ajalle, päättyy'
+      paattyy:
+        '#type': date
+        '#title': Päättyy
+        '#required': true
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '3. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#attributes':
+          class:
+            - webform--large
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#counter_type': character
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+
+          <div class="hds-notification__body"><p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p></div>
+          </div>
+          </div>
+        '#format': full_html
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#maxlength': 5000
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '4. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: false
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -1,4 +1,4 @@
-uuid: 2c6da593-88ba-471f-a46e-8a13b6143431
+uuid: 3840ed64-4e5e-4a8d-ab38-b3556354a7e6
 langcode: fi
 status: open
 dependencies:
@@ -7,32 +7,36 @@ dependencies:
     - grants_metadata
 third_party_settings:
   grants_metadata:
-    applicationType: ECONOMICGRANTAPPLICATION
-    applicationTypeID: '29'
+    applicationTypeSelect: '51'
+    applicationType: KASKOYLEIS
+    applicationTypeID: '51'
+    applicationIndustry: KASKO
     applicantTypes:
       registered_community: registered_community
     applicationTypeTerms:
-      49: '49'
-    applicationOpen: '2022-10-03T11:08:26'
-    applicationClose: '2023-07-30T11:19:00'
+      45: '45'
+      48: '48'
+      64: '64'
+    applicationTargetGroup: '21'
+    applicationOpen: '2023-04-03T08:00:00'
+    applicationClose: '2023-10-06T16:00:00'
     applicationContinuous: 0
-    applicationTargetGroup: '12'
     disableCopying: 0
-    applicationTypeSelect: '29'
-    applicationIndustry: KASKO
     applicationActingYears:
       2023: '2023'
       2024: '2024'
       2025: '2025'
+    applicationActingYearsType: fixed
+    applicationActingYearsNextCount: ''
 weight: 0
 open: null
 close: null
 uid: 1
 template: false
 archive: false
-id: yleisavustushakemus
-title: 'Kaupunginhallituksen yleisavustushakemus'
-description: MVP-lomake
+id: kasvatus_ja_koulutus_yleisavustu
+title: 'Kasvatus ja koulutus: yleisavustuslomake'
+description: 'KASKO yleisavustus'
 category: ''
 elements: |-
   applicant_type:
@@ -46,7 +50,6 @@ elements: |-
     '#collect_field':
       subventions%%amount: subventions%%amount
       application_number: 0
-      applicant_type: 0
       status: 0
       hakijan_tiedot: 0
       email: 0
@@ -61,8 +64,6 @@ elements: |-
       compensation_purpose: 0
       olemme_saaneet_muita_avustuksia: 0
       myonnetty_avustus: 0
-      olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta: 0
-      haettu_avustus_tieto: 0
       benefits_loans: 0
       benefits_premises: 0
       compensation_boolean: 0
@@ -76,6 +77,7 @@ elements: |-
       members_applicant_community_local: 0
       members_applicant_community_global: 0
       additional_information: 0
+      yhteison_saannot: 0
       vahvistettu_tilinpaatos: 0
       vahvistettu_toimintakertomus: 0
       vahvistettu_tilin_tai_toiminnantarkastuskertomus: 0
@@ -120,28 +122,28 @@ elements: |-
       email:
         '#type': email
         '#title': Sähköpostiosoite
-        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
-        '#size': 63
-        '#autocomplete': 'off'
         '#required': true
+        '#autocomplete': 'off'
+        '#size': 63
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
     contact_person_section:
       '#type': webform_section
       '#title': 'Hakemuksen yhteyshenkilö'
       contact_person:
         '#type': textfield
         '#title': Yhteyshenkilö
-        '#autocomplete': 'off'
         '#attributes':
           class:
             - webform--large
+        '#autocomplete': 'off'
         '#required': true
         '#size': 63
       contact_person_phone_number:
         '#type': textfield
+        '#title': Puhelinnumero
         '#attributes':
           class:
             - webform--medium
-        '#title': Puhelinnumero
         '#required': true
         '#autocomplete': 'off'
         '#size': 32
@@ -223,24 +225,26 @@ elements: |-
         '#type': grants_compensations
         '#title': Avustukset
         '#multiple': true
-        '#multiple__add': false
-        '#multiple__add_more': false
-        '#multiple__empty_items': 0
-        '#multiple__remove': false
-        '#multiple__sorting': false
-        '#multiple__header': true
         '#subventionType':
-          6: '6'
+          1: '1'
+          5: '5'
+          36: '36'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
         '#subvention_type':
           1: '1'
           6: '6'
         '#subvention_type_id__access': false
         '#subvention_type__title': Avustuslaji
         '#subvention_amount__title': 'Avustuksen summa'
-        '#attributes':
-          class:
-            - subventions
-        '#required': true
       markup_01:
         '#type': webform_markup
         '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
@@ -255,10 +259,10 @@ elements: |-
         '#counter_type': character
         '#maxlength': 5000
         '#counter_maximum': 5000
+        '#cols': 63
         '#attributes':
           class:
             - webform--large
-        '#cols': 63
         '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
     muut_samaan_tarkoitukseen_myonnetyt_avustukset:
       '#type': webform_section
@@ -325,110 +329,20 @@ elements: |-
           year:
             '#type': textfield
             '#required': true
-            '#title': Vuosi
             '#attributes':
               class:
                 - webform--small
+            '#title': Vuosi
             '#maxlength': 4
             '#pattern': '^[0-9]*$'
             '#pattern_error': 'Vain numeroita'
           amount:
             '#type': textfield
-            '#required': true
             '#attributes':
               class:
                 - webform--small
+            '#required': true
             '#title': 'Myönnetyn avustuksen summa'
-            '#input_mask': '''alias'': ''currency'', ''prefix'': '''', ''suffix'': ''€'',''groupSeparator'': '' '',''radixPoint'':'','''
-          purpose:
-            '#type': textarea
-            '#title': 'Kuvaus käyttötarkoituksesta'
-            '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
-            '#maxlength': 1000
-            '#counter_type': character
-            '#attributes':
-              class:
-                - webform--large
-            '#counter_maximum': 1000
-            '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
-    muut_samaan_tarkoitukseen_haetut_avustukset:
-      '#type': webform_section
-      '#title': 'Muut samaan tarkoitukseen haetut avustukset'
-      info_muut_samaan_tarkoitukseen_haettu:
-        '#type': processed_text
-        '#text': |
-          Ilmoita t&auml;h&auml;n ainoastaan avustukset, jotka on haettu muualta kuin Helsingin kaupungilta, eik&auml; p&auml;&auml;t&ouml;st&auml; ole viel&auml; tehty.
-          <div class="hds-notification hds-notification--info">
-            <div class="hds-notification__content">
-              <div class="hds-notification__label" role="heading" aria-level="2">
-                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
-                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
-              </div>
-            </div>
-          </div>
-        '#format': full_html
-      olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta:
-        '#type': radios
-        '#title': 'Olemme hakeneet avustuksia muualta kuin Helsingin kaupungilta'
-        '#options':
-          1: Kyllä
-          0: Ei
-      haettu_avustus_tieto:
-        '#type': webform_custom_composite
-        '#title': 'Lisää uusi haettu avustus'
-        '#title_display': before
-        '#states':
-          visible:
-            ':input[name="olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta"]':
-              value: '1'
-          required:
-            ':input[name="olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta"]':
-              value: '1'
-        '#multiple__header': false
-        '#multiple__item_label': 'haettu avustus'
-        '#multiple__no_items_message': 'Ei sy&ouml;tettyj&auml; arvoja. Lis&auml;&auml; uusi haettu avustus alta.'
-        '#multiple__min_items': 1
-        '#multiple__empty_items': 0
-        '#multiple__sorting': false
-        '#multiple__add': false
-        '#multiple__add_more_input': false
-        '#multiple__add_more_button_label': 'Lisää uusi haettu avustus'
-        '#element':
-          issuer:
-            '#type': select
-            '#options':
-              1: Valtio
-              3: EU
-              4: Muu
-              5: Säätiö
-              6: STEA
-            '#required': true
-            '#title': 'Avustuksen myöntäjä'
-          issuer_name:
-            '#type': textfield
-            '#required': true
-            '#title': 'Myöntäjän nimi'
-            '#attributes':
-              class:
-                - webform--large
-            '#help': 'Mikä taho avustusta on myöntänyt (esim. ministeriön nimi)'
-          year:
-            '#type': textfield
-            '#required': true
-            '#attributes':
-              class:
-                - webform--small
-            '#title': Vuosi
-            '#maxlength': 4
-            '#pattern': '^[0-9]*$'
-            '#pattern_error': 'Vain numeroita'
-          amount:
-            '#type': textfield
-            '#required': true
-            '#attributes':
-              class:
-                - webform--small
-            '#title': 'Haetun avustuksen summa'
             '#input_mask': '''alias'': ''currency'', ''prefix'': '''', ''suffix'': ''€'',''groupSeparator'': '' '',''radixPoint'':'','''
           purpose:
             '#type': textarea
@@ -466,12 +380,12 @@ elements: |-
         '#markup': 'Tilat, jotka kaupunki on antanut korvauksetta tai vuokrannut hakijan k&auml;ytt&ouml;&ouml;n (tilan nimi tai osoite, vuokran m&auml;&auml;r&auml; &euro;/kk)'
       benefits_premises:
         '#type': textarea
-        '#title': 'Kuvaus tiloihin liittyvästä tuesta'
-        '#maxlength': 500
-        '#counter_type': character
         '#attributes':
           class:
             - webform--large
+        '#title': 'Kuvaus tiloihin liittyvästä tuesta'
+        '#maxlength': 500
+        '#counter_type': character
         '#counter_maximum': 500
         '#counter_maximum_message': '%d/500 merkkiä jäljellä'
         '#cols': 63
@@ -512,6 +426,9 @@ elements: |-
         '#counter_type': character
         '#counter_minimum': 1
         '#counter_maximum': 5000
+        '#attributes':
+          class:
+            - webform--large
         '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
         '#states':
           visible:
@@ -520,9 +437,6 @@ elements: |-
           required:
             ':input[name="compensation_boolean"]':
               value: '1'
-        '#attributes':
-          class:
-            - webform--large
         '#cols': 63
   3_yhteison_tiedot:
     '#type': webform_wizard_page
@@ -542,6 +456,7 @@ elements: |-
         '#options':
           1: Kyllä
           0: Ei
+        '#required': false
         '#options_display': side_by_side
         '#options_description_display': help
     ensimmainen_otsikko:
@@ -552,7 +467,7 @@ elements: |-
         '#title': 'Henkilöjäsenen jäsenmaksu (€ / vuosi)'
         '#attributes':
           class:
-            - webform--sall
+            - webform--small
         '#maxlength': 50
         '#input_mask': '''alias'': ''currency'', ''prefix'': '''', ''suffix'': ''€'',''groupSeparator'': '' '',''radixPoint'':'','''
         '#size': 16
@@ -629,11 +544,11 @@ elements: |-
       additional_information:
         '#type': textarea
         '#title': Lisätiedot
-        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
-        '#counter_type': character
         '#attributes':
           class:
             - webform--large
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#counter_type': character
         '#maxlength': 5000
         '#counter_maximum': 5000
         '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
@@ -644,24 +559,19 @@ elements: |-
       attachments_info:
         '#type': webform_markup
         '#markup': |-
-          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
-          <br />
-          <strong>Vaaditut liitteet</strong><br />
-          Avustushakemuksen k&auml;sittely&auml; varten tarvitaan vahvistettuja, yhteis&ouml;n kokouksessaan hyv&auml;ksymi&auml; ja allekirjoittamia, liitteit&auml; edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilikaudelta sek&auml; liitteit&auml; sille toimintavuodelle, jolle avustusta haetaan. Edellist&auml; tilikautta koskevat liitteet ovat: tilinp&auml;&auml;t&ouml;s, toimintakertomus ja tilin- tai toiminnantarkastuskertomus sek&auml; vuosikokouksen p&ouml;yt&auml;kirja. Liitteet vuodelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.&nbsp;<br />
-          <br />
-          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
-          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;. &nbsp;<br />
-          <br />
-          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong><br />
-          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
-          &nbsp;
+          <p>Avustushakemuksen käsittelyä varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hylätä, jos liitteitä ei ole toimitettu. Mikäli joku liitteistä puuttuu kerro siitä hakemuksen Lisäselvitys liitteistä -kohdassa.
+          </p><h3>Vaaditut liitteet</h3>
+          <p>Avustushakemuksen käsittelyä varten tarvitaan vahvistettuja, yhteisön kokouksessaan hyväksymiä ja allekirjoittamia, liitteitä edelliseltä päättyneeltä tilikaudelta sekä liitteitä sille toimintavuodelle, jolle avustusta haetaan. Edellistä tilikautta koskevat liitteet ovat: tilinpäätös, toimintakertomus ja tilin- tai toiminnantarkastuskertomus sekä vuosikokouksen pöytäkirja. Liitteet vuodelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.
+          </p><h3>Usean liitteen toimittaminen yhtenä tiedostona</h3>
+          <p>Voit halutessasi toimittaa useampia liitteitä yhtenä tiedostona Tilinpäätös tai talousarvio -liitekohdassa. Merkitse tällöin muiden liiteotsikoiden kohdalla ”Liite on toimitettu yhtenä tiedostona tai toisen hakemuksen yhteydessä”.
+          </p><h3>Helsingin kaupungille aiemmin toimitetut liitteet</h3>
+          <p>Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteenä, samoja liitteitä ei tarvitse toimittaa uudelleen. Yhteisön vahvistettu tilinpäätös, toimintakertomus, toimintasuunnitelma ja talousarvio eivät voi olla erilaisia eri hakemusten liitteenä. Merkitse tällöin toimitettujen liitteiden kohdalla ”Liite on toimitettu yhtenä tiedostona tai toisen hakemuksen yhteydessä”.</p>
       notification_attachments:
         '#type': processed_text
         '#text': |
           <div class="hds-notification hds-notification--info">
           <div class="hds-notification__content">
           <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
-
           <div class="hds-notification__body"><p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
           <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p></div>
           </div>
@@ -672,7 +582,8 @@ elements: |-
         '#title': 'Yhteisön säännöt'
         '#multiple': false
         '#filetype': '7'
-        '#title_display': ''
+        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Uusi hakija tai säännöt muuttuneet.</span></span></span>'
+        '#title_display': before
         '#description__access': false
       vahvistettu_tilinpaatos:
         '#type': grants_attachments
@@ -727,20 +638,20 @@ elements: |-
         '#type': grants_attachments
         '#title': 'Talousarvio (sille vuodelle jolle haet avustusta)'
         '#multiple': false
-        '#filetype': '2'
+        '#filetype': '22'
         '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n talousarvio.</span></span></span>'
         '#title_display': before
         '#description__access': false
       extra_info:
         '#type': textarea
         '#title': 'Lisäselvitys liitteistä'
-        '#counter_type': character
         '#attributes':
           class:
             - webform--large
+        '#counter_type': character
         '#maxlength': 5000
         '#counter_maximum': 5000
-        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#counter_maximum_message': 'Max 5000 characters.'
         '#cols': 63
       muu_liite:
         '#type': grants_attachments
@@ -781,7 +692,7 @@ settings:
   ajax_effect: ''
   ajax_speed: null
   page: true
-  page_submit_path: /hakemus/kaupunginhallituksen-yleisavustushakemus
+  page_submit_path: ''
   page_confirm_path: ''
   page_theme_name: ''
   form_title: source_entity_webform

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
@@ -1,0 +1,1348 @@
+uuid: 099f2c14-fa1d-41fa-bdae-f26bd47f936e
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationType: KUVAPROJ
+    applicationTypeID: '48'
+    applicantTypes:
+      registered_community: registered_community
+      unregistered_community: unregistered_community
+      private_person: private_person
+    applicationTypeTerms:
+      47: '47'
+    applicationOpen: '2022-10-02T11:08:26'
+    applicationClose: '2023-07-31T11:19:00'
+    applicationContinuous: 0
+    applicationTargetGroup: '22'
+    disableCopying: 0
+    applicationTypeSelect: '48'
+    applicationIndustry: KUVA
+    applicationActingYears: {  }
+    applicationActingYearsType: current_and_next_x_years
+    applicationActingYearsNextCount: '1'
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: kuva_projekti
+title: 'Taide ja kulttuuri: projektiavustus'
+description: KUVAPROJ
+category: ''
+elements: |-
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      applicant_type: 0
+      application_number: 0
+      status: 0
+      hakijan_tiedot: 0
+      email: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+      ensisijainen_taiteen_ala: 0
+      hankkeen_nimi: 0
+      kyseessa_on_festivaali_tai_tapahtuma: 0
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti: 0
+      olemme_saaneet_muita_avustuksia: 0
+      myonnetty_avustus: 0
+      members_applicant_person_global: 0
+      members_applicant_person_local: 0
+      members_applicant_community_global: 0
+      members_applicant_community_local: 0
+      kokoaikainen_henkilosto: 0
+      kokoaikainen_henkilotyovuosia: 0
+      osa_aikainen_henkilosto: 0
+      osa_aikainen_henkilotyovuosia: 0
+      vapaaehtoinen_henkilosto: 0
+      tapahtuma_tai_esityspaivien_maara_helsingissa: 0
+      esitykset_maara_helsingissa: 0
+      nayttelyt_maara_helsingissa: 0
+      tyopaja_maara_helsingissa: 0
+      esitykset_maara_kaikkiaan: 0
+      nayttelyt_maara_kaikkiaan: 0
+      tyopaja_maara_kaikkiaan: 0
+      esitykset_kavijamaara_helsingissa: 0
+      nayttelyt_kavijamaara_helsingissa: 0
+      tyopaja_kavijamaara_helsingissa: 0
+      esitykset_kavijamaara_kaikkiaan: 0
+      nayttelyt_kavijamaara_kaikkiaan: 0
+      tyopaja_kavijamaara_kaikkiaan: 0
+      kantaesitysten_maara: 0
+      ensi_iltojen_maara_helsingissa: 0
+      ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa: 0
+      postinumero: 0
+      kyseessa_on_kaupungin_omistama_tila: 0
+      tila: 0
+      ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara: 0
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat: 0
+      hanke_alkaa: 0
+      hanke_loppuu: 0
+      laajempi_hankekuvaus: 0
+      toiminta_taiteelliset_lahtokohdat: 0
+      toiminta_tasa_arvo: 0
+      toiminta_saavutettavuus: 0
+      toiminta_yhteisollisyys: 0
+      toiminta_kohderyhmat: 0
+      toiminta_ammattimaisuus: 0
+      toiminta_ekologisuus: 0
+      toiminta_yhteistyokumppanit: 0
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_: 0
+      budget_static_income: 0
+      budget_static_cost: 0
+      budget_other_cost: 0
+      muu_huomioitava_panostus: 0
+      additional_information: 0
+      extra_info: 0
+      muu_liite: 0
+    '#data_type': euro
+    '#form_item': hidden
+  applicant_type:
+    '#type': hidden
+    '#title': 'Hakijan tyyppi'
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    hakemusprofiili:
+      '#type': webform_section
+      '#title': 'Hakijan tiedot'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': Sähköpostiosoite
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#states':
+          required:
+            ':input[name="applicant_type"]':
+              value: registered_community
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#required': true
+        '#attributes':
+          class:
+            - webform--large
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#title': Puhelinnumero
+        '#required': true
+        '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--medium
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              value: registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2023: '2023'
+          2024: '2024'
+        '#required': true
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          4: '4'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+          6: '6'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+      markup:
+        '#type': webform_markup
+        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
+      ensisijainen_taiteen_ala:
+        '#type': select
+        '#title': 'Ensisijainen taiteenala'
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#help': 'Valitse pudotusvalikosta toimintaa parhaiten kuvaava vaihtoehto.'
+        '#options':
+          'Design ja käsityö': 'Design ja käsityö'
+          'Elokuva, valokuva ja media': 'Elokuva, valokuva ja media'
+          Kaupunkikulttuuri: Kaupunkikulttuuri
+          Kirjallisuus: Kirjallisuus
+          'Kuvataide ': 'Kuvataide ja sarjakuva'
+          Monitaide: Monitaide
+          Museo: Museo
+          Musiikki: Musiikki
+          Muu: Muu
+          Sirkus: Sirkus
+          Tanssi: Tanssi
+          Teatteri: Teatteri
+        '#required': true
+      hankkeen_nimi:
+        '#type': textfield
+        '#title': 'Hankkeen nimi'
+        '#help': 'Valitse hankkeelle nimi, joka voidaan julkaista p&auml;&auml;t&ouml;ksen yhteydess&auml;.'
+        '#maxlength': 100
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+      kyseessa_on_festivaali_tai_tapahtuma:
+        '#type': radios
+        '#title': 'Kyseessä on festivaali tai tapahtuma'
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#help': 'T&auml;ss&auml; tarkoitetaan festivaalia tai tapahtumaa, joka tapahtuu tiiviin ajanjakson sis&auml;ll&auml; ja on ohjelmaltaan ja kestoltaan laajempi kuin yksitt&auml;inen konsertti, esitys tms. Festivaali tai tapahtuma sis&auml;lt&auml;&auml; useampia eri ohjelmasis&auml;lt&ouml;j&auml;, esim. esityksi&auml;, joiden v&auml;liss&auml; yleis&ouml; voi my&ouml;s vaihtua. Esimerkiksi kaupunginosatapahtumat. Ei esimerkiksi esityssarjat. Festivaali tai tapahtuma voi olla toistuva tai kertaluonteinen.'
+        '#options':
+          1: Kyllä
+          0: Ei
+        '#required': true
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti:
+        '#type': textarea
+        '#title': 'Hankkeen tai toiminnan lyhyt esittelyteksti'
+        '#help': 'Teksti voidaan julkaista tai sit&auml; voidaan k&auml;ytt&auml;&auml; esittelytekstin&auml; p&auml;&auml;t&ouml;ksen yhteydess&auml; sellaisenaan tai muokattuna.'
+        '#maxlength': 500
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 500
+        '#counter_maximum_message': '%d/500 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+    muut_samaan_tarkoitukseen_myonnetyt_avustukset:
+      '#type': webform_section
+      '#title': 'Muut samaan tarkoitukseen myönnetyt avustukset'
+      info_muut_samaan_tarkoitukseen_myonnetty:
+        '#type': processed_text
+        '#text': |
+          Ilmoita tähän ainoastaan avustukset, jotka on myönnetty muualta kuin Helsingin kaupungilta kuluvana ja kahtena edellisenä verovuotena.
+          <div class="hds-notification hds-notification--info">
+            <div class="hds-notification__content">
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
+              </div>
+            </div>
+          </div>
+        '#format': full_html
+      olemme_saaneet_muita_avustuksia:
+        '#type': radios
+        '#title': 'Olemme saaneet muita avustuksia'
+        '#description_display': before
+        '#options':
+          1: Kyllä
+          0: Ei
+      myonnetty_avustus:
+        '#type': webform_custom_composite
+        '#title': 'Myönnetty avustus'
+        '#title_display': before
+        '#states':
+          visible:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: 1
+          required:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: 1
+        '#multiple__header': false
+        '#multiple__item_label': 'myönnetty avustus'
+        '#multiple__no_items_message': 'Ei sy&ouml;tettyj&auml; arvoja. Lis&auml;&auml; uusi my&ouml;nnetty avustus alta.'
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää uusi myönnetty avustus'
+        '#element':
+          issuer:
+            '#type': select
+            '#options':
+              1: Valtio
+              3: EU
+              4: Muu
+              5: Säätiö
+              6: STEA
+            '#required': true
+            '#title': 'Avustuksen myöntäjä'
+          issuer_name:
+            '#type': textfield
+            '#required': true
+            '#title': 'Myöntäjän nimi'
+            '#attributes':
+              class:
+                - webform--large
+            '#help': 'Mikä taho avustusta on myöntänyt (esim. ministeriön nimi)'
+          year:
+            '#type': textfield
+            '#required': true
+            '#title': Vuosi
+            '#attributes':
+              class:
+                - webform--small
+            '#maxlength': 4
+            '#pattern': '^[0-9]*$'
+            '#pattern_error': 'Vain numeroita'
+          amount:
+            '#type': textfield
+            '#required': true
+            '#attributes':
+              class:
+                - webform--small
+            '#title': 'Myönnetyn avustuksen summa'
+            '#input_mask': '''alias'': ''currency'', ''prefix'': '''', ''suffix'': ''€'',''groupSeparator'': '' '',''radixPoint'':'','''
+          purpose:
+            '#type': textarea
+            '#title': 'Kuvaus käyttötarkoituksesta'
+            '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
+            '#maxlength': 1000
+            '#counter_type': character
+            '#counter_maximum': 1000
+            '#attributes':
+              class:
+                - webform--large
+            '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  3_yhteison_tiedot:
+    '#type': webform_wizard_page
+    '#title': '3. Yhteisön tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    jasenmaara:
+      '#type': webform_section
+      '#title': Jäsenmäärä
+      jasenmaara_fieldset:
+        '#type': fieldset
+        '#title': Jäsenmäärä
+        '#help': 'Jos yhteisöllä on jäseniä, merkitse ne tähän.'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        members_applicant_person_global:
+          '#type': number
+          '#title': 'Henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_person_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_global:
+          '#type': number
+          '#title': Yhteisöjäseniä
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä yhteisöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+    henkilosto_hankkeessa_jolle_avustusta_haetaan:
+      '#type': webform_section
+      '#title': 'Henkilöstö hankkeessa, jolle avustusta haetaan'
+      henkilosto_hankkeessa:
+        '#type': fieldset
+        '#title': 'Henkilöstö hankkeessa'
+        '#help': 'Henkil&ouml;st&ouml;&ouml;n voi sis&auml;llytt&auml;&auml; muitakin kuin palkattuja ty&ouml;ntekij&ouml;it&auml;, mm. palkkioilla tai muilla korvauksilla ty&ouml;skentelevi&auml; tai ostopalveluna ostettavaa ty&ouml;t&auml;. Kokoaikaiset ty&ouml;ntekij&auml;t voivat sis&auml;lt&auml;&auml; my&ouml;s m&auml;&auml;r&auml;aikaisia ty&ouml;ntekij&ouml;it&auml;, jos n&auml;m&auml; ty&ouml;skentelev&auml;t t&auml;ysp&auml;iv&auml;isesti. Henkil&ouml;ty&ouml;vuosi kuvaa kokoaikaiseksi muutetun henkil&ouml;n ty&ouml;panosta. Esimerkiksi 6kk kokop&auml;iv&auml;isesti ty&ouml;skentelev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,5 henkil&ouml;ty&ouml;vuotta. Vastaavasti koko vuoden osa-aikaisesti 30% ty&ouml;m&auml;&auml;r&auml;&auml; tekev&auml;st&auml; henkil&ouml;st&auml; voi laskea muodostuvan 0,3 henkil&ouml;ty&ouml;vuotta. Kyseess&auml; on arvio, joka kuvaa suuntaa-antavasti projektiin osallistuvan henkil&ouml;st&ouml;n ty&ouml;panosta.'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        kokoaikainen_henkilosto:
+          '#type': number
+          '#title': 'Kokoaikaisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+        kokoaikainen_henkilotyovuosia:
+          '#type': number
+          '#title': 'Kokoaikaisia: Henkilötyövuosia'
+          '#attributes':
+            class:
+              - webform--small
+        osa_aikainen_henkilosto:
+          '#type': number
+          '#title': 'Osa-aikaisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+        osa_aikainen_henkilotyovuosia:
+          '#type': number
+          '#title': 'Osa-aikaisia: Henkilötyövuosia'
+          '#attributes':
+            class:
+              - webform--small
+        vapaaehtoinen_henkilosto:
+          '#type': number
+          '#title': 'Vapaaehtoisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+  4_suunniteltu_toiminta:
+    '#type': webform_wizard_page
+    '#title': '4. Suunniteltu toiminta'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    arvio_maarista:
+      '#type': webform_section
+      '#title': 'Arvio määristä'
+      '#description': 'Sy&ouml;t&auml; tiedot koskien koko hanketta, johon avustusta haetaan. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.'
+      tapahtuma_tai_esityspaivien_maara_helsingissa:
+        '#type': number
+        '#title': 'Tapahtuma- tai esityspäivien määrä Helsingissä'
+        '#required': true
+        '#attributes':
+          class:
+            - webform--small
+      esityspaivien_maara_helsingissa_fieldset:
+        '#type': fieldset
+        '#title': 'Määrä Helsingissä'
+        '#attributes':
+          class:
+            - grants-fieldset
+        esitykset_maara_helsingissa:
+          '#type': number
+          '#title': Esitykset
+          '#attributes':
+            class:
+              - webform--small
+        nayttelyt_maara_helsingissa:
+          '#type': number
+          '#title': Näyttelyt
+          '#attributes':
+            class:
+              - webform--small
+        tyopaja_maara_helsingissa:
+          '#type': number
+          '#title': 'Työpaja tai muu osallistava toimintamuoto'
+          '#attributes':
+            class:
+              - webform--small
+      esityspaivien_maara_kaikkiaan_fieldset:
+        '#type': fieldset
+        '#title': 'Määrä kaikkiaan'
+        '#attributes':
+          class:
+            - grants-fieldset
+        '#help': 'T&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
+        esitykset_maara_kaikkiaan:
+          '#type': number
+          '#title': Esitykset
+          '#attributes':
+            class:
+              - webform--small
+        nayttelyt_maara_kaikkiaan:
+          '#type': number
+          '#title': Näyttelyt
+          '#attributes':
+            class:
+              - webform--small
+        tyopaja_maara_kaikkiaan:
+          '#type': number
+          '#title': 'Työpaja tai muu osallistava toimintamuoto'
+          '#attributes':
+            class:
+              - webform--small
+      maara_helsingissa:
+        '#type': number
+        '#title': 'Kävijämäärä Helsingissä'
+        '#help': 'Älä täytä samoja kävijöitä kahteen kertaan, esim. näyttelytilassa järjestettyä työpajaa sekä näyttelyihin että työpajoihin.'
+        '#attributes':
+          class:
+            - webform--small
+      maara_kaikkiaan:
+        '#type': number
+        '#title': 'Kävijämäärä kaikkiaan'
+        '#help': 'Määrä kaikkiaan -kohdassa täytä luvut sisältäen toiminnan kokonaisuudessaan sekä Suomessa että mahdollisesti ulkomailla.'
+        '#attributes':
+          class:
+            - webform--small
+    esityksista:
+      '#type': webform_section
+      '#title': Esityksistä
+      kantaesitysten_maara:
+        '#type': number
+        '#title': 'Kantaesitysten määrä'
+        '#attributes':
+          class:
+            - webform--small
+        '#help': 'Kantaesityksell&auml; tarkoitetaan ennen esitt&auml;m&auml;t&ouml;nt&auml;, t&auml;ysin uutta teosta. Esimerkiksi uusinta-ensi-ilta ei ole kantaesitys.'
+      ensi_iltojen_maara_helsingissa:
+        '#type': number
+        '#title': 'Ensi-iltojen määrä Helsingissä'
+        '#attributes':
+          class:
+            - webform--small
+        '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimm&auml;ist&auml; esityst&auml;. T&auml;yt&auml; t&auml;h&auml;n ne ensi-illat, jotka tapahtuvat Helsingiss&auml;.'
+    yleisolle_avoin_toiminta:
+      '#type': webform_section
+      '#title': 'Yleisölle avoin toiminta'
+      '#help': 'Yleisölle avoimella toiminnalla tarkoitetaan tässä mm. esityksiä, näyttelyitä ja työpajoja tai muita osallistavia toimintamuotoja.'
+      ensimmainen_tila_fieldset:
+        '#type': fieldset
+        '#title': 'Ensimmäinen yleisölle avoimen tilaisuuden paikka Helsingissä'
+        ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa:
+          '#type': textfield
+          '#title': 'Tilan nimi'
+          '#required': true
+          '#attributes':
+            class:
+              - webform--large
+        postinumero:
+          '#type': number
+          '#title': Postinumero
+          '#attributes':
+            class:
+              - webform--small
+          '#input_mask': '99999'
+        kyseessa_on_kaupungin_omistama_tila:
+          '#type': radios
+          '#title': 'Kyseessä on kaupungin omistama tila'
+          '#options':
+            1: Kyllä
+            0: Ei
+      tila:
+        '#type': premises_composite
+        '#title': 'Muut tilat'
+        '#multiple': true
+        '#title_display': before
+        '#multiple__no_items_message': ''
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää uusi tila'
+        '#premiseType__access': false
+        '#premiseAddress__access': false
+        '#location__access': false
+        '#streetAddress__access': false
+        '#address__access': false
+        '#studentCount__access': false
+        '#specialStudents__access': false
+        '#groupCount__access': false
+        '#specialGroups__access': false
+        '#personnelCount__access': false
+        '#totalRent__access': false
+        '#rentTimeBegin__access': false
+        '#rentTimeEnd__access': false
+        '#free__access': false
+        '#isOthersUse__access': false
+        '#isOwnedByApplicant__access': false
+        '#isOwnedByCity__title': 'Kyseessä on kaupungin omistama tila'
+        '#citySection__access': false
+        '#premiseSuitability__access': false
+    aikataulu:
+      '#type': webform_section
+      '#title': Aikataulu
+      ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara:
+        '#type': date
+        '#title': 'Ensimmäisen yleisölle avoimen tilaisuuden päivämäärä'
+        '#required': true
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
+        '#type': textfield
+        '#title': 'Festivaalin tai tapahtuman kohdalla tapahtuman päivämäärät'
+        '#attributes':
+          class:
+            - webform--large
+      hanke_alkaa:
+        '#type': date
+        '#title': 'Hanke alkaa'
+        '#required': true
+      hanke_loppuu:
+        '#type': date
+        '#title': 'Hanke loppuu'
+        '#required': true
+    hankekuvaus:
+      '#type': webform_section
+      '#title': Hankekuvaus
+      laajempi_hankekuvaus:
+        '#type': textarea
+        '#maxlength': 2500
+        '#counter_type': character
+        '#counter_maximum': 2500
+        '#counter_maximum_message': '%d/2500 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Laajempi hankekuvaus'
+        '#help': 'Kerro hankkeesta tiiviisti. Esim. miksi, mit&auml;, kenelle, miten ja mitk&auml; ovat tavoitteet.'
+  5_toiminnan_lahtokohdat:
+    '#type': webform_wizard_page
+    '#title': '5. Toiminnan lähtökohdat'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    toiminnan_sisallot:
+      '#type': webform_section
+      '#title': 'Toiminnan sisällöt'
+      '#states':
+        visible:
+          ':input[name="avustukset_summa"]':
+            value:
+              greater_equal: '5001'
+      toiminta_taiteelliset_lahtokohdat:
+        '#type': textarea
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Kuvaa toiminnan taiteellisia lähtökohtia ja tavoitteita, taiteellista ammattimaisuutta sekä asemaa taiteen kentällä.'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#help': 'Voit nostaa myös esiin esimerkisksi keskeisiä palkintoja tai muita noteerauksia.'
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5001'
+      toiminta_tasa_arvo:
+        '#type': textarea
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5001'
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Miten monimuotoisuus ja tasa-arvo toteutuu ja näkyy toiminnan järjestäjissä ja organisaatioissa sekä toiminnan sisällöissä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+    toiminnan_tavoittavuus:
+      '#type': webform_section
+      '#title': 'Toiminnan tavoittavuus'
+      toiminta_saavutettavuus:
+        '#type': textarea
+        '#title': 'Miten toiminta tehdään kaupunkilaiselle sosiaalisesti, kulttuurisesti, kielellisesti, taloudellisesti, fyysisesti, alueellisesti tai muutoin mahdollisimman saavutettavaksi? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5001'
+      toiminta_yhteisollisyys:
+        '#type': textarea
+        '#title': 'Miten toiminta vahvistaa yhteisöllisyyttä, verkostomaista yhteistyöskentelyä ja miten kaupunkilaisten on mahdollista osallistua toiminnan eri vaiheisiin? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5001'
+      toiminta_kohderyhmat:
+        '#type': textarea
+        '#title': 'Keitä toiminnalla tavoitellaan? Miten kyseiset kohderyhmät aiotaan tavoittaa ja mitä osaamista näiden kanssa työskentelyyn on?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+    toiminnan_jarjestaminen:
+      '#type': webform_section
+      '#title': 'Toiminnan järjestäminen'
+      toiminta_ammattimaisuus:
+        '#type': textarea
+        '#title': 'Kuvaa toiminnan järjestämisen ammattimaisuutta ja organisoimista'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5001'
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_ekologisuus:
+        '#type': textarea
+        '#title': 'Miten ekologisuus huomioidaan toiminnan järjestämisessä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5001'
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_yhteistyokumppanit:
+        '#type': textarea
+        '#title': 'Nimeä keskeisimmät yhteistyökumppanit ja kuvaa yhteistyön muotoja ja ehtoja.'
+        '#help': 'Nime&auml; maksimissaan noin viisi yhteisty&ouml;kumppania.'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  6_talous:
+    '#type': webform_wizard_page
+    '#title': '6. Talous'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    talousarvio:
+      '#type': webform_section
+      '#title': Talousarvio
+      '#states':
+        visible:
+          - ':input[name="applicant_type"]':
+              value: private_person
+          - or
+          - ':input[name="applicant_type"]':
+              value: unregistered_community
+          - or
+          - ':input[name="applicant_type"]':
+              value: registered_community
+      markup_01:
+        '#type': webform_markup
+        '#markup': 'Koskien koko hanketta, johon avustusta haetaan.'
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_:
+        '#type': radios
+        '#required': true
+        '#title': 'Organisaatio kuuluu valtionosuusjärjestelmään (VOS)'
+        '#options':
+          1: Kyllä
+          0: Ei
+    tulot:
+      '#type': webform_section
+      '#title': 'Suunnitellut tulot'
+      budget_static_income:
+        '#type': grants_budget_income_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add': false
+        '#multiple__add_more': false
+        '#multiple__add_more_input': false
+        '#plannedStateOperativeSubvention__access': false
+        '#otherCompensationFromCity__access': false
+        '#stateOperativeSubvention__access': false
+        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#financialFundingAndInterests__access': false
+        '#customerFees__access': false
+        '#donations__access': false
+        '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationType__access': false
+        '#incomeWithoutCompensations__access': false
+        '#plannedTotalIncome__access': false
+        '#otherCompensations__access': false
+        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#plannedTotalIncomeWithoutSubventions__access': false
+        '#plannedShareOfIncomeWithoutSubventions__access': false
+        '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__access': false
+    menot:
+      '#type': webform_section
+      '#title': 'Suunnitellut menot'
+      budget_static_cost:
+        '#type': grants_budget_cost_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add': false
+        '#multiple__add_more': false
+        '#multiple__add_more_input': false
+        '#salaries__access': false
+        '#personnelSocialSecurityCosts__access': false
+        '#rentSum__access': false
+        '#materials__access': false
+        '#transport__access': false
+        '#food__access': false
+        '#pr__access': false
+        '#insurance__access': false
+        '#snacks__access': false
+        '#cleaning__access': false
+        '#premisesService__access': false
+        '#travel__access': false
+        '#heating__access': false
+        '#servicesTotal__access': false
+        '#water__access': false
+        '#electricity__access': false
+        '#suppliesTotal__access': false
+        '#admin__access': false
+        '#accounting__access': false
+        '#health__access': false
+        '#otherCostsTotal__access': false
+        '#services__access': false
+        '#supplies__access': false
+        '#useOfCustomerFeesTotal__access': false
+        '#netCosts__access': false
+        '#generalCosts__access': false
+        '#permits__access': false
+        '#setsAndCostumes__access': false
+        '#security__access': false
+        '#costsWithoutDeferredItems__access': false
+        '#generalCostsTotal__access': false
+        '#showCosts__help': 'Teosten esittämisestä muuna kuin palkkana tai palkkiona maksettavat korvaukset.'
+        '#totalCosts__access': false
+        '#allCostsTotal__access': false
+        '#plannedTotalCosts__access': false
+      budget_other_cost:
+        '#type': grants_budget_other_cost
+        '#title': 'Muut menot'
+        '#multiple': true
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+    muu_huomioitava_panostus_osio:
+      '#type': webform_section
+      '#title': 'Muu huomioitava panostus'
+      muu_huomioitava_panostus:
+        '#type': textarea
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Sisältyykö toiminnan toteuttamiseen jotain muuta rahanarvoista panosta tai vaihtokauppaa, joka ei käy ilmi budjetista?'
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '7. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#attributes':
+          class:
+            - webform--large
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#counter_type': character
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet</strong><br />
+          Avustushakemuksen k&auml;sittely&auml; varten tarvitaan ty&ouml;ryhm&auml;n j&auml;senten ansioluettelot, kun kyseess&auml; on taiteen ammattilaisten hanke.&nbsp;<br />
+          <br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen</strong><br />
+          Voit toimittaa useampia ty&ouml;ryhm&auml;n j&auml;senten ansioluetteloita erillisin&auml; tiedostoina liitt&auml;m&auml;ll&auml; ne Muu liite -kohtaan. Voit halutessasi my&ouml;s toimittaa useampia liitteit&auml; yhten&auml; tiedostona.
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+
+          <div class="hds-notification__body"><p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p></div>
+          </div>
+          </div>
+        '#format': full_html
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': 'Max 5000 characters.'
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements:
+    application_number: application_number
+    status: status
+    applicant_type: applicant_type
+    hakijan_tiedot: hakijan_tiedot
+    email: email
+    contact_person: contact_person
+    contact_person_phone_number: contact_person_phone_number
+    community_address: community_address
+    community_address__community_address_select: community_address__community_address_select
+    community_address__community_street: community_address__community_street
+    community_address__community_post_code: community_address__community_post_code
+    community_address__community_city: community_address__community_city
+    community_address__community_country: community_address__community_country
+    bank_account: bank_account
+    bank_account__account_number_select: bank_account__account_number_select
+    bank_account__account_number: bank_account__account_number
+    community_officials: community_officials
+    community_officials__community_officials_select: community_officials__community_officials_select
+    community_officials__name: community_officials__name
+    community_officials__role: community_officials__role
+    community_officials__email: community_officials__email
+    community_officials__phone: community_officials__phone
+    acting_year: acting_year
+    subventions: subventions
+    subventions__subventionTypeTitle: subventions__subventionTypeTitle
+    subventions__subventionType: subventions__subventionType
+    subventions__amount: subventions__amount
+    avustukset_summa: avustukset_summa
+    ensisijainen_taiteen_ala: ensisijainen_taiteen_ala
+    hankkeen_nimi: hankkeen_nimi
+    kyseessa_on_festivaali_tai_tapahtuma: kyseessa_on_festivaali_tai_tapahtuma
+    hankkeen_tai_toiminnan_lyhyt_esittelyteksti: hankkeen_tai_toiminnan_lyhyt_esittelyteksti
+    olemme_saaneet_muita_avustuksia: olemme_saaneet_muita_avustuksia
+    myonnetty_avustus: myonnetty_avustus
+    myonnetty_avustus__issuer: myonnetty_avustus__issuer
+    myonnetty_avustus__issuer_name: myonnetty_avustus__issuer_name
+    myonnetty_avustus__year: myonnetty_avustus__year
+    myonnetty_avustus__amount: myonnetty_avustus__amount
+    myonnetty_avustus__purpose: myonnetty_avustus__purpose
+    members_applicant_person_global: members_applicant_person_global
+    members_applicant_person_local: members_applicant_person_local
+    members_applicant_community_global: members_applicant_community_global
+    members_applicant_community_local: members_applicant_community_local
+    kokoaikainen_henkilosto: kokoaikainen_henkilosto
+    osa_aikainen_henkilosto: osa_aikainen_henkilosto
+    vapaaehtoinen_henkilosto: vapaaehtoinen_henkilosto
+    tapahtuma_tai_esityspaivien_maara_helsingissa: tapahtuma_tai_esityspaivien_maara_helsingissa
+    kantaesitysten_maara: kantaesitysten_maara
+    ensi_iltojen_maara_helsingissa: ensi_iltojen_maara_helsingissa
+    postinumero: postinumero
+    kyseessa_on_kaupungin_omistama_tila: kyseessa_on_kaupungin_omistama_tila
+    tila: tila
+    tila__premiseName: tila__premiseName
+    tila__premiseAddress: tila__premiseAddress
+    tila__location: tila__location
+    tila__streetAddress: tila__streetAddress
+    tila__address: tila__address
+    tila__postCode: tila__postCode
+    tila__studentCount: tila__studentCount
+    tila__specialStudents: tila__specialStudents
+    tila__groupCount: tila__groupCount
+    tila__specialGroups: tila__specialGroups
+    tila__personnelCount: tila__personnelCount
+    tila__totalRent: tila__totalRent
+    tila__rentTimeBegin: tila__rentTimeBegin
+    tila__rentTimeEnd: tila__rentTimeEnd
+    tila__free: tila__free
+    tila__isOthersUse: tila__isOthersUse
+    tila__isOwnedByApplicant: tila__isOwnedByApplicant
+    tila__isOwnedByCity: tila__isOwnedByCity
+    ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara: ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara
+    festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat: festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat
+    hanke_alkaa: hanke_alkaa
+    hanke_loppuu: hanke_loppuu
+    laajempi_hankekuvaus: laajempi_hankekuvaus
+    toiminta_taiteelliset_lahtokohdat: toiminta_taiteelliset_lahtokohdat
+    toiminta_tasa_arvo: toiminta_tasa_arvo
+    toiminta_saavutettavuus: toiminta_saavutettavuus
+    toiminta_yhteisollisyys: toiminta_yhteisollisyys
+    toiminta_kohderyhmat: toiminta_kohderyhmat
+    toiminta_ammattimaisuus: toiminta_ammattimaisuus
+    toiminta_ekologisuus: toiminta_ekologisuus
+    toiminta_yhteistyokumppanit: toiminta_yhteistyokumppanit
+    organisaatio_kuuluu_valtionosuusjarjestelmaan: organisaatio_kuuluu_valtionosuusjarjestelmaan
+    additional_information: additional_information
+    extra_info: extra_info
+    muu_liite: muu_liite
+    muu_liite__attachment: muu_liite__attachment
+    muu_liite__attachmentName: muu_liite__attachmentName
+    muu_liite__description: muu_liite__description
+    muu_liite__isDeliveredLater: muu_liite__isDeliveredLater
+    muu_liite__isIncludedInOtherFile: muu_liite__isIncludedInOtherFile
+    muu_liite__fileStatus: muu_liite__fileStatus
+    muu_liite__fileType: muu_liite__fileType
+    muu_liite__integrationID: muu_liite__integrationID
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: true
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '8. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: true
+  confirmation_exclude_token: true
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kuva_toiminta.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kuva_toiminta.yml
@@ -1,0 +1,1632 @@
+uuid: e02b8012-bb8b-40d7-9d6b-2f6776882fe6
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationType: KUVATOIM
+    applicationTypeID: '47'
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      45: '45'
+    applicationOpen: '2022-10-02T11:08:26'
+    applicationClose: '2023-07-31T11:19:00'
+    applicationContinuous: 0
+    applicationTargetGroup: '22'
+    disableCopying: 0
+    applicationTypeSelect: '47'
+    applicationIndustry: KUVA
+    applicationActingYears:
+      2023: '2023'
+      2024: '2024'
+      2025: '2025'
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: kuva_toiminta
+title: 'Taide- ja kulttuuriavustukset, toiminta-avustus'
+description: KUVATOIM
+category: ''
+elements: |-
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#title_display': none
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      applicant_type: 0
+      application_number: 0
+      status: 0
+      hakijan_tiedot: 0
+      email: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+      ensisijainen_taiteen_ala: 0
+      hankkeen_nimi: 0
+      kyseessa_on_festivaali_tai_tapahtuma: 0
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti: 0
+      olemme_saaneet_muita_avustuksia: 0
+      myonnetty_avustus: 0
+      members_applicant_person_global: 0
+      members_applicant_person_local: 0
+      members_applicant_community_global: 0
+      members_applicant_community_local: 0
+      kokoaikainen_henkilosto: 0
+      kokoaikainen_henkilotyovuosia: 0
+      osa_aikainen_henkilosto: 0
+      osa_aikainen_henkilotyovuosia: 0
+      vapaaehtoinen_henkilosto: 0
+      tapahtuma_tai_esityspaivien_maara_helsingissa: 0
+      esitykset_maara_helsingissa: 0
+      nayttelyt_maara_helsingissa: 0
+      tyopaja_maara_helsingissa: 0
+      esitykset_maara_kaikkiaan: 0
+      nayttelyt_maara_kaikkiaan: 0
+      tyopaja_maara_kaikkiaan: 0
+      esitykset_kavijamaara_helsingissa: 0
+      nayttelyt_kavijamaara_helsingissa: 0
+      tyopaja_kavijamaara_helsingissa: 0
+      esitykset_kavijamaara_kaikkiaan: 0
+      nayttelyt_kavijamaara_kaikkiaan: 0
+      tyopaja_kavijamaara_kaikkiaan: 0
+      kantaesitysten_maara: 0
+      ensi_iltojen_maara_helsingissa: 0
+      ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa: 0
+      postinumero: 0
+      kyseessa_on_kaupungin_omistama_tila: 0
+      tila: 0
+      ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara: 0
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat: 0
+      hanke_alkaa: 0
+      hanke_loppuu: 0
+      laajempi_hankekuvaus: 0
+      toiminta_taiteelliset_lahtokohdat: 0
+      toiminta_tasa_arvo: 0
+      toiminta_saavutettavuus: 0
+      toiminta_yhteisollisyys: 0
+      toiminta_kohderyhmat: 0
+      toiminta_ammattimaisuus: 0
+      toiminta_ekologisuus: 0
+      toiminta_yhteistyokumppanit: 0
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_: 0
+      budget_static_income: 0
+      budget_static_cost: 0
+      budget_other_cost: 0
+      muu_huomioitava_panostus: 0
+      additional_information: 0
+      extra_info: 0
+      muu_liite: 0
+    '#data_type': euro
+    '#form_item': hidden
+  applicant_type:
+    '#type': hidden
+    '#title': 'Hakijan tyyppi'
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    hakemusprofiili:
+      '#type': webform_section
+      '#title': 'Hakijan tiedot'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': 'Hakemusta koskeva sähköposti'
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#required': true
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#required': true
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#title': Puhelinnumero
+        '#required': true
+        '#autocomplete': 'off'
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            'value': registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              'value': registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2024: '2024'
+        '#required': true
+      info_subvention_summa:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+            <div class="hds-notification__content">
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Yli 5000€ avustusten syöttäminen avaa joukon lisäkysymyksiä.</span>
+              </div>
+            </div>
+          </div>
+        '#format': full_html
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          1: '1'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+      markup:
+        '#type': webform_markup
+        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
+      info_monivuotinen:
+        '#type': processed_text
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+            <div class="hds-notification__content">
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
+              </div>
+            </div>
+          </div>
+        '#format': full_html
+      kyseessa_on_monivuotinen_avustus:
+        '#type': radios
+        '#title': 'Kyseessä on monivuotinen avustus'
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+        '#description': 'Nelivuotiskaudella 2023-2026 monivuotisia toiminta-avustuksia voidaan my&ouml;nt&auml;&auml; helsinkil&auml;isille rekister&ouml;ityneille esitt&auml;v&auml;n taiteen ja musiikin valtionosuusj&auml;rjestelm&auml;n piiriss&auml; oleville taide- ja kulttuuriyhteis&ouml;ille. Tuen saajat on p&auml;&auml;tetty vuoden 2022 lopulla.'
+        '#options':
+          1: Kyllä
+          0: Ei
+      tulevat_vuodet_joiden_ajalle_monivuotista_avustusta_on_haettu_ta:
+        '#type': textfield
+        '#title': 'Tulevat vuodet joiden ajalle monivuotista avustusta haetaan tai on myönnetty'
+        '#help': 'T&auml;yt&auml; vuodet vain t&auml;st&auml; eteenp&auml;in haettavan avustuskauden osalta. &Auml;l&auml; kirjaa saman tai aikaisemman avustuskauden aikaisempia vuosia.'
+        '#maxlength': 100
+        '#counter_type': character
+        '#counter_maximum': 100
+        '#counter_maximum_message': '%d/100 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+          required:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+        '#attributes':
+          class:
+            - webform--large
+      erittely_kullekin_vuodelle_haettavasta_avustussummasta_:
+        '#type': textfield
+        '#title': 'Erittely kullekin vuodelle haettavasta avustussummasta.'
+        '#help': 'Kirjoita vuosikohtaisesti muotoon: vuosi: avustussumma.'
+        '#maxlength': 100
+        '#counter_type': character
+        '#counter_maximum': 100
+        '#counter_maximum_message': '%d/100 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#states':
+          visible:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+          required:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+      ensisijainen_taiteen_ala:
+        '#type': select
+        '#title': 'Ensisijainen taiteenala'
+        '#help': 'Valitse pudotusvalikosta toimintaa parhaiten kuvaava vaihtoehto.'
+        '#options':
+          'Design ja käsityö': 'Design ja käsityö'
+          'Elokuva, valokuva ja media': 'Elokuva, valokuva ja media'
+          Kaupunkikulttuuri: Kaupunkikulttuuri
+          Kirjallisuus: Kirjallisuus
+          'Kuvataide ': 'Kuvataide ja sarjakuva'
+          Monitaide: Monitaide
+          Museo: Museo
+          Musiikki: Musiikki
+          Muu: Muu
+          Sirkus: Sirkus
+          Tanssi: Tanssi
+          Teatteri: Teatteri
+        '#required': true
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+      kyseessa_on_festivaali_tai_tapahtuma:
+        '#type': radios
+        '#title': 'Kyseessä on festivaali tai tapahtuma'
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#help': 'T&auml;ss&auml; tarkoitetaan festivaalia tai tapahtumaa, joka tapahtuu tiiviin ajanjakson sis&auml;ll&auml; ja on ohjelmaltaan ja kestoltaan laajempi kuin yksitt&auml;inen konsertti, esitys tms. Festivaali tai tapahtuma sis&auml;lt&auml;&auml; useampia eri ohjelmasis&auml;lt&ouml;j&auml;, esim. esityksi&auml;, joiden v&auml;liss&auml; yleis&ouml; voi my&ouml;s vaihtua. Esimerkiksi kaupunginosatapahtumat. Ei esimerkiksi esityssarjat. Festivaali tai tapahtuma voi olla toistuva tai kertaluonteinen.'
+        '#options':
+          1: Kyllä
+          0: Ei
+        '#required': true
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti:
+        '#type': textarea
+        '#title': 'Hankkeen tai toiminnan lyhyt esittelyteksti'
+        '#help': 'Teksti voidaan julkaista tai sit&auml; voidaan k&auml;ytt&auml;&auml; esittelytekstin&auml; p&auml;&auml;t&ouml;ksen yhteydess&auml; sellaisenaan tai muokattuna.'
+        '#maxlength': 700
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 700
+        '#counter_maximum_message': '%d/700 merkkiä jäljellä'
+    muut_samaan_tarkoitukseen_myonnetyt_avustukset:
+      '#type': webform_section
+      '#title': 'Muut samaan tarkoitukseen myönnetyt avustukset'
+      info_muut_samaan_tarkoitukseen_myonnetty:
+        '#type': processed_text
+        '#text': |
+          Ilmoita tähän ainoastaan avustukset, jotka on myönnetty muualta kuin Helsingin kaupungilta kuluvana ja kahtena edellisenä verovuotena.
+          <div class="hds-notification hds-notification--info">
+            <div class="hds-notification__content">
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
+              </div>
+            </div>
+          </div>
+        '#format': full_html
+      olemme_saaneet_muita_avustuksia:
+        '#type': radios
+        '#title': 'Olemme saaneet muita avustuksia'
+        '#required': true
+        '#description_display': before
+        '#options':
+          1: Kyllä
+          0: Ei
+      myonnetty_avustus:
+        '#type': webform_custom_composite
+        '#title': 'Myönnetty avustus'
+        '#title_display': before
+        '#states':
+          visible:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: 1
+          required:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: 1
+        '#multiple__header': false
+        '#multiple__item_label': 'myönnetty avustus'
+        '#multiple__no_items_message': 'Ei sy&ouml;tettyj&auml; arvoja. Lis&auml;&auml; uusi my&ouml;nnetty avustus alta.'
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää uusi myönnetty avustus'
+        '#element':
+          issuer:
+            '#type': select
+            '#options':
+              1: Valtio
+              3: EU
+              4: Muu
+              5: Säätiö
+              6: STEA
+            '#required': true
+            '#title': 'Avustuksen myöntäjä'
+          issuer_name:
+            '#type': textfield
+            '#required': true
+            '#title': 'Myöntäjän nimi'
+            '#attributes':
+              class:
+                - webform--large
+            '#help': 'Mikä taho avustusta on myöntänyt (esim. ministeriön nimi)'
+          year:
+            '#type': textfield
+            '#required': true
+            '#title': Vuosi
+            '#maxlength': 4
+            '#pattern': '^[0-9]*$'
+            '#attributes':
+              class:
+                - webform--small
+            '#pattern_error': 'Vain numeroita'
+          amount:
+            '#type': textfield
+            '#required': true
+            '#title': 'Myönnetyn avustuksen summa'
+            '#attributes':
+              class:
+                - webform--small
+            '#input_mask': '''alias'': ''currency'', ''prefix'': '''', ''suffix'': ''€'',''groupSeparator'': '' '',''radixPoint'':'','''
+          purpose:
+            '#type': textarea
+            '#title': 'Kuvaus käyttötarkoituksesta'
+            '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
+            '#maxlength': 1000
+            '#attributes':
+              class:
+                - webform--large
+            '#counter_type': character
+            '#counter_maximum': 1000
+            '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  3_yhteison_tiedot:
+    '#type': webform_wizard_page
+    '#title': '3. Yhteisön tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    jasenmaara:
+      '#type': webform_section
+      '#title': Jäsenmäärä
+      jasenmaara_fieldset:
+        '#type': fieldset
+        '#title': Jäsenmäärä
+        '#help': 'Jos yhteisöllä on jäseniä, merkitse ne tähän.'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        members_applicant_person_global:
+          '#type': number
+          '#title': 'Henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_person_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_global:
+          '#type': number
+          '#title': Yhteisöjäseniä
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä yhteisöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+    henkilosto_edellisena_paattyneena_tilivuonna:
+      '#type': webform_section
+      '#title': 'Henkilöstö edellisenä päättyneenä tilivuonna'
+      henkilosto:
+        '#type': fieldset
+        '#title': Henkilöstö
+        '#help': 'Henkilöstöön voi sisällyttää muitakin kuin palkattuja työntekijöitä, mm. palkkioilla tai muilla korvauksilla työskenteleviä tai ostopalveluna ostettavaa työtä. Kokoaikaiset työntekijät voivat sisältää myös määräaikaisia työntekijöitä, jos nämä työskentelevät täyspäiväisesti. Henkilötyövuosi kuvaa kokoaikaiseksi muutetun henkilön työpanosta. Esimerkiksi 6kk kokopäiväisesti työskentelevästä henkilöstä voi laskea muodostuvan 0,5 henkilötyövuotta. Vastaavasti koko vuoden osa-aikaisesti 30% työmäärää tekevästä henkilöstä voi laskea muodostuvan 0,3 henkilötyövuotta. Jos toimitatte tietoja henkilötyövuosistanne valtiolle tai muun tahon tilastointiin, niin käyttäkää tässä samaa laskentatapaa jos mahdollista.'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        kokoaikainen_henkilosto:
+          '#type': number
+          '#title': 'Kokoaikaisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+        kokoaikainen_henkilotyovuosia:
+          '#type': number
+          '#title': 'Kokoaikaisia: Henkilötyövuosia'
+          '#attributes':
+            class:
+              - webform--small
+        osa_aikainen_henkilosto:
+          '#type': number
+          '#title': 'Osa-aikaisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+        osa_aikainen_henkilotyovuosia:
+          '#type': number
+          '#title': 'Osa-aikaisia: Henkilötyövuosia'
+          '#attributes':
+            class:
+              - webform--small
+        vapaaehtoinen_henkilosto:
+          '#type': number
+          '#title': 'Vapaaehtoisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+    taiteellisen_toiminnan_tilat:
+      '#type': webform_section
+      '#title': 'Taiteellisen toiminnan tilat'
+      info_taiteellisen_toiminnan_tilat:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+            <div class="hds-notification__content">
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
+              </div>
+            </div>
+          </div>
+          <p>Vastaa hakuhetken tilanteen mukaisesti.</p>
+        '#format': full_html
+      taiteellisen_toiminnan_tilaa_omistuksessa_tai_ymparivuotisesti_p:
+        '#type': radios
+        '#title': 'Taiteellisen toiminnan tilaa omistuksessa tai ympärivuotisesti päävuokralaisena'
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#help': 'Taiteellisen toiminnan tilalla tarkoitetaan t&auml;ss&auml; esitystilaa, n&auml;yttelytilaa tai erillist&auml; harjoittelutilaa tai muuta taiteellisen ty&ouml;skentelyn tilaa. Ei kuitenkaan esim. toimisto tai varasto.'
+        '#options':
+          1: Kyllä
+          0: Ei
+        '#required': true
+      tila:
+        '#type': premises_composite
+        '#title': Tila
+        '#multiple': true
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#premiseType__access': true
+        '#premiseAddress__access': false
+        '#location__access': false
+        '#streetAddress__access': false
+        '#address__access': false
+        '#studentCount__access': false
+        '#specialStudents__access': false
+        '#groupCount__access': false
+        '#specialGroups__access': false
+        '#personnelCount__access': false
+        '#totalRent__access': false
+        '#rentTimeBegin__access': false
+        '#rentTimeEnd__access': false
+        '#free__access': false
+        '#isOthersUse__title': 'Tilaa tarjotaan muiden käyttöön (ilmaiseksi tai vuokralla)'
+        '#isOwnedByApplicant__title': 'Tila on omassa omistuksessa'
+        '#states':
+          visible:
+            ':input[name="taiteellisen_toiminnan_tilaa_omistuksessa_tai_ymparivuotisesti_p"]':
+              value: '1'
+          required:
+            ':input[name="taiteellisen_toiminnan_tilaa_omistuksessa_tai_ymparivuotisesti_p"]':
+              value: '1'
+  4_toiminta:
+    '#type': webform_wizard_page
+    '#title': '4. Toiminta'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    suunniteltu_toiminta:
+      '#type': webform_section
+      '#title': 'Suunniteltu toiminta'
+      arvio_maarasta_markup:
+        '#type': webform_markup
+        '#markup': |-
+          <h3>Arvio m&auml;&auml;rist&auml;</h3>
+
+          <p>Sy&ouml;t&auml; tiedot koskien omaa toimintaa vuonna, jolle avustusta haetaan. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.</p>
+      tapahtuma_tai_esityspaivien_maara_helsingissa:
+        '#type': number
+        '#title': 'Tapahtuma- tai esityspäivien määrä Helsingissä'
+        '#required': true
+        '#attributes':
+          class:
+            - webform--small
+      esityspaivien_maara_helsingissa_fieldset:
+        '#type': fieldset
+        '#title': 'Määrä Helsingissä'
+        '#attributes':
+          class:
+            - grants-fieldset
+        esitykset_maara_helsingissa:
+          '#type': number
+          '#title': Esitykset
+          '#attributes':
+            class:
+              - webform--small
+        nayttelyt_maara_helsingissa:
+          '#type': number
+          '#title': Näyttelyt
+          '#attributes':
+            class:
+              - webform--small
+        tyopaja_maara_helsingissa:
+          '#type': number
+          '#title': 'Työpaja tai muu osallistava toimintamuoto'
+          '#attributes':
+            class:
+              - webform--small
+      esityspaivien_maara_kaikkiaan_fieldset:
+        '#type': fieldset
+        '#title': 'Määrä kaikkiaan'
+        '#attributes':
+          class:
+            - grants-fieldset
+        '#help': 'T&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
+        esitykset_maara_kaikkiaan:
+          '#type': number
+          '#title': Esitykset
+          '#attributes':
+            class:
+              - webform--small
+        nayttelyt_maara_kaikkiaan:
+          '#type': number
+          '#title': Näyttelyt
+          '#attributes':
+            class:
+              - webform--small
+        tyopaja_maara_kaikkiaan:
+          '#type': number
+          '#title': 'Työpaja tai muu osallistava toimintamuoto'
+          '#attributes':
+            class:
+              - webform--small
+      esitysista_fieldset:
+        '#type': fieldset
+        '#title': Esityksistä
+        '#attributes':
+          class:
+            - grants-fieldset
+        kantaesitysten_maara:
+          '#type': number
+          '#title': 'Kantaesitysten määrä'
+          '#attributes':
+            class:
+              - webform--small
+          '#help': 'Kantaesityksell&auml; tarkoitetaan ennen esitt&auml;m&auml;t&ouml;nt&auml;, t&auml;ysin uutta teosta. Esimerkiksi uusinta-ensi-ilta ei ole kantaesitys.'
+        ensi_iltojen_maara_helsingissa:
+          '#type': number
+          '#title': 'Ensi-iltojen määrä Helsingissä'
+          '#attributes':
+            class:
+              - webform--small
+          '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimmäistä esitystä. Täytä tähän ne ensi-illat, jotka tapahtuvat Helsingissä.'
+      festivaali_paivanmaarat_maarasta_markup:
+        '#type': webform_markup
+        '#markup': '<h3>Tapahtuman tai festivaalin päivämäärät</h3>'
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
+        '#type': textarea
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Tapahtuman tai festivaalin päivämäärät'
+      toimintamuodot_markup:
+        '#type': webform_markup
+        '#markup': |-
+          <h3>Muut keskeiset toimintamuodot</h3>
+          <p>Jos toiminta sis&auml;lt&auml;&auml; yleis&ouml;lle avointen esitysten, n&auml;yttelyiden ja ty&ouml;pajojen tai muiden osallistavien toimintamuotojen lis&auml;ksi muita keskeisi&auml; muotoja, listaa ne t&auml;h&auml;n.</p>
+      muut_keskeiset_toimintamuodot:
+        '#type': textarea
+        '#title': 'Muut keskeiset toimintamuodot'
+        '#attributes':
+          class:
+            - webform--large
+    toteutunut_toiminta:
+      '#type': webform_section
+      '#title': 'Toteutunut toiminta'
+      oliko_kyseessa_festivaali_tai_tapahtuma_:
+        '#type': radios
+        '#title': 'Oliko kyseessä festivaali tai tapahtuma?'
+        '#help': 'T&auml;ss&auml; tarkoitetaan festivaalia tai tapahtumaa, joka tapahtuu tiiviin ajanjakson sis&auml;ll&auml; ja on ohjelmaltaan ja kestoltaan laajempi kuin yksitt&auml;inen konsertti, esitys tms. &nbsp;Festivaali tai tapahtuma sis&auml;lt&auml;&auml; useampia eri ohjelmasis&auml;lt&ouml;j&auml;, esim. esityksi&auml;, joiden v&auml;liss&auml; yleis&ouml; voi my&ouml;s vaihtua. Esimerkiksi kaupunginosatapahtumat. Ei esimerkiksi esityssarjat. Festivaali tai tapahtuma voi olla toistuva tai kertaluonteinen.'
+        '#options':
+          1: Kyllä
+          0: Ei
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#required': true
+      toteutuneet_markup:
+        '#type': webform_markup
+        '#markup': |-
+          <h3>Toteutuneet m&auml;&auml;r&auml;t</h3>
+
+          <p>Sy&ouml;t&auml; tiedot koskien omaa toimintaa edellisen&auml; p&auml;&auml;ttyneen&auml; vuonna. Sy&ouml;t&auml; tiedot vain fyysisten esitysten, n&auml;yttelyiden ja ty&ouml;pajojen osalta, &auml;l&auml; laske mukaan pelk&auml;st&auml;&auml;n digitaalisina toteutettuja ohjelmasis&auml;lt&ouml;j&auml;.</p>
+      tapahtuma_tai_esityspaivien_maara_helsingissa_toteutuneet:
+        '#type': number
+        '#title': 'Tapahtuma- tai esityspäivien määrä Helsingissä'
+        '#required': true
+        '#attributes':
+          class:
+            - webform--small
+      esityspaivien_maara_helsingissa_toteutuneet_fieldset:
+        '#type': fieldset
+        '#title': 'Määrä Helsingissä'
+        '#attributes':
+          class:
+            - grants-fieldset
+        esitykset_maara_helsingissa_toteutuneet:
+          '#type': number
+          '#title': Esitykset
+          '#attributes':
+            class:
+              - webform--small
+        nayttelyt_maara_helsingissa_toteutuneet:
+          '#type': number
+          '#title': Näyttelyt
+          '#attributes':
+            class:
+              - webform--small
+        tyopaja_maara_helsingissa_toteutuneet:
+          '#type': number
+          '#title': 'Työpaja tai muu osallistava toimintamuoto'
+          '#attributes':
+            class:
+              - webform--small
+      esityspaivien_maara_kaikkiaan_toteutuneet_fieldset:
+        '#type': fieldset
+        '#title': 'Määrä kaikkiaan'
+        '#attributes':
+          class:
+            - grants-fieldset
+        '#help': 'T&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
+        esitykset_maara_kaikkiaan_toteutuneet:
+          '#type': number
+          '#title': Esitykset
+          '#attributes':
+            class:
+              - webform--small
+        nayttelyt_maara_kaikkiaan_toteutuneet:
+          '#type': number
+          '#title': Näyttelyt
+          '#attributes':
+            class:
+              - webform--small
+        tyopaja_maara_kaikkiaan_toteutuneet:
+          '#type': number
+          '#title': 'Työpaja tai muu osallistava toimintamuoto'
+          '#attributes':
+            class:
+              - webform--small
+      maarat_fieldset:
+        '#type': fieldset
+        '#title': Kävijämääristä
+        '#attributes':
+          class:
+            - grants-fieldset
+        maara_helsingissa_toteutuneet:
+          '#type': number
+          '#title': 'Kävijämäärä Helsingissä'
+          '#help': 'Älä täytä samoja kävijöitä kahteen kertaan, esim. näyttelytilassa järjestettyä työpajaa sekä näyttelyihin että työpajoihin.'
+          '#attributes':
+            class:
+              - webform--small
+        maara_kaikkiaan_toteutuneet:
+          '#type': number
+          '#title': 'Kävijämäärä kaikkiaan'
+          '#help': 'Määrä kaikkiaan -kohdassa täytä luvut sisältäen toiminnan kokonaisuudessaan sekä Suomessa että mahdollisesti ulkomailla.'
+          '#attributes':
+            class:
+              - webform--small
+      toteutuneet_esitysista_fieldset:
+        '#type': fieldset
+        '#title': Esityksistä
+        '#attributes':
+          class:
+            - grants-fieldset
+        toteutuneet_kantaesitysten_maara:
+          '#type': number
+          '#title': 'Kantaesitysten määrä'
+          '#help': 'Kantaesityksell&auml; tarkoitetaan ennen esitt&auml;m&auml;t&ouml;nt&auml;, t&auml;ysin uutta teosta. Esimerkiksi uusinta-ensi-ilta ei ole kantaesitys.'
+          '#attributes':
+            class:
+              - webform--small
+        toteutuneet_ensi_iltojen_maara_helsingissa:
+          '#type': number
+          '#title': 'Ensi-iltojen määrä Helsingissä'
+          '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimmäistä esitystä. Täytä tähän ne ensi-illat, jotka tapahtuvat Helsingissä.'
+          '#attributes':
+            class:
+              - webform--small
+      toteutuneet_tila_markup:
+        '#type': webform_markup
+        '#markup': '<h3>Helsingissä järjestettävä yleisölle avoin toiminta toteutettiin</h3>'
+      toteutuneet_tila:
+        '#type': premises_composite
+        '#title': Tila
+        '#multiple': true
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#premiseType__access': false
+        '#premiseAddress__access': false
+        '#location__access': false
+        '#streetAddress__access': false
+        '#address__access': false
+        '#studentCount__access': false
+        '#specialStudents__access': false
+        '#groupCount__access': false
+        '#specialGroups__access': false
+        '#personnelCount__access': false
+        '#totalRent__access': false
+        '#rentTimeBegin__access': false
+        '#rentTimeEnd__access': false
+        '#free__access': false
+        '#isOthersUse__access': false
+        '#isOwnedByApplicant__access': false
+  5_toiminnan_lahtokohdat:
+    '#type': webform_wizard_page
+    '#title': '5. Toiminnan lähtökohdat'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    toiminnan_sisallot:
+      '#type': webform_section
+      '#title': 'Toiminnan sisällöt'
+      '#states':
+        visible:
+          ':input[name="avustukset_summa"]':
+            value:
+              greater_equal: '5000'
+      toiminta_taiteelliset_lahtokohdat:
+        '#type': textarea
+        '#title': 'Kuvaa toiminnan taiteellisia lähtökohtia ja tavoitteita, taiteellista ammattimaisuutta sekä asemaa taiteen kentällä.'
+        '#maxlength': 1000
+        '#help': 'Voit nostaa myös esiin esimerkisksi keskeisiä palkintoja tai muita noteerauksia.'
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+      toiminta_tasa_arvo:
+        '#type': textarea
+        '#title': 'Miten monimuotoisuus ja tasa-arvo toteutuu ja näkyy toiminnan järjestäjissä ja organisaatioissa sekä toiminnan sisällöissä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+    toiminnan_tavoittavuus:
+      '#type': webform_section
+      '#title': 'Toiminnan tavoittavuus'
+      toiminta_saavutettavuus:
+        '#type': textarea
+        '#title': 'Miten toiminta tehdään kaupunkilaiselle sosiaalisesti, kulttuurisesti, kielellisesti, taloudellisesti, fyysisesti, alueellisesti tai muutoin mahdollisimman saavutettavaksi? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_yhteisollisyys:
+        '#type': textarea
+        '#title': 'Miten toiminta vahvistaa yhteisöllisyyttä, verkostomaista yhteistyöskentelyä ja miten kaupunkilaisten on mahdollista osallistua toiminnan eri vaiheisiin? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_kohderyhmat:
+        '#type': textarea
+        '#title': 'Keitä toiminnalla tavoitellaan? Miten kyseiset kohderyhmät aiotaan tavoittaa ja mitä osaamista näiden kanssa työskentelyyn on?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+    toiminnan_jarjestaminen:
+      '#type': webform_section
+      '#title': 'Toiminnan järjestäminen'
+      toiminta_ammattimaisuus:
+        '#type': textarea
+        '#title': 'Kuvaa toiminnan järjestämisen ammattimaisuutta ja organisoimista'
+        '#maxlength': 1000
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_ekologisuus:
+        '#type': textarea
+        '#states':
+          visible:
+            ':input[name="avustukset_summa"]':
+              value:
+                greater_equal: '5000'
+        '#title': 'Miten ekologisuus huomioidaan toiminnan järjestämisessä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_yhteistyokumppanit:
+        '#type': textarea
+        '#title': 'Nimeä keskeisimmät yhteistyökumppanit ja kuvaa yhteistyön muotoja ja ehtoja.'
+        '#help': 'Nime&auml; maksimissaan noin viisi yhteisty&ouml;kumppania.'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+    toiminnan_kehittyminen:
+      '#type': webform_section
+      '#title': 'Toiminnan kehittyminen'
+      toiminta_tavoitteet:
+        '#type': textarea
+        '#title': 'Mitkä olivat keskeisimmät edelliselle kaudelle asetetut tavoitteet ja saavutettiinko ne?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_kaytetyt_keinot:
+        '#type': textarea
+        '#title': 'Millaisia keinoja käytetään itsearviointiin ja toiminnan kehittämiseen?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_tulevat_muutokset:
+        '#type': textarea
+        '#title': 'Mitkä ovat tulevalle vuodelle suunnitellut keskeisimmät muutokset toiminnassa ja sen järjestämisessä suhteessa aikaisempaan?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  6_talous:
+    '#type': webform_wizard_page
+    '#title': '6. Talous'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    talousarvio:
+      '#type': webform_section
+      '#title': Talousarvio
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_:
+        '#type': radios
+        '#required': true
+        '#title': 'Organisaatio kuuluu valtionosuusjärjestelmään (VOS)'
+        '#options':
+          1: Kyllä
+          0: Ei
+    suunnitellut_tulot:
+      '#type': webform_section
+      '#title': 'Suunnitellut tulot'
+      budget_static_income:
+        '#type': grants_budget_income_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#compensation__required': true
+        '#plannedStateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#plannedStateOperativeSubvention__required': true
+        '#otherCompensationFromCity__access': false
+        '#stateOperativeSubvention__access': false
+        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#plannedOtherCompensations__required': true
+        '#sponsorships__required': true
+        '#entryFees__required': true
+        '#sales__required': true
+        '#financialFundingAndInterests__required': true
+        '#customerFees__access': false
+        '#donations__access': false
+        '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationType__access': false
+        '#incomeWithoutCompensations__access': false
+        '#ownFunding__access': false
+        '#plannedTotalIncome__access': false
+        '#otherCompensations__access': false
+        '#plannedTotalIncomeWithoutSubventions__access': false
+        '#plannedShareOfIncomeWithoutSubventions__access': false
+        '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__access': false
+    suunnitellut_menot_osio:
+      '#type': webform_section
+      '#title': 'Suunnitellut menot'
+      suunnitellut_menot:
+        '#type': grants_budget_cost_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#salaries__access': false
+        '#personnelSocialSecurityCosts__access': false
+        '#rentSum__access': false
+        '#materials__access': false
+        '#transport__access': false
+        '#food__access': false
+        '#pr__access': false
+        '#insurance__access': false
+        '#snacks__access': false
+        '#cleaning__access': false
+        '#premisesService__access': false
+        '#travel__access': false
+        '#heating__access': false
+        '#servicesTotal__access': false
+        '#water__access': false
+        '#electricity__access': false
+        '#suppliesTotal__access': false
+        '#admin__access': false
+        '#accounting__access': false
+        '#health__access': false
+        '#otherCostsTotal__access': false
+        '#services__access': false
+        '#supplies__access': false
+        '#useOfCustomerFeesTotal__access': false
+        '#netCosts__access': false
+        '#performerFees__access': false
+        '#otherFees__access': false
+        '#personnelSideCosts__access': false
+        '#generalCosts__access': false
+        '#permits__access': false
+        '#setsAndCostumes__access': false
+        '#security__access': false
+        '#costsWithoutDeferredItems__access': false
+        '#generalCostsTotal__access': false
+        '#showCosts__access': false
+        '#travelCosts__access': false
+        '#transportCosts__access': false
+        '#equipment__access': false
+        '#premises__access': false
+        '#marketing__access': false
+        '#totalCosts__access': false
+        '#allCostsTotal__access': false
+        '#plannedTotalCosts__required': true
+    muu_huomioitava_panostus:
+      '#type': webform_section
+      '#title': 'Muu huomioitava panostus'
+      sisaltyyko_toiminnan_toteuttamiseen_jotain_muuta_rahanarvoista_p:
+        '#type': textarea
+        '#title': 'Sisältyykö toiminnan toteuttamiseen jotain muuta rahanarvoista panosta tai vaihtokauppaa, joka ei käy ilmi budjetista?'
+        '#attributes':
+          class:
+            - webform--large
+    toteutuneet_tulot_ja_menot:
+      '#type': webform_section
+      '#title': 'Toteutuneet tulot ja menot'
+      organisaatio_kuului_valtionosuusjarjestelmaan_vos_:
+        '#type': radios
+        '#required': true
+        '#title': 'Organisaatio kuului valtionosuusjärjestelmään (VOS)'
+        '#options':
+          1: Kyllä
+          0: Ei
+    toteutuneet_tulot:
+      '#type': webform_section
+      '#title': 'Toteutuneet tulot'
+      '#title_tag': h3
+      toteutuneet_tulot_data:
+        '#type': grants_budget_income_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#compensation__access': false
+        '#plannedStateOperativeSubvention__access': false
+        '#otherCompensationFromCity__help': 'Samaan toimitaan edelliselle päättyneelle tilivuodelle myönnetty avustus. '
+        '#otherCompensationFromCity__required': true
+        '#stateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#stateOperativeSubvention__required': true
+        '#plannedOtherCompensations__access': false
+        '#sponsorships__access': false
+        '#entryFees__access': false
+        '#sales__access': false
+        '#financialFundingAndInterests__access': false
+        '#customerFees__access': false
+        '#donations__access': false
+        '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationType__access': false
+        '#incomeWithoutCompensations__access': false
+        '#ownFunding__access': false
+        '#plannedTotalIncome__access': false
+        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#otherCompensations__required': true
+        '#plannedTotalIncomeWithoutSubventions__access': false
+        '#plannedShareOfIncomeWithoutSubventions__access': false
+        '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__help': 'Kirjaa tähän kaikki tulot yhteensä, sisältäen myös jo aiemmissa kohdissa kirjatut avustukset.'
+        '#totalIncome__required': true
+    toteutuneet_menot_osio:
+      '#type': webform_section
+      '#title': 'Toteutuneet menot'
+      menot_yhteensa:
+        '#type': grants_budget_cost_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#salaries__access': false
+        '#personnelSocialSecurityCosts__access': false
+        '#rentSum__access': false
+        '#materials__access': false
+        '#transport__access': false
+        '#food__access': false
+        '#pr__access': false
+        '#insurance__access': false
+        '#snacks__access': false
+        '#cleaning__access': false
+        '#premisesService__access': false
+        '#travel__access': false
+        '#heating__access': false
+        '#servicesTotal__access': false
+        '#water__access': false
+        '#electricity__access': false
+        '#suppliesTotal__access': false
+        '#admin__access': false
+        '#accounting__access': false
+        '#health__access': false
+        '#otherCostsTotal__access': false
+        '#services__access': false
+        '#supplies__access': false
+        '#useOfCustomerFeesTotal__access': false
+        '#netCosts__access': false
+        '#performerFees__access': false
+        '#otherFees__access': false
+        '#personnelSideCosts__access': false
+        '#generalCosts__access': false
+        '#permits__access': false
+        '#setsAndCostumes__access': false
+        '#security__access': false
+        '#costsWithoutDeferredItems__access': false
+        '#generalCostsTotal__access': false
+        '#showCosts__access': false
+        '#travelCosts__access': false
+        '#transportCosts__access': false
+        '#equipment__access': false
+        '#premises__access': false
+        '#marketing__access': false
+        '#totalCosts__required': true
+        '#allCostsTotal__access': false
+        '#plannedTotalCosts__access': false
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '7. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet</strong><br />
+          Avustushakemuksen k&auml;sittely&auml; varten tarvitaan vahvistettuja, yhteis&ouml;n kokouksessaan hyv&auml;ksymi&auml; ja allekirjoittamia, liitteit&auml; edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilivuodelta sek&auml; liitteit&auml; sille toimintavuodelle, jolle avustusta haetaan. Edellist&auml; tilivuotta koskevat liitteet ovat: tilinp&auml;&auml;t&ouml;s, toimintakertomus ja tilin- tai toiminnantarkastuskertomus. Liitteet vuodelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.<br />
+          <br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero. Uusilta hakijoilta ja tapauksissa, joissa s&auml;&auml;nn&ouml;t ovat muuttuneet edellisen hakemuksen j&auml;lkeen, tarvitaan my&ouml;s yhdistyksen s&auml;&auml;nn&ouml;t.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
+          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
+          <br />
+          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong><br />
+          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;.<br />
+          &nbsp;
+          <h3>Monivuotiset toiminta-avustukset</h3>
+          <br />
+          <br />
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liittee</strong>t<br />
+          Avustushakemuksen k&auml;sittely&auml; varten tarvitaan vahvistettuja, yhteis&ouml;n kokouksessaan hyv&auml;ksymi&auml; ja allekirjoittamia, liitteit&auml; edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilivuodelta sek&auml; liitteit&auml; sille toimintakaudelle, jolle avustusta haetaan. Edellist&auml; tilivuotta koskevat liitteet ovat: tilinp&auml;&auml;t&ouml;s, toimintakertomus ja tilin- tai toiminnantarkastuskertomus. Liitteet kaudelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.<br />
+          <br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero. Uusilta hakijoilta ja tapauksissa, joissa s&auml;&auml;nn&ouml;t ovat muuttuneet edellisen hakemuksen j&auml;lkeen, tarvitaan my&ouml;s yhdistyksen s&auml;&auml;nn&ouml;t.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong> Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
+          <br />
+          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong> Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;.
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+          <div class="hds-notification__body">
+          <p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p>
+          </div>
+          </div>
+        '#format': full_html
+      yhteison_saannot:
+        '#type': grants_attachments
+        '#title': 'Yhteisön säännöt'
+        '#multiple': false
+        '#filetype': '7'
+        '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet'
+        '#title_display': ''
+        '#description__access': false
+      vahvistettu_tilinpaatos_edelliselta_paattyneelta_tilikaudelta_:
+        '#type': grants_attachments
+        '#title': 'Vahvistettu tilinpäätös (edelliseltä päättyneeltä tilikaudelta)'
+        '#multiple': false
+        '#filetype': '43'
+        '#help': |-
+          Tilinp&auml;&auml;t&ouml;ksen t&auml;ytyy sis&auml;lt&auml;&auml; v&auml;hint&auml;&auml;n tuloslaskelma ja tase. Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun ja allekirjoitetun tilinp&auml;&auml;t&ouml;ksen.<br />
+          <br />
+          Yhteis&ouml;n tilikausi voi olla kalenterivuosi tai jokin muu kausi. Yhdistysten kohdalla niiden omissa s&auml;&auml;nn&ouml;iss&auml; lukee, mik&auml; on yhdistyksen tilikausi.
+        '#title_display': ''
+        '#description__access': false
+      vahvistettu_toimintakertomus_edelliselta_paattyneelta_tilikaudel:
+        '#type': grants_attachments
+        '#title': 'Vahvistettu toimintakertomus (edelliseltä päättyneeltä tilikaudelta)'
+        '#multiple': false
+        '#filetype': '4'
+        '#help': |-
+          Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun toimintakertomuksen.<br />
+          Jos toimintakertomus on osana tilinp&auml;&auml;t&ouml;st&auml; ja liititte sen jo tilinp&auml;&auml;t&ouml;ksen mukana lomakkeelle, sit&auml; ei tarvitse liitt&auml;&auml; t&auml;h&auml;n erikseen. Valitse t&auml;llaisessa tilanteessa toimintakertomuksen kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.
+        '#title_display': ''
+        '#description__access': false
+      vahvistettu_tilin_tai_toiminnantarkastuskertomus_edelliselta_paa:
+        '#type': grants_attachments
+        '#title': 'Vahvistettu tilin- tai toiminnantarkastuskertomus (edelliseltä päättyneeltä tilikaudelta)'
+        '#multiple': false
+        '#filetype': '5'
+        '#help': |-
+          &quot;Liit&auml; t&auml;h&auml;n allekirjoitettu tilin- tai toiminnantarkastuskertomus yhteis&ouml;n edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilikaudelta.<br />
+          Jos allekirjoitettu tilin- tai toiminnantarkastuskertomus on osa yhteis&ouml;nne tilinp&auml;&auml;t&ouml;st&auml; ja liitit sen jo lomakkeelle tilinp&auml;&auml;t&ouml;ksen kohdalla, valitse t&auml;ss&auml; kohdassa &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.&quot;
+        '#title_display': ''
+        '#description__access': false
+      toimintasuunnitelma_sille_vuodelle_jolle_haet_avustusta_monivuot:
+        '#type': grants_attachments
+        '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta, monivuotisissa koko avustuskaudelle sisältäen suunnitelman itsearviointityökalusta ja tasa-arvo- ja yhtenvertaisuussuunnitelmasta) '
+        '#multiple': false
+        '#filetype': '1'
+        '#help': 'Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n toimintasuunnitelma. , monivuotisissa koko avustuskaudelle sis&auml;lt&auml;en suunnitelman itsearviointity&ouml;kalusta ja tasa-arvo- ja yhtenvertaisuussuunnitelmasta)&nbsp;'
+        '#title_display': ''
+        '#description__access': false
+      talousarvio_sille_vuodelle_jolle_haet_avustusta_monivuotisissa_k:
+        '#type': grants_attachments
+        '#title': 'Talousarvio (sille vuodelle jolle haet avustusta, monivuotisissa koko avustuskaudelle) '
+        '#multiple': false
+        '#filetype': '2'
+        '#help': 'Talousarvio (sille vuodelle jolle haet avustusta) monivuotisissa koko avustuskaudelle)'
+        '#title_display': ''
+        '#description__access': false
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': 'Max 5000 characters.'
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: true
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: true
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: true
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '8. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: true
+  confirmation_exclude_token: true
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_tapahtuma.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_tapahtuma.yml
@@ -1,0 +1,748 @@
+uuid: f7ac8742-a0b5-48e0-a20c-b184d478282c
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationTypeSelect: '59'
+    applicationType: LIIKUNTATAPAHTUMA
+    applicationTypeID: '59'
+    applicationIndustry: KASKO
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      65: '65'
+    applicationTargetGroup: '26'
+    applicationOpen: '2023-02-18T09:28:04'
+    applicationClose: '2023-11-24T09:28:11'
+    applicationActingYearsType: fixed
+    applicationActingYears:
+      2023: '2023'
+      2024: '2024'
+      2025: '2025'
+    applicationActingYearsNextCount: ''
+    applicationContinuous: 0
+    disableCopying: 0
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: liikunta_tapahtuma
+title: 'Liikunta: Tapahtuma-avustushakemus'
+description: LIIKUNTATAPAHTUMA
+category: ''
+elements: |-
+  applicant_type:
+    '#type': hidden
+    '#title': 'Applicant Type'
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#title_display': none
+    '#description_display': invisible
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      applicant_type: 0
+      application_number: 0
+      status: 0
+      hakijan_tiedot: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+    '#data_type': euro
+    '#form_item': hidden
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+    yhteiso_jolle_haetaan_avustusta:
+      '#type': webform_section
+      '#title': 'Yhteisö, jolle haetaan avustusta'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': 'Tiedot on haettu Patentti- ja rekisterihallinnon rekisterist&auml; (PRH), eik&auml; niit&auml; voi t&auml;m&auml;n takia muokata.'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita t&auml;ss&auml; sellainen yhteis&ouml;n s&auml;hk&ouml;postiosoite, jota luetaan aktiivisesti. S&auml;hk&ouml;postiin l&auml;hetet&auml;&auml;n avustushakemukseen liittyvi&auml; yhteydenottoja esim. lis&auml;selvitys- ja t&auml;ydennyspyynt&ouml;j&auml;.'
+      email:
+        '#type': email
+        '#title': Sähköpostiosoite
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyv&auml;t viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#required': true
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#size': 63
+        '#autocomplete': 'off'
+        '#required': true
+      contact_person_phone_number:
+        '#type': textfield
+        '#title': Puhelinnumero
+        '#size': 32
+        '#autocomplete': 'off'
+        '#required': true
+        '#attributes':
+          class:
+            - webform--medium
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            'value': registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              'value': registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2022: '2022'
+          2023: '2023'
+          2024: '2024'
+        '#required': true
+    avustuslajit:
+      '#type': webform_section
+      '#title': Avustuslajit
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          37: '37'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+          6: '6'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+      markup_01:
+        '#type': webform_markup
+        '#markup': 'Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.'
+    osallistujat:
+      '#type': webform_section
+      '#title': Osallistujat
+      markup_02:
+        '#type': webform_markup
+        '#markup': 'Arvioiduissa osallistujam&auml;&auml;riss&auml; tulee huomioida ne osallistujat, joita tapahtuma liikuttaa. Arvioiduissa m&auml;&auml;riss&auml; ei siis huomioida esimerkiksi tapahtumaan osallistuvan yleis&ouml;n tai vapaaehtoisten m&auml;&auml;r&auml;&auml;.'
+      20_age_participants:
+        '#type': fieldset
+        '#title': 'Yli 20-vuotiaat osallistujat'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-medium
+        20_men:
+          '#type': number
+          '#title': Miehet
+          '#size': '32'
+          '#autocomplete': 'off'
+          '#required': true
+          '#attributes':
+            class:
+              - webform--small
+        20_women:
+          '#type': number
+          '#title': Naiset
+          '#size': '32'
+          '#autocomplete': 'off'
+          '#required': true
+          '#attributes':
+            class:
+              - webform--small
+        20_other:
+          '#type': number
+          '#title': Muut
+          '#size': '32'
+          '#autocomplete': 'off'
+          '#required': true
+          '#attributes':
+            class:
+              - webform--small
+      under_20_age_participants:
+        '#type': fieldset
+        '#title': 'Alle 20-vuotiaat osallistujat'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-medium
+        under_20_men:
+          '#type': number
+          '#title': Pojat
+          '#size': '32'
+          '#autocomplete': 'off'
+          '#required': true
+          '#attributes':
+            class:
+              - webform--small
+        under_20_women:
+          '#type': number
+          '#title': Tytöt
+          '#size': '32'
+          '#autocomplete': 'off'
+          '#required': true
+          '#attributes':
+            class:
+              - webform--small
+        under_20_other:
+          '#type': number
+          '#title': Muut
+          '#size': '32'
+          '#autocomplete': 'off'
+          '#required': true
+          '#attributes':
+            class:
+              - webform--small
+    tapahtuman_tiedot:
+      '#type': webform_section
+      '#title': 'Tapahtuman tiedot'
+      event_for_applied_grant:
+        '#type': textarea
+        '#title': 'Tapahtuma, johon avustusta haetaan'
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      event_target_group:
+        '#type': textarea
+        '#title': 'Tapahtuman kohderyhmä'
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      event_location:
+        '#type': textarea
+        '#title': Tapahtumapaikka
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      event_details:
+        '#type': textarea
+        '#title': 'Tarkemmat tiedot tapahtumasta ja sen sisällöstä'
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 3000
+        '#counter_maximum_message': '%d/3000 merkkiä jäljellä'
+      equality_radios:
+        '#type': radios
+        '#title': 'Tapahtuma edistää yhdenvertaisuutta ja tasa-arvoa'
+        '#options': yes_no
+        '#options_display': side_by_side
+      equality_how:
+        '#type': textarea
+        '#title': 'Miten?'
+        '#size': 32
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="equality_radios"]':
+              value: 'Yes'
+      inclusion_radios:
+        '#type': radios
+        '#title': 'Tapahtuma edistää osallisuutta ja yhteisöllisyyttä'
+        '#options': yes_no
+        '#options_display': side_by_side
+      inclusion_how:
+        '#type': textarea
+        '#title': 'Miten?'
+        '#size': 32
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="inclusion_radios"]':
+              value: 'Yes'
+      environment_radios:
+        '#type': radios
+        '#title': 'Tapahtumassa on huomioitu ympäristöasiat'
+        '#options': yes_no
+        '#options_display': side_by_side
+      environment_how:
+        '#type': textarea
+        '#title': 'Miten?'
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="environment_radios"]':
+              value: 'Yes'
+      exercise_radios:
+        '#type': radios
+        '#title': 'Tapahtuma innostaa uusia harrastajia omatoimisen tai ohjatun liikunnan pariin'
+        '#options': yes_no
+        '#options_display': side_by_side
+      exercise_how:
+        '#type': textarea
+        '#title': 'Miten?'
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="exercise_radios"]':
+              value: 'Yes'
+      activity_radios:
+        '#type': radios
+        '#title': 'Tapahtuma innostaa ihmisiä arkiaktiivisuuteen'
+        '#options': yes_no
+        '#options_display': side_by_side
+      activity_how:
+        '#type': textarea
+        '#title': 'Miten?'
+        '#autocomplete': 'off'
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#states':
+          visible:
+            ':input[name="activity_radios"]':
+              value: 'Yes'
+    tapahtuma_ajankohta:
+      '#type': webform_section
+      '#title': Tapahtuma-ajankohta
+      alkaa:
+        '#type': date
+        '#title': Alkaa
+        '#required': true
+        '#datepicker': true
+      paattyy:
+        '#type': date
+        '#title': Päättyy
+        '#required': true
+        '#datepicker': true
+  tapahtuman_talousarvio:
+    '#type': webform_wizard_page
+    '#title': '3. Tapahtuman talousarvio'
+    itemise_income:
+      '#type': webform_section
+      '#title': 'Tapahtuman tulot'
+      markup_03:
+        '#type': webform_markup
+        '#markup': 'Erittele tapahtuman tulot tulotyypeitt&auml;in. Kirjaa tuloihin erikseen my&ouml;s tapahtumalle my&ouml;nnetyt muut avustukset sek&auml; niiden my&ouml;nt&auml;j&auml;taho.&nbsp;'
+      budget_other_income:
+        '#type': grants_budget_other_income
+        '#title': Tulo
+        '#multiple': true
+        '#incomeGroup': general
+        '#title_display': none
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+    itemise_cost:
+      '#type': webform_section
+      '#title': 'Tapahtuman menot'
+      markup_04:
+        '#type': webform_markup
+        '#markup': 'Erittele tapahtuman menot menotyypeitt&auml;in (esimerkiksi tilavuokrat, ty&ouml;ntekij&auml;kulut).'
+      budget_other_cost:
+        '#type': grants_budget_other_cost
+        '#title': Meno
+        '#multiple': true
+        '#incomeGroup': general
+        '#title_display': none
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '4. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#maxlength': 5000
+        '#autocomplete': 'off'
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          Vaaditut liitteet:<br />
+          Vapaamuotoinen tapahtumasuunnitelma (laajempi kuvaus tapahtumasta, sen j&auml;rjestelyist&auml; ja kohderyhm&auml;st&auml;)<br />
+          Tapahtumabudjetti (mik&auml;li se ei tule riitt&auml;v&auml;ll&auml; tavalla ilmi hakemuslomakkeella)<br />
+          <br />
+          Mik&auml;li hakija ei ole aiemmin hakenut Helsingin kaupungin avustuksia tai tiedot ovat muuttuneet, hakemuksen liitteen&auml; tulee toimittaa my&ouml;s seuraavat liitteet:&nbsp;<br />
+          Yhteis&ouml;n s&auml;&auml;nn&ouml;t<br />
+          Pankin ilmoitus tilinomistajasta tai tiliotekopio (hakijalla tulee olla oma suomalainen pankkitili, jolle avustus maksetaan)&nbsp;<br />
+          Ote yhteis&ouml;muotoa koskevasta rekisterist&auml;<br />
+          <br />
+          Usean liitteen toimittaminen yhten&auml; tiedostona<br />
+          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+
+          <div class="hds-notification__body">
+          <p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p>
+          </div>
+          </div>
+          </div>
+        '#format': full_html
+      tapahtumasuunnitelma:
+        '#type': grants_attachments
+        '#title': Tapahtumasuunnitelma
+        '#multiple': false
+        '#filetype': '38'
+        '#title_display': ''
+        '#description__access': false
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#maxlength': 5000
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: true
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: true
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '5. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_yleisavustushakemus.yml
@@ -1,0 +1,584 @@
+uuid: de1894c1-0d7e-4a1f-b99d-3c4ff4d18f13
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationTypeSelect: '56'
+    applicationType: LIIKUNTAYLEIS
+    applicationTypeID: '56'
+    applicationIndustry: KASKO
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      52: '52'
+      60: '60'
+      71: '71'
+    applicationTargetGroup: '26'
+    applicationOpen: '2022-10-03T11:08:26'
+    applicationClose: '2023-07-30T11:19:00'
+    applicationActingYearsType: current_and_next_x_years
+    applicationActingYears: {  }
+    applicationActingYearsNextCount: '1'
+    applicationContinuous: 0
+    disableCopying: 0
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: liikunta_yleisavustushakemus
+title: 'Liikunta, yleisavustushakemus'
+description: LIIKUNTAYLEIS
+category: ''
+elements: |-
+  applicant_type:
+    '#type': hidden
+    '#title': 'Applicant type'
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#title_display': none
+    '#description_display': invisible
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      application_number: 0
+      applicant_type: 0
+      status: 0
+      hakijan_tiedot: 0
+      email: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+      compensation_purpose: 0
+      olemme_saaneet_muita_avustuksia: 0
+      myonnetty_avustus: 0
+      olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta: 0
+      haettu_avustus_tieto: 0
+      benefits_loans: 0
+      benefits_premises: 0
+      compensation_boolean: 0
+      compensation_explanation: 0
+      business_purpose: 0
+      community_practices_business: 0
+      fee_person: 0
+      fee_community: 0
+      members_applicant_person_local: 0
+      members_applicant_person_global: 0
+      members_applicant_community_local: 0
+      members_applicant_community_global: 0
+      additional_information: 0
+      vahvistettu_tilinpaatos: 0
+      vahvistettu_toimintakertomus: 0
+      vahvistettu_tilin_tai_toiminnantarkastuskertomus: 0
+      vuosikokouksen_poytakirja: 0
+      toimintasuunnitelma: 0
+      talousarvio: 0
+      extra_info: 0
+      muu_liite: 0
+    '#data_type': euro
+    '#form_item': hidden
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    yhteiso_jolle_haetaan_avustusta:
+      '#type': webform_section
+      '#title': 'Yhteisö, jolle haetaan avustusta'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': '<div class="grants-profile-prh-info">Tiedot on haettu Patentti- ja rekisterihallinnon rekisteristä (PRH), eikä niitä voi tämän takia muokata.</div>'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': Sähköpostiosoite
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#required': true
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#attributes':
+          class:
+            - webform--medium
+        '#title': Puhelinnumero
+        '#required': true
+        '#autocomplete': 'off'
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              value: registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#help': 'Huomioi, ett&auml; avustusten kriteerit saattavat muuttua vuosittain.'
+        '#options':
+          2022: '2022'
+          2023: '2023'
+          2024: '2024'
+        '#required': true
+    avustuslajit:
+      '#type': webform_section
+      '#title': Avustuslajit
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          9: '9'
+          31: '31'
+          43: '43'
+        '#onlyOneSubventionPerApplication': 1
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+          6: '6'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+    kayttotarkoitus:
+      '#type': webform_section
+      '#title': Käyttötarkoitus
+      compensation_purpose:
+        '#type': textarea
+        '#title': 'Lyhyt kuvaus haettavan avustuksen käyttötarkoituksista'
+        '#description': 'Kerro mit&auml; tarkoitusta varten avustusta haetaan, erittele tarvittaessa eri k&auml;ytt&ouml;kohteet.'
+        '#help': 'Kohdeavustuksen osalta tarkemmat tiedot kysyt&auml;&auml;n Webropol-lomakkeella (pakollinen liite)'
+        '#maxlength': 5000
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#cols': 63
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '3. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet avustuslajeittain</strong><br />
+          <em>Kohdeavustus:</em> erillinen hakemusliite (webropol-lomake), joka l&ouml;ytyy liikunnan avustusten verkkosivuilta.<br />
+          Jos kyseess&auml; on uusi yhdistys (ensimm&auml;ist&auml; kertaa avustusta hakevat), toimitetaan erillisen hakemusliitteen lis&auml;ksi: yhdistyksen s&auml;&auml;nn&ouml;t, pankin ilmoitus tilinomistajasta tai tiliotekopio (yhdistyksell&auml; tulee olla oma suomalainen pankkitili, jolle avustus maksetaan) sek&auml; ote yhdistysrekisterist&auml;.<br />
+          Mik&auml;li hakija ei ole toimittanut Helsingin kaupungille hakuvuonna seuraavia liitteit&auml; muiden avustushakujen yhteydess&auml;, niin edell&auml; mainittujen lis&auml;ksi tulee liitt&auml;&auml; my&ouml;s: hakuvuotta koskeva toimintasuunnitelma, hakuvuotta koskeva talousarvio, tilinp&auml;&auml;t&ouml;s (viimeisin vahvistettu), j&auml;ljenn&ouml;s tilin- tai toiminnantarkastuskertomuksesta (viimeisin vahvistettu) sek&auml; toimintakertomus (viimeisin vahvistettu).<br />
+          <br />
+          <em>Starttiavustus:</em> ote yhdistysrekisterist&auml;, yhdistyksen s&auml;&auml;nn&ouml;t, talousarvio, toimintasuunnitelma sek&auml; pankin ilmoitus tilinomistajasta tai tiliotekopio (yhdistyksell&auml; tulee olla oma suomalainen pankkitili, jolle avustus maksetaan).<br />
+          <br />
+          <em>Muu:</em> mahdollisten erillishakujen pakollisista liitteist&auml; tiedotetaan liikunnan avustusten verkkosivuilla tapauskohtaisesti.<br />
+          <br />
+          Mik&auml;li haettavaan avustukseen ei tarvitse jotain liitett&auml; toimittaa, valitse t&auml;ss&auml; tapauksessa kyseisen liitteen kohdalla vaihtoehto &quot;liite toimitetaan my&ouml;hemmin&quot;.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
+          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
+          &nbsp;
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+
+          <div class="hds-notification__body"><p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p></div>
+          </div>
+          </div>
+        '#format': full_html
+      yhteison_saannot:
+        '#type': grants_attachments
+        '#title': 'Yhteisön säännöt'
+        '#multiple': false
+        '#filetype': '7'
+        '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet.'
+        '#title_display': ''
+        '#description__access': false
+      ote_yhdistysrekisterista_uudet_seurat_:
+        '#type': grants_attachments
+        '#title': 'Ote yhdistysrekisteristä (uudet seurat)'
+        '#multiple': false
+        '#filetype': '13'
+        '#title_display': ''
+        '#description__access': false
+      toimintasuunnitelma:
+        '#type': grants_attachments
+        '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta)'
+        '#multiple': false
+        '#filetype': '1'
+        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n toimintasuunnitelma. </span></span></span>'
+        '#title_display': before
+        '#description__access': false
+      talousarvio:
+        '#type': grants_attachments
+        '#title': 'Talousarvio (sille vuodelle jolle haet avustusta)'
+        '#multiple': false
+        '#filetype': '2'
+        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n talousarvio.</span></span></span>'
+        '#title_display': before
+        '#description__access': false
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': 'Max 5000 characters.'
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: true
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: true
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: true
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '4. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: true
+  confirmation_exclude_token: true
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -1,0 +1,702 @@
+uuid: c7ee144c-3755-4676-8b45-5d262868593d
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationTypeSelect: '66'
+    applicationType: NUORTOIMPALKENNAKKO
+    applicationTypeID: '66'
+    applicationIndustry: KUVA
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      45: '45'
+      46: '46'
+    applicationTargetGroup: '27'
+    applicationOpen: '2022-10-02T11:08:26'
+    applicationClose: '2023-07-31T11:19:00'
+    applicationActingYears: {  }
+    applicationContinuous: 0
+    disableCopying: 0
+    applicationActingYearsType: current_and_next_x_years
+    applicationActingYearsNextCount: '1'
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: nuorisopalvelut_toiminta_ja_palk
+title: 'Nuorisopalvelut, toiminta- ja palkkausavustus ennakkohakemus'
+description: NUORTOIMPALKENNAKKO
+category: ''
+elements: |-
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      applicant_type: 0
+      application_number: 0
+      status: 0
+      hakijan_tiedot: 0
+      email: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+      ensisijainen_taiteen_ala: 0
+      hankkeen_nimi: 0
+      kyseessa_on_festivaali_tai_tapahtuma: 0
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti: 0
+      olemme_saaneet_muita_avustuksia: 0
+      myonnetty_avustus: 0
+      members_applicant_person_global: 0
+      members_applicant_person_local: 0
+      members_applicant_community_global: 0
+      members_applicant_community_local: 0
+      kokoaikainen_henkilosto: 0
+      kokoaikainen_henkilotyovuosia: 0
+      osa_aikainen_henkilosto: 0
+      osa_aikainen_henkilotyovuosia: 0
+      vapaaehtoinen_henkilosto: 0
+      tapahtuma_tai_esityspaivien_maara_helsingissa: 0
+      esitykset_maara_helsingissa: 0
+      nayttelyt_maara_helsingissa: 0
+      tyopaja_maara_helsingissa: 0
+      esitykset_maara_kaikkiaan: 0
+      nayttelyt_maara_kaikkiaan: 0
+      tyopaja_maara_kaikkiaan: 0
+      esitykset_kavijamaara_helsingissa: 0
+      nayttelyt_kavijamaara_helsingissa: 0
+      tyopaja_kavijamaara_helsingissa: 0
+      esitykset_kavijamaara_kaikkiaan: 0
+      nayttelyt_kavijamaara_kaikkiaan: 0
+      tyopaja_kavijamaara_kaikkiaan: 0
+      kantaesitysten_maara: 0
+      ensi_iltojen_maara_helsingissa: 0
+      ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa: 0
+      postinumero: 0
+      kyseessa_on_kaupungin_omistama_tila: 0
+      tila: 0
+      ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara: 0
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat: 0
+      hanke_alkaa: 0
+      hanke_loppuu: 0
+      laajempi_hankekuvaus: 0
+      toiminta_taiteelliset_lahtokohdat: 0
+      toiminta_tasa_arvo: 0
+      toiminta_saavutettavuus: 0
+      toiminta_yhteisollisyys: 0
+      toiminta_kohderyhmat: 0
+      toiminta_ammattimaisuus: 0
+      toiminta_ekologisuus: 0
+      toiminta_yhteistyokumppanit: 0
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_: 0
+      budget_static_income: 0
+      budget_static_cost: 0
+      budget_other_cost: 0
+      muu_huomioitava_panostus: 0
+      additional_information: 0
+      extra_info: 0
+      muu_liite: 0
+    '#data_type': euro
+    '#form_item': hidden
+  applicant_type:
+    '#type': hidden
+    '#title': 'Hakijan tyyppi'
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    hakemusprofiili:
+      '#type': webform_section
+      '#title': 'Hakijan tiedot'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': Sähköpostiosoite
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#states':
+          required:
+            ':input[name="applicant_type"]':
+              '!value': private_person
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#required': true
+        '#attributes':
+          class:
+            - webform--large
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#title': Puhelinnumero
+        '#required': true
+        '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--medium
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              value: registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2023: '2023'
+          2024: '2024'
+        '#required': true
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          1: '1'
+          2: '2'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+          6: '6'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+      markup:
+        '#type': webform_markup
+        '#markup': '<p>Valitse se avustuslaji jota haette. Voit valita my&ouml;s molemmat, jos haette molempia. Kerro t&auml;ss&auml; my&ouml;s, kuinka paljon haette avustusta. Ilmoita hakusumma kokonaislukuna ja euroissa. Hakusumma ilmoitetaan molemmille avustuslajeille erikseen.</p>'
+    edellisen_avustuksen_kayttoselvitys:
+      '#type': webform_section
+      '#title': 'Edellisen avustuksen käyttöselvitys'
+      yhdistyksen_kuluvan_vuoden_toiminta_avustus:
+        '#type': number
+        '#title': 'Yhdistyksen kuluvan vuoden toiminta-avustus'
+        '#help': 'Kirjoita t&auml;h&auml;n yhdistyksen kuluvalle vuodelle my&ouml;nnetyn toiminta-avustuksen m&auml;&auml;r&auml;'
+      selvitys_kuluvan_vuoden_toiminta_avustuksen_kaytosta:
+        '#type': number
+        '#title': 'Selvitys kuluvan vuoden toiminta-avustuksen käytöstä'
+        '#help': 'Ilmoita t&auml;ss&auml; euroina yhteens&auml;, kuinka paljon yhdistys on k&auml;ytt&auml;nyt ja k&auml;ytt&auml;&auml; kuluvan vuoden toiminta-avustusta. Ilmoitettu luku on aina osittain arvio, koska vuosi on viel&auml; kesken.&nbsp;&nbsp;'
+      yhdistyksen_kuluvan_vuoden_palkkausavustus_:
+        '#type': number
+        '#title': 'Yhdistyksen kuluvan vuoden palkkausavustus '
+        '#help': 'Kirjoita t&auml;h&auml;n yhdistyksen kuluvalle vuodelle my&ouml;nnetyn palkkausavustuksen m&auml;&auml;r&auml;'
+      selvitys_kuluvan_vuoden_palkkausavustuksen_kaytosta:
+        '#type': number
+        '#title': 'Selvitys kuluvan vuoden palkkausavustuksen käytöstä'
+        '#help': 'Ilmoita t&auml;ss&auml; euroina yhteens&auml;, kuinka paljon yhdistys on k&auml;ytt&auml;nyt ja k&auml;ytt&auml;&auml; kuluvan vuoden palkkausavustusta. Ilmoitettu luku on aina osittain arvio, koska vuosi on viel&auml; kesken.&nbsp;&nbsp;'
+      sanallinen_selvitys_avustuksen_kaytosta:
+        '#type': textarea
+        '#title': 'Kuvaus kuluvan vuoden avustuksen käytöstä'
+        '#help': 'Kerro t&auml;ss&auml; halutessasi tarkemmin kuluvan vuoden toiminta- ja palkkausavustuksen tai starttiavustuksen k&auml;yt&ouml;st&auml; ja arvioista loppuvuoden osalta.'
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '3. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen.'
+        '#maxlength': 5000
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet</strong><br />
+          Toiminta- ja palkkausavustuksen ennakkohakemuksen pakolliset liitteet ovat yhdistyksen voimassa olevat säännöt sekä yhdistyksen talousarvio ja toimintasuunnitelma sille vuodelle, jolle avustusta haetaan. Sääntöjen täytyy olla Patentti- ja rekisterihallituksen hyväksymät. <br />
+          <br />
+          <strong>Usean liitteen toimittaminen</strong><br />
+          Voit halutessasi toimittaa useampia liitteitä yhtenä tiedostona. Kerro tästä lisäselvitys liitteistä -kohdassa.<br />
+          <br />
+          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong><br />
+          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+
+          <div class="hds-notification__body"><p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p></div>
+          </div>
+          </div>
+        '#format': full_html
+      yhteison_saannot:
+        '#type': grants_attachments
+        '#title': 'Yhteisön säännöt'
+        '#multiple': false
+        '#filetype': '7'
+        '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet'
+        '#title_display': before
+      projektisuunnitelma_liite:
+        '#type': grants_attachments
+        '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta)'
+        '#multiple': false
+        '#filetype': '1'
+        '#help': 'Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n toimintasuunnitelma.'
+        '#title_display': before
+      projektin_talousarvio:
+        '#type': grants_attachments
+        '#title': 'Talousarvio (sille vuodelle jolle haet avustusta) '
+        '#multiple': false
+        '#filetype': '2'
+        '#help': 'Talousarvio (sille vuodelle jolle haet avustusta)'
+        '#title_display': before
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#maxlength': 5000
+        '#counter_type': character
+        '#counter_maximum': 5000
+        '#counter_maximum_message': 'Max 5000 merkkiä.'
+        '#attributes':
+          class:
+            - webform--large
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements:
+    application_number: application_number
+    status: status
+    applicant_type: applicant_type
+    hakijan_tiedot: hakijan_tiedot
+    email: email
+    contact_person: contact_person
+    contact_person_phone_number: contact_person_phone_number
+    community_address: community_address
+    community_address__community_address_select: community_address__community_address_select
+    community_address__community_street: community_address__community_street
+    community_address__community_post_code: community_address__community_post_code
+    community_address__community_city: community_address__community_city
+    community_address__community_country: community_address__community_country
+    bank_account: bank_account
+    bank_account__account_number_select: bank_account__account_number_select
+    bank_account__account_number: bank_account__account_number
+    community_officials: community_officials
+    community_officials__community_officials_select: community_officials__community_officials_select
+    community_officials__name: community_officials__name
+    community_officials__role: community_officials__role
+    community_officials__email: community_officials__email
+    community_officials__phone: community_officials__phone
+    acting_year: acting_year
+    subventions: subventions
+    subventions__subventionTypeTitle: subventions__subventionTypeTitle
+    subventions__subventionType: subventions__subventionType
+    subventions__amount: subventions__amount
+    avustukset_summa: avustukset_summa
+    ensisijainen_taiteen_ala: ensisijainen_taiteen_ala
+    hankkeen_nimi: hankkeen_nimi
+    kyseessa_on_festivaali_tai_tapahtuma: kyseessa_on_festivaali_tai_tapahtuma
+    hankkeen_tai_toiminnan_lyhyt_esittelyteksti: hankkeen_tai_toiminnan_lyhyt_esittelyteksti
+    olemme_saaneet_muita_avustuksia: olemme_saaneet_muita_avustuksia
+    myonnetty_avustus: myonnetty_avustus
+    myonnetty_avustus__issuer: myonnetty_avustus__issuer
+    myonnetty_avustus__issuer_name: myonnetty_avustus__issuer_name
+    myonnetty_avustus__year: myonnetty_avustus__year
+    myonnetty_avustus__amount: myonnetty_avustus__amount
+    myonnetty_avustus__purpose: myonnetty_avustus__purpose
+    members_applicant_person_global: members_applicant_person_global
+    members_applicant_person_local: members_applicant_person_local
+    members_applicant_community_global: members_applicant_community_global
+    members_applicant_community_local: members_applicant_community_local
+    kokoaikainen_henkilosto: kokoaikainen_henkilosto
+    osa_aikainen_henkilosto: osa_aikainen_henkilosto
+    vapaaehtoinen_henkilosto: vapaaehtoinen_henkilosto
+    tapahtuma_tai_esityspaivien_maara_helsingissa: tapahtuma_tai_esityspaivien_maara_helsingissa
+    kantaesitysten_maara: kantaesitysten_maara
+    ensi_iltojen_maara_helsingissa: ensi_iltojen_maara_helsingissa
+    postinumero: postinumero
+    kyseessa_on_kaupungin_omistama_tila: kyseessa_on_kaupungin_omistama_tila
+    tila: tila
+    tila__premiseName: tila__premiseName
+    tila__premiseAddress: tila__premiseAddress
+    tila__location: tila__location
+    tila__streetAddress: tila__streetAddress
+    tila__address: tila__address
+    tila__postCode: tila__postCode
+    tila__studentCount: tila__studentCount
+    tila__specialStudents: tila__specialStudents
+    tila__groupCount: tila__groupCount
+    tila__specialGroups: tila__specialGroups
+    tila__personnelCount: tila__personnelCount
+    tila__totalRent: tila__totalRent
+    tila__rentTimeBegin: tila__rentTimeBegin
+    tila__rentTimeEnd: tila__rentTimeEnd
+    tila__free: tila__free
+    tila__isOthersUse: tila__isOthersUse
+    tila__isOwnedByApplicant: tila__isOwnedByApplicant
+    tila__isOwnedByCity: tila__isOwnedByCity
+    ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara: ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara
+    festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat: festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat
+    hanke_alkaa: hanke_alkaa
+    hanke_loppuu: hanke_loppuu
+    laajempi_hankekuvaus: laajempi_hankekuvaus
+    toiminta_taiteelliset_lahtokohdat: toiminta_taiteelliset_lahtokohdat
+    toiminta_tasa_arvo: toiminta_tasa_arvo
+    toiminta_saavutettavuus: toiminta_saavutettavuus
+    toiminta_yhteisollisyys: toiminta_yhteisollisyys
+    toiminta_kohderyhmat: toiminta_kohderyhmat
+    toiminta_ammattimaisuus: toiminta_ammattimaisuus
+    toiminta_ekologisuus: toiminta_ekologisuus
+    toiminta_yhteistyokumppanit: toiminta_yhteistyokumppanit
+    organisaatio_kuuluu_valtionosuusjarjestelmaan: organisaatio_kuuluu_valtionosuusjarjestelmaan
+    additional_information: additional_information
+    extra_info: extra_info
+    muu_liite: muu_liite
+    muu_liite__attachment: muu_liite__attachment
+    muu_liite__attachmentName: muu_liite__attachmentName
+    muu_liite__description: muu_liite__description
+    muu_liite__isDeliveredLater: muu_liite__isDeliveredLater
+    muu_liite__isIncludedInOtherFile: muu_liite__isIncludedInOtherFile
+    muu_liite__fileStatus: muu_liite__fileStatus
+    muu_liite__fileType: muu_liite__fileType
+    muu_liite__integrationID: muu_liite__integrationID
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: true
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '4. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: true
+  confirmation_exclude_token: true
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
@@ -1,0 +1,598 @@
+uuid: 2b6116cc-01bd-41d1-ac3d-014896a6f095
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationTypeSelect: '65'
+    applicationType: NUORLOMALEIR
+    applicationTypeID: '65'
+    applicationIndustry: KASKO
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      54: '54'
+    applicationTargetGroup: '27'
+    applicationOpen: '2022-10-03T11:08:26'
+    applicationClose: '2023-07-30T11:19:00'
+    applicationActingYearsType: next_x_years
+    applicationActingYears: {  }
+    applicationActingYearsNextCount: '1'
+    applicationContinuous: 0
+    disableCopying: 0
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: nuorlomaleir
+title: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
+description: NUORLOMALEIR
+category: ''
+elements: |-
+  applicant_type:
+    '#type': hidden
+    '#title': 'Applicant type'
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#title_display': none
+    '#description_display': invisible
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      application_number: 0
+      applicant_type: 0
+      status: 0
+      hakijan_tiedot: 0
+      email: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+      compensation_purpose: 0
+      olemme_saaneet_muita_avustuksia: 0
+      myonnetty_avustus: 0
+      olemme_hakeneet_avustuksia_muualta_kuin_helsingin_kaupungilta: 0
+      haettu_avustus_tieto: 0
+      benefits_loans: 0
+      benefits_premises: 0
+      compensation_boolean: 0
+      compensation_explanation: 0
+      business_purpose: 0
+      community_practices_business: 0
+      fee_person: 0
+      fee_community: 0
+      members_applicant_person_local: 0
+      members_applicant_person_global: 0
+      members_applicant_community_local: 0
+      members_applicant_community_global: 0
+      additional_information: 0
+      vahvistettu_tilinpaatos: 0
+      vahvistettu_toimintakertomus: 0
+      vahvistettu_tilin_tai_toiminnantarkastuskertomus: 0
+      vuosikokouksen_poytakirja: 0
+      toimintasuunnitelma: 0
+      talousarvio: 0
+      extra_info: 0
+      muu_liite: 0
+    '#data_type': euro
+    '#form_item': hidden
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    yhteiso_jolle_haetaan_avustusta:
+      '#type': webform_section
+      '#title': 'Yhteisö, jolle haetaan avustusta'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': '<div class="grants-profile-prh-info">Tiedot on haettu Patentti- ja rekisterihallinnon rekisteristä (PRH), eikä niitä voi tämän takia muokata.</div>'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': Sähköpostiosoite
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#required': true
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#attributes':
+          class:
+            - webform--medium
+        '#title': Puhelinnumero
+        '#required': true
+        '#autocomplete': 'off'
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              value: registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2022: '2022'
+          2023: '2023'
+          2024: '2024'
+        '#required': true
+    avustuslajit:
+      '#type': webform_section
+      '#title': Avustuslajit
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          12: '12'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+          6: '6'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+    leirien_tiedot:
+      '#type': webform_section
+      '#title': 'Leirien tiedot'
+      markup_02:
+        '#type': webform_markup
+        '#markup': 'Leirien arvioidut tiedot ilmoitetaan erillisell&auml; Ennakkotiedot leireist&auml; excel-liitteell&auml;. <strong>T&auml;yt&auml; liite huolellisesti jokaisen leirin kohdalta</strong>. <a href="https://www.hel.fi/static/liitteet/nk/LA_leiriavustushakemus_Liite_tiedot%20leireista.xls">Liite on ladattavissa t&auml;st&auml;</a> tai <a href="https://avustukset.hel.fi/fi/nuorisotoiminnan-loma-aikojen-leiriavustus">leiriavustuksen palvelukuvaussivulta</a>. Liite on pakollinen ja se on toimitettava hakemuksen l&auml;hett&auml;misen yhteydess&auml;.'
+  3_talousarvio:
+    '#type': webform_wizard_page
+    '#title': '3. Talousarvio'
+    tulot:
+      '#type': webform_section
+      '#title': Tulot
+      markup_04:
+        '#type': webform_markup
+        '#markup': 'Erittele t&auml;ss&auml; seuraavan leirikauden tulot'
+      tulo:
+        '#type': grants_budget_other_income
+        '#title': Tulo
+        '#multiple': true
+        '#incomeGroup': general
+        '#help': 'Kerro t&auml;ss&auml;, millainen tulo on kyseess&auml;. Leiritoiminnan tuloja voivat olla esimerkiksi osallistumismaksut.'
+        '#required': true
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__add_more_input': false
+    menot:
+      '#type': webform_section
+      '#title': Menot
+      markup_05:
+        '#type': webform_markup
+        '#markup': 'Erittele t&auml;ss&auml; seuraavan leirikauden menot'
+      meno:
+        '#type': grants_budget_other_cost
+        '#title': Meno
+        '#multiple': true
+        '#incomeGroup': general
+        '#help': 'Kerro t&auml;ss&auml;, millainen meno on kyseess&auml;. Leiritoiminnan menoja voivat olla esimerkiksi majoituskulut, ruokakulut ja ohjaajien palkkakulut.'
+        '#required': true
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__add_more_input': false
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '4. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen&nbsp;'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet</strong><br />
+          Loma-aikojen leiriavustushakemuksen pakolliset liitteet ovat ennakkotiedot leireist&auml; excel-liite, yhdistyksen voimassa olevat s&auml;&auml;nn&ouml;t sek&auml; yhdistyksen talousarvio ja toimintasuunnitelma sille vuodelle, jolle avustusta haetaan. S&auml;&auml;nt&ouml;jen t&auml;ytyy olla Patentti- ja rekisterihallituksen hyv&auml;ksym&auml;t.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
+          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona. Kerro t&auml;st&auml; lis&auml;selvitys liitteist&auml;-kohdassa. ​​​​​​​<br />
+          <br />
+          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong><br />
+          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
+          &nbsp;
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+
+          <div class="hds-notification__body"><p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p></div>
+          </div>
+          </div>
+        '#format': full_html
+      yhteison_saannot:
+        '#type': grants_attachments
+        '#title': 'Yhteisön säännöt'
+        '#multiple': false
+        '#filetype': '7'
+        '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet.'
+        '#title_display': ''
+        '#description__access': false
+      leiri_excel:
+        '#type': grants_attachments
+        '#title': Leiri-excel
+        '#multiple': false
+        '#filetype': '0'
+        '#help': 'T&auml;yt&auml; t&auml;m&auml; pakollinen liite huolellisesti.'
+        '#title_display': ''
+        '#description__access': false
+      toimintasuunnitelma:
+        '#type': grants_attachments
+        '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta)'
+        '#multiple': false
+        '#filetype': '1'
+        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n toimintasuunnitelma. </span></span></span>'
+        '#title_display': before
+        '#description__access': false
+      talousarvio:
+        '#type': grants_attachments
+        '#title': 'Talousarvio (sille vuodelle jolle haet avustusta)'
+        '#multiple': false
+        '#filetype': '2'
+        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n talousarvio.</span></span></span>'
+        '#title_display': before
+        '#description__access': false
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': 'Max 5000 characters.'
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: true
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: true
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: true
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '5. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: true
+  confirmation_exclude_token: true
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -1,0 +1,1110 @@
+uuid: b22c9a02-f44e-4b32-9a02-45c80c71e0ee
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationTypeSelect: '49'
+    applicationType: KUVAKEHA
+    applicationTypeID: '49'
+    applicationIndustry: KUVA
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      58: '58'
+    applicationTargetGroup: '22'
+    applicationOpen: '2022-10-02T11:08:26'
+    applicationClose: '2023-07-30T11:19:00'
+    applicationContinuous: 0
+    disableCopying: 0
+    applicationActingYears:
+      2023: '2023'
+      2024: '2024'
+      2025: '2025'
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: taide_ja_kulttuuri_kehittamisavu
+title: 'Taide ja kulttuuri: kehittämisavustus'
+description: KUVAKEHA
+category: ''
+elements: |-
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    applicant_type:
+      '#type': hidden
+      '#title': 'Hakijan tyyppi'
+    hakemusprofiili:
+      '#type': webform_section
+      '#title': 'Hakijan tiedot'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': Sähköpostiosoite
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#title': Puhelinnumero
+        '#required': true
+        '#attributes':
+          class:
+            - webform--medium
+        '#autocomplete': 'off'
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            'value': registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              'value': registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2024: '2024'
+        '#required': true
+    avustuslajit:
+      '#type': webform_section
+      '#title': Avustuslajit
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          44: '44'
+          45: '45'
+          46: '46'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+      markup:
+        '#type': webform_markup
+        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
+      info_kyseessa_on_monivuotinen_avustus:
+        '#type': processed_text
+        '#text': |
+          <p>&nbsp;</p>
+
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>
+          </div>
+          </div>
+        '#format': full_html
+      kyseessa_on_monivuotinen_avustus:
+        '#type': radios
+        '#title': 'Kyseessä on monivuotinen avustus'
+        '#required': true
+        '#options':
+          1: Kyllä
+          0: Ei
+      vuodet_joille_monivuotista_avustusta_on_haettu_tai_myonetty:
+        '#type': textfield
+        '#title': 'Tulevat vuodet joiden ajalle monivuotista avustusta haetaan tai on myönnetty'
+        '#maxlength': 100
+        '#counter_type': character
+        '#counter_maximum': 100
+        '#counter_maximum_message': '%d/100 merkkiä jäljellä'
+        '#help': 'Täytä vuodet vain tästä eteenpäin haettavan avustuskauden osalta. Älä kirjaa saman tai aikaisemman avustuskauden aikaisempia vuosia.'
+        '#attributes':
+          class:
+            - webform--large
+        '#states':
+          visible:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+          required:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+      erittely_kullekin_vuodelle_haettavasta_avustussummasta:
+        '#type': textfield
+        '#title': 'Erittely kullekin vuodelle haettavasta avustussummasta'
+        '#help': 'Kirjoita vuosikohtaisesti muotoon: vuosi: avustussumma.'
+        '#maxlength': 100
+        '#counter_type': character
+        '#counter_maximum': 100
+        '#counter_maximum_message': '%d/100 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#states':
+          visible:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+          required:
+            ':input[name="kyseessa_on_monivuotinen_avustus"]':
+              value: '1'
+      ensisijainen_taiteen_ala:
+        '#type': select
+        '#title': 'Ensisijainen taiteenala'
+        '#required': true
+        '#help': 'Valitse pudotusvalikosta toimintaa parhaiten kuvaava vaihtoehto.'
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#options':
+          'Design ja käsityö': 'Design ja käsityö'
+          'Elokuva, valokuva ja media': 'Elokuva, valokuva ja media'
+          Kaupunkikulttuuri: Kaupunkikulttuuri
+          Kirjallisuus: Kirjallisuus
+          'Kuvataide ja sarjakuva': 'Kuvataide ja sarjakuva'
+          Monitaide: Monitaide
+          Museo: Museo
+          Musiikki: Musiikki
+          Muu: Muu
+          Sirkus: Sirkus
+          Tanssi: Tanssi
+          Teatteri: Teatteri
+    hankkeen_tiedot:
+      '#type': webform_section
+      '#title': 'Hankkeen tiedot'
+      hankkeen_nimi:
+        '#type': textfield
+        '#title': 'Hankkeen nimi'
+        '#help': 'Valitse hankkeelle nimi, joka voidaan julkaista päätöksen yhteydessä.'
+        '#maxlength': 100
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 100
+        '#counter_maximum_message': '%d/100 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+      kyseessa_on_festivaali_tai_tapahtuma:
+        '#type': radios
+        '#title': 'Kyseessä on festivaali tai tapahtuma'
+        '#required': true
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#help': 'Tässä tarkoitetaan festivaalia tai tapahtumaa, joka tapahtuu tiiviin ajanjakson sisällä ja on ohjelmaltaan ja kestoltaan laajempi kuin yksittäinen konsertti, esitys tms.  Festivaali tai tapahtuma sisältää useampia eri ohjelmasisältöjä, esim. esityksiä, joiden välissä yleisö voi myös vaihtua. Esimerkiksi kaupunginosatapahtumat. Ei esimerkiksi esityssarjat. Festivaali tai tapahtuma voi olla toistuva tai kertaluonteinen.'
+        '#options':
+          1: Kyllä
+          0: Ei
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti:
+        '#type': textarea
+        '#title': 'Hankkeen tai toiminnan lyhyt esittelyteksti'
+        '#help': 'Teksti voidaan julkaista tai sit&auml; voidaan k&auml;ytt&auml;&auml; esittelytekstin&auml; p&auml;&auml;t&ouml;ksen yhteydess&auml; sellaisenaan tai muokattuna.'
+        '#maxlength': 700
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 700
+        '#counter_maximum_message': '%d/700 merkkiä jäljellä'
+    muut_samaan_tarkoitukseen_myonnetyt_avustukset:
+      '#type': webform_section
+      '#title': 'Muut samaan tarkoitukseen myönnetyt avustukset'
+      info_muut_samaan_tarkoitukseen_myonnetty:
+        '#type': processed_text
+        '#text': |
+          <p>Ilmoita tähän ainoastaan avustukset, jotka on myönnetty muualta kuin Helsingin kaupungilta kuluvana ja kahtena edellisenä verovuotena.</p>
+
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Myöntävä vastaus avaa lisäkysymyksen</span></div>
+          </div>
+          </div>
+        '#format': full_html
+      olemme_saaneet_muita_avustuksia:
+        '#type': radios
+        '#title': 'Olemme saaneet muita avustuksia'
+        '#description_display': before
+        '#required': true
+        '#options':
+          1: Kyllä
+          0: Ei
+      myonnetty_avustus:
+        '#type': webform_custom_composite
+        '#title': 'Myönnetty avustus'
+        '#title_display': before
+        '#states':
+          visible:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: '1'
+          required:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: '1'
+        '#multiple__header': false
+        '#multiple__item_label': 'myönnetty avustus'
+        '#multiple__no_items_message': 'Ei sy&ouml;tettyj&auml; arvoja. Lis&auml;&auml; uusi my&ouml;nnetty avustus alta.'
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää uusi myönnetty avustus'
+        '#element':
+          issuer:
+            '#type': select
+            '#options':
+              1: Valtio
+              3: EU
+              4: Muu
+              5: Säätiö
+              6: STEA
+            '#required': true
+            '#title': 'Avustuksen myöntäjä'
+          issuer_name:
+            '#type': textfield
+            '#required': true
+            '#title': 'Myöntäjän nimi'
+            '#attributes':
+              class:
+                - webform--large
+            '#help': 'Mikä taho avustusta on myöntänyt (esim. ministeriön nimi)'
+          year:
+            '#type': textfield
+            '#required': true
+            '#title': Vuosi
+            '#attributes':
+              class:
+                - webform--small
+            '#maxlength': 4
+            '#pattern': '^[0-9]*$'
+            '#pattern_error': 'Vain numeroita'
+          amount:
+            '#type': textfield
+            '#attributes':
+              class:
+                - webform--small
+            '#required': true
+            '#title': 'Myönnetyn avustuksen summa'
+            '#input_mask': '''alias'': ''currency'', ''prefix'': '''', ''suffix'': ''€'',''groupSeparator'': '' '',''radixPoint'':'','''
+          purpose:
+            '#type': textarea
+            '#title': 'Kuvaus käyttötarkoituksesta'
+            '#attributes':
+              class:
+                - webform--large
+            '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
+            '#maxlength': 1000
+            '#counter_type': character
+            '#counter_maximum': 1000
+            '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  3_yhteison_tiedot:
+    '#type': webform_wizard_page
+    '#title': '3. Yhteisön tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    jasenmaara:
+      '#type': webform_section
+      '#title': Jäsenmäärä
+      jasenmaara_fieldset:
+        '#type': fieldset
+        '#title': Jäsenmäärä
+        '#help': 'Jos yhteisöllä on jäseniä, merkitse ne tähän.'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        members_applicant_person_global:
+          '#type': number
+          '#title': 'Henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_person_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_global:
+          '#type': number
+          '#title': Yhteisöjäseniä
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä yhteisöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+    henkilosto_hankkeessa_sina_vuonna_jolle_avustusta_haetaan:
+      '#type': webform_section
+      '#title': 'Henkilöstö hankkeessa sinä vuonna, jolle avustusta tällä hakemuksella haetaan.'
+      henkilosto:
+        '#type': fieldset
+        '#title': Henkilöstö
+        '#help': 'Henkilöstöön voi sisällyttää muitakin kuin palkattuja työntekijöitä, mm. palkkioilla tai muilla korvauksilla työskenteleviä tai ostopalveluna ostettavaa työtä. Kokoaikaiset työntekijät voivat sisältää myös määräaikaisia työntekijöitä, jos nämä työskentelevät täyspäiväisesti. Henkilötyövuosi kuvaa kokoaikaiseksi muutetun henkilön työpanosta. Esimerkiksi 6kk kokopäiväisesti työskentelevästä henkilöstä voi laskea muodostuvan 0,5 henkilötyövuotta. Vastaavasti koko vuoden osa-aikaisesti 30% työmäärää tekevästä henkilöstä voi laskea muodostuvan 0,3 henkilötyövuotta. Kyseessä on arvio, joka kuvaa suuntaa-antavasti projektiin osallistuvan henkilöstön työpanosta.'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        kokoaikainen_henkilosto:
+          '#type': number
+          '#title': 'Kokoaikaisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+        kokoaikainen_henkilotyovuosia:
+          '#type': number
+          '#title': 'Kokoaikaisia: Henkilötyövuosia'
+          '#attributes':
+            class:
+              - webform--small
+        osa_aikainen_henkilosto:
+          '#type': number
+          '#title': 'Osa-aikaisia: Henkilöitä'
+          '#attributes':
+            class:
+              - webform--small
+        osa_aikainen_henkilotyovuosia:
+          '#type': number
+          '#title': 'Osa-aikaisia: Henkilötyövuosia'
+          '#attributes':
+            class:
+              - webform--small
+      vapaaehtoinen_henkilosto:
+        '#type': number
+        '#title': Vapaaehtoisia
+        '#attributes':
+          class:
+            - webform--small
+  4_suunniteltu_toiminta:
+    '#type': webform_wizard_page
+    '#title': '4. Suunniteltu toiminta'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    yleisolle_avoin_toiminta:
+      '#type': webform_section
+      '#title': 'Yleisölle avoin toiminta Helsingissä toteutetaan'
+      tila:
+        '#type': premises_composite
+        '#title': Tilat
+        '#multiple': true
+        '#title_display': before
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__no_items_message': 'Ei syötettyjä tiloja. Lisää tilan tiedot alta.'
+        '#multiple__add_more_input': false
+        '#premiseType__access': false
+        '#premiseAddress__access': false
+        '#location__access': false
+        '#streetAddress__access': false
+        '#address__access': false
+        '#studentCount__access': false
+        '#specialStudents__access': false
+        '#groupCount__access': false
+        '#specialGroups__access': false
+        '#personnelCount__access': false
+        '#totalRent__access': false
+        '#rentTimeBegin__access': false
+        '#rentTimeEnd__access': false
+        '#free__access': false
+        '#isOthersUse__access': false
+        '#isOwnedByApplicant__access': false
+    aikataulu:
+      '#type': webform_section
+      '#title': Aikataulu
+      festivaalin_tai_tapahtuman_paivamaarat:
+        '#type': textfield
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Festivaalin tai tapahtuman kohdalla tapahtuman päivämäärät'
+      hanke_alkaa:
+        '#type': date
+        '#title': 'Hanke alkaa'
+        '#required': true
+      hanke_loppuu:
+        '#type': date
+        '#title': 'Hanke loppuu'
+        '#required': true
+    hankekuvaus:
+      '#type': webform_section
+      '#title': Hankekuvaus
+      laajempi_hankekuvaus:
+        '#type': textarea
+        '#maxlength': 2500
+        '#counter_type': character
+        '#counter_maximum': 2500
+        '#counter_maximum_message': '%d/2500 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Laajempi hankekuvaus'
+        '#help': 'Kerro hankkeesta tiiviisti. Esim. miksi, mit&auml;, kenelle, miten ja mitk&auml; ovat tavoitteet.'
+  5_toiminnan_lahtokohdat:
+    '#type': webform_wizard_page
+    '#title': '5. Toiminnan lähtökohdat'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    toiminnan_sisallot:
+      '#type': webform_section
+      '#title': 'Toiminnan sisällöt'
+      toiminta_taiteelliset_lahtokohdat:
+        '#type': textarea
+        '#title': 'Kuvaa toiminnan taiteellisia lähtökohtia ja tavoitteita, taiteellista ammattimaisuutta sekä asemaa taiteen kentällä.'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#help': 'Voit nostaa myös esiin esimerkisksi keskeisiä palkintoja tai muita noteerauksia.'
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_tasa_arvo:
+        '#type': textarea
+        '#title': 'Miten monimuotoisuus ja tasa-arvo toteutuu ja näkyy toiminnan järjestäjissä ja organisaatioissa sekä toiminnan sisällöissä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+    toiminnan_tavoittavuus:
+      '#type': webform_section
+      '#title': 'Toiminnan tavoittavuus'
+      toiminta_saavutettavuus:
+        '#type': textarea
+        '#title': 'Miten toiminta tehdään kaupunkilaiselle sosiaalisesti, kulttuurisesti, kielellisesti, taloudellisesti, fyysisesti, alueellisesti tai muutoin mahdollisimman saavutettavaksi? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_yhteisollisyys:
+        '#type': textarea
+        '#title': 'Miten toiminta vahvistaa yhteisöllisyyttä, verkostomaista yhteistyöskentelyä ja miten kaupunkilaisten on mahdollista osallistua toiminnan eri vaiheisiin? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_kohderyhmat:
+        '#type': textarea
+        '#title': 'Keitä toiminnalla tavoitellaan? Miten kyseiset kohderyhmät aiotaan tavoittaa ja mitä osaamista näiden kanssa työskentelyyn on?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+    toiminnan_jarjestaminen:
+      '#type': webform_section
+      '#title': 'Toiminnan järjestäminen'
+      toiminta_ammattimaisuus:
+        '#type': textarea
+        '#title': 'Kuvaa toiminnan järjestämisen ammattimaisuutta ja organisoimista'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_ekologisuus:
+        '#type': textarea
+        '#title': 'Miten ekologisuus huomioidaan toiminnan järjestämisessä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_yhteistyokumppanit:
+        '#type': textarea
+        '#title': 'Nimeä keskeisimmät yhteistyökumppanit ja kuvaa yhteistyön muotoja ja ehtoja.'
+        '#help': 'Nime&auml; maksimissaan noin viisi yhteisty&ouml;kumppania.'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  6_talous:
+    '#type': webform_wizard_page
+    '#title': '6. Talous'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    talousarvio:
+      '#type': webform_section
+      '#title': Talousarvio
+      '#description': 'Koskien hankkeen sitä vuotta, jolle avustusta tällä hakemuksella haetaan.'
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_:
+        '#type': radios
+        '#required': true
+        '#title': 'Organisaatio kuuluu valtionosuusjärjestelmään (VOS)'
+        '#options':
+          1: Kyllä
+          0: Ei
+    tulot:
+      '#type': webform_section
+      '#title': 'Suunnitellut tulot'
+      budget_static_income:
+        '#type': grants_budget_income_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add': false
+        '#multiple__add_more': false
+        '#multiple__add_more_input': false
+        '#plannedStateOperativeSubvention__access': false
+        '#otherCompensationFromCity__access': false
+        '#stateOperativeSubvention__access': false
+        '#customerFees__access': false
+        '#donations__access': false
+        '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationType__access': false
+        '#incomeWithoutCompensations__access': false
+        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#otherCompensations__access': false
+        '#financialFundingAndInterests__access': false
+        '#plannedTotalIncome__access': false
+        '#plannedTotalIncomeWithoutSubventions__access': false
+        '#plannedShareOfIncomeWithoutSubventions__access': false
+        '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__access': false
+    menot:
+      '#type': webform_section
+      '#title': 'Suunnitellut menot'
+      budget_other_cost:
+        '#type': grants_budget_other_cost
+        '#title': 'Muut menot'
+        '#multiple': true
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+    muu_huomioitava_panostus:
+      '#type': webform_section
+      '#title': 'Muu huomioitava panostus'
+      sisaltyyko_toiminnan_toteuttamiseen_jotain_muuta_rahanarvoista_p:
+        '#type': textarea
+        '#attributes':
+          class:
+            - webform--large
+        '#title': 'Sisältyykö toiminnan toteuttamiseen jotain muuta rahanarvoista panosta tai vaihtokauppaa, joka ei käy ilmi budjetista?'
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '7. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#counter_type': character
+        '#maxlength': 5000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet</strong>
+          <div class="ewa-rteLine">Avustushakemuksen k&auml;sittely&auml; varten tarvitaan projektisuunnitelma haetulle ajanjaksolle</div>
+
+          <div class="ewa-rteLine">sek&auml; budjetti haetulle ajanjaksolle.&nbsp;</div>
+          <br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
+          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+
+          <div class="hds-notification__body"><p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p></div>
+          </div>
+          </div>
+        '#format': full_html
+      projektisuunnitelma_liite:
+        '#type': grants_attachments
+        '#title': Projektisuunnitelma
+        '#multiple': false
+        '#filetype': '19'
+        '#help': 'Projektisuunnitelma haetulle ajanjaksolle'
+        '#title_display': before
+        '#description__access': false
+      talousarvio_liite:
+        '#type': grants_attachments
+        '#title': Talousarvio
+        '#multiple': false
+        '#filetype': '22'
+        '#help': 'Budjetti haetulle ajanjaksolle'
+        '#title_display': before
+        '#description__access': false
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': 'Max 5000 characters.'
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements:
+    application_number: application_number
+    status: status
+    applicant_type: applicant_type
+    hakijan_tiedot: hakijan_tiedot
+    email: email
+    contact_person: contact_person
+    contact_person_phone_number: contact_person_phone_number
+    community_address: community_address
+    community_address__community_address_select: community_address__community_address_select
+    community_address__community_street: community_address__community_street
+    community_address__community_post_code: community_address__community_post_code
+    community_address__community_city: community_address__community_city
+    community_address__community_country: community_address__community_country
+    bank_account: bank_account
+    bank_account__account_number_select: bank_account__account_number_select
+    bank_account__account_number: bank_account__account_number
+    community_officials: community_officials
+    community_officials__community_officials_select: community_officials__community_officials_select
+    community_officials__name: community_officials__name
+    community_officials__role: community_officials__role
+    community_officials__email: community_officials__email
+    community_officials__phone: community_officials__phone
+    acting_year: acting_year
+    subventions: subventions
+    subventions__subventionTypeTitle: subventions__subventionTypeTitle
+    subventions__subventionType: subventions__subventionType
+    subventions__amount: subventions__amount
+    hankkeen_nimi: hankkeen_nimi
+    kyseessa_on_festivaali_tai_tapahtuma: kyseessa_on_festivaali_tai_tapahtuma
+    hankkeen_tai_toiminnan_lyhyt_esittelyteksti: hankkeen_tai_toiminnan_lyhyt_esittelyteksti
+    olemme_saaneet_muita_avustuksia: olemme_saaneet_muita_avustuksia
+    myonnetty_avustus: myonnetty_avustus
+    myonnetty_avustus__issuer: myonnetty_avustus__issuer
+    myonnetty_avustus__issuer_name: myonnetty_avustus__issuer_name
+    myonnetty_avustus__year: myonnetty_avustus__year
+    myonnetty_avustus__amount: myonnetty_avustus__amount
+    myonnetty_avustus__purpose: myonnetty_avustus__purpose
+    members_applicant_person_global: members_applicant_person_global
+    members_applicant_person_local: members_applicant_person_local
+    members_applicant_community_global: members_applicant_community_global
+    members_applicant_community_local: members_applicant_community_local
+    kokoaikainen_henkilosto: kokoaikainen_henkilosto
+    osa_aikainen_henkilosto: osa_aikainen_henkilosto
+    vapaaehtoinen_henkilosto: vapaaehtoinen_henkilosto
+    tila: tila
+    tila__premiseName: tila__premiseName
+    tila__premiseAddress: tila__premiseAddress
+    tila__location: tila__location
+    tila__streetAddress: tila__streetAddress
+    tila__address: tila__address
+    tila__postCode: tila__postCode
+    tila__studentCount: tila__studentCount
+    tila__specialStudents: tila__specialStudents
+    tila__groupCount: tila__groupCount
+    tila__specialGroups: tila__specialGroups
+    tila__personnelCount: tila__personnelCount
+    tila__totalRent: tila__totalRent
+    tila__rentTimeBegin: tila__rentTimeBegin
+    tila__rentTimeEnd: tila__rentTimeEnd
+    tila__free: tila__free
+    tila__isOthersUse: tila__isOthersUse
+    tila__isOwnedByApplicant: tila__isOwnedByApplicant
+    tila__isOwnedByCity: tila__isOwnedByCity
+    laajempi_hankekuvaus: laajempi_hankekuvaus
+    toiminta_taiteelliset_lahtokohdat: toiminta_taiteelliset_lahtokohdat
+    toiminta_tasa_arvo: toiminta_tasa_arvo
+    toiminta_saavutettavuus: toiminta_saavutettavuus
+    toiminta_yhteisollisyys: toiminta_yhteisollisyys
+    toiminta_kohderyhmat: toiminta_kohderyhmat
+    toiminta_ammattimaisuus: toiminta_ammattimaisuus
+    toiminta_ekologisuus: toiminta_ekologisuus
+    toiminta_yhteistyokumppanit: toiminta_yhteistyokumppanit
+    organisaatio_kuuluu_valtionosuusjarjestelmaan: organisaatio_kuuluu_valtionosuusjarjestelmaan
+    additional_information: additional_information
+    extra_info: extra_info
+    muu_liite: muu_liite
+    muu_liite__attachment: muu_liite__attachment
+    muu_liite__attachmentName: muu_liite__attachmentName
+    muu_liite__description: muu_liite__description
+    muu_liite__isDeliveredLater: muu_liite__isDeliveredLater
+    muu_liite__isIncludedInOtherFile: muu_liite__isIncludedInOtherFile
+    muu_liite__fileStatus: muu_liite__fileStatus
+    muu_liite__fileType: muu_liite__fileType
+    muu_liite__integrationID: muu_liite__integrationID
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: true
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '8. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: true
+  confirmation_exclude_token: true
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1,0 +1,1279 @@
+uuid: 5a67fcdb-8e64-4d4b-a508-2b94c8efb8ca
+langcode: fi
+status: open
+dependencies:
+  module:
+    - grants_handler
+    - grants_metadata
+third_party_settings:
+  grants_metadata:
+    applicationTypeSelect: '50'
+    applicationType: KUVAPERUS
+    applicationTypeID: '50'
+    applicationIndustry: KUVA
+    applicantTypes:
+      registered_community: registered_community
+    applicationTypeTerms:
+      45: '45'
+    applicationTargetGroup: '22'
+    applicationOpen: '2022-10-02T11:08:26'
+    applicationClose: '2023-07-31T11:19:00'
+    applicationContinuous: 0
+    disableCopying: 0
+    applicationActingYearsType: next_x_years
+    applicationActingYears: {  }
+    applicationActingYearsNextCount: '1'
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: taide_ja_kulttuuriavustukset_tai
+title: 'Taide- ja kulttuuriavustukset, taiteen perusopetus'
+description: KUVAPERUS
+category: ''
+elements: |-
+  avustukset_summa:
+    '#type': grants_webform_summation_field
+    '#title': 'Avustukset summa'
+    '#title_display': none
+    '#collect_field':
+      subventions%%amount: subventions%%amount
+      applicant_type: 0
+      application_number: 0
+      status: 0
+      hakijan_tiedot: 0
+      email: 0
+      contact_person: 0
+      contact_person_phone_number: 0
+      community_address: 0
+      bank_account: 0
+      community_officials: 0
+      acting_year: 0
+      subventions%%subventionTypeTitle: 0
+      subventions%%subventionType: 0
+      ensisijainen_taiteen_ala: 0
+      hankkeen_nimi: 0
+      kyseessa_on_festivaali_tai_tapahtuma: 0
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti: 0
+      olemme_saaneet_muita_avustuksia: 0
+      myonnetty_avustus: 0
+      members_applicant_person_global: 0
+      members_applicant_person_local: 0
+      members_applicant_community_global: 0
+      members_applicant_community_local: 0
+      kokoaikainen_henkilosto: 0
+      kokoaikainen_henkilotyovuosia: 0
+      osa_aikainen_henkilosto: 0
+      osa_aikainen_henkilotyovuosia: 0
+      vapaaehtoinen_henkilosto: 0
+      tapahtuma_tai_esityspaivien_maara_helsingissa: 0
+      esitykset_maara_helsingissa: 0
+      nayttelyt_maara_helsingissa: 0
+      tyopaja_maara_helsingissa: 0
+      esitykset_maara_kaikkiaan: 0
+      nayttelyt_maara_kaikkiaan: 0
+      tyopaja_maara_kaikkiaan: 0
+      esitykset_kavijamaara_helsingissa: 0
+      nayttelyt_kavijamaara_helsingissa: 0
+      tyopaja_kavijamaara_helsingissa: 0
+      esitykset_kavijamaara_kaikkiaan: 0
+      nayttelyt_kavijamaara_kaikkiaan: 0
+      tyopaja_kavijamaara_kaikkiaan: 0
+      kantaesitysten_maara: 0
+      ensi_iltojen_maara_helsingissa: 0
+      ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa: 0
+      postinumero: 0
+      kyseessa_on_kaupungin_omistama_tila: 0
+      tila: 0
+      ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara: 0
+      festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat: 0
+      hanke_alkaa: 0
+      hanke_loppuu: 0
+      laajempi_hankekuvaus: 0
+      toiminta_taiteelliset_lahtokohdat: 0
+      toiminta_tasa_arvo: 0
+      toiminta_saavutettavuus: 0
+      toiminta_yhteisollisyys: 0
+      toiminta_kohderyhmat: 0
+      toiminta_ammattimaisuus: 0
+      toiminta_ekologisuus: 0
+      toiminta_yhteistyokumppanit: 0
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_: 0
+      budget_static_income: 0
+      budget_static_cost: 0
+      budget_other_cost: 0
+      muu_huomioitava_panostus: 0
+      additional_information: 0
+      extra_info: 0
+      muu_liite: 0
+    '#data_type': euro
+    '#form_item': hidden
+  applicant_type:
+    '#type': hidden
+    '#title': 'Hakijan tyyppi'
+  1_hakijan_tiedot:
+    '#type': webform_wizard_page
+    '#title': '1. Hakijan tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    application_number:
+      '#type': hidden
+      '#title': Hakemusnumero
+      '#disabled': true
+    status:
+      '#type': hidden
+      '#title': 'Hakemuksen tila'
+      '#readonly': true
+    hakemusprofiili:
+      '#type': webform_section
+      '#title': 'Hakijan tiedot'
+      '#attributes':
+        class:
+          - grants-profile--imported-section
+      prh_markup:
+        '#type': webform_markup
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
+      hakijan_tiedot:
+        '#type': applicant_info
+        '#title': 'Hakijan tiedot'
+    contact_person_email_section:
+      '#type': webform_section
+      '#title': Sähköposti
+      contact_markup:
+        '#type': webform_markup
+        '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
+      email:
+        '#type': email
+        '#title': 'Hakemusta koskeva sähköposti'
+        '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
+        '#size': 63
+        '#autocomplete': 'off'
+        '#required': true
+    contact_person_section:
+      '#type': webform_section
+      '#title': 'Hakemuksen yhteyshenkilö'
+      contact_person:
+        '#type': textfield
+        '#title': Yhteyshenkilö
+        '#autocomplete': 'off'
+        '#required': true
+        '#size': 63
+      contact_person_phone_number:
+        '#type': textfield
+        '#title': Puhelinnumero
+        '#required': true
+        '#autocomplete': 'off'
+        '#size': 32
+    osoite:
+      '#type': webform_section
+      '#title': Osoite
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
+      community_address:
+        '#type': community_address_composite
+        '#title': 'Yhteisön osoite'
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään osoitetietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#states':
+          visible:
+            ':input[name="applicant_type"]':
+              value: registered_community
+    tilinumero:
+      '#type': webform_section
+      '#title': Tilinumero
+      bank_account:
+        '#type': bank_account_composite
+        '#title': Tilinumero
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry ylläpitämään tilinumerotietoa omiin tietoihin.'
+        '#attributes':
+          class:
+            - webform--medium
+        '#required': true
+    toiminnasta_vastaavat_henkilot:
+      '#type': webform_section
+      '#title': 'Toiminnasta vastaavat henkilöt'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            '!value': private_person
+      community_officials:
+        '#type': community_officials_composite
+        '#help': 'Jos haluat lisätä, poistaa tai muuttaa henkilöitä tallenna hakemus luonnokseksi ja siirry ylläpitämään henkilöiden tietoja omiin tietoihin.'
+        '#title': 'Valitse toiminnasta vastaavat henkilöt'
+        '#multiple': true
+        '#multiple__item_label': henkilö
+        '#multiple__min_items': 0
+        '#multiple__empty_items': 1
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää henkilö'
+        '#wrapper_attributes':
+          class:
+            - community_officials_wrapper
+        '#attributes':
+          class:
+            - webform--large
+  2_avustustiedot:
+    '#type': webform_wizard_page
+    '#title': '2. Avustustiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    avustuksen_tiedot:
+      '#type': webform_section
+      '#title': 'Avustuksen tiedot'
+      acting_year:
+        '#type': select
+        '#title': 'Vuosi, jolle haen avustusta'
+        '#options':
+          2024: '2024'
+        '#required': true
+      subventions:
+        '#type': grants_compensations
+        '#title': Avustukset
+        '#multiple': true
+        '#subventionType':
+          1: '1'
+        '#required': true
+        '#multiple__header': true
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more': false
+        '#attributes':
+          class:
+            - subventions
+        '#subvention_type':
+          1: '1'
+        '#subvention_type_id__access': false
+        '#subvention_type__title': Avustuslaji
+        '#subvention_amount__title': 'Avustuksen summa'
+      markup:
+        '#type': webform_markup
+        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
+      ensisijainen_taiteen_ala:
+        '#type': select
+        '#title': 'Ensisijainen taiteenala'
+        '#help': 'Valitse pudotusvalikosta toimintaa parhaiten kuvaava vaihtoehto.'
+        '#options':
+          'Design ja käsityö': 'Design ja käsityö'
+          'Elokuva, valokuva ja media': 'Elokuva, valokuva ja media'
+          Kirjallisuus: Kirjallisuus
+          'Kuvataide ': 'Kuvataide ja sarjakuva'
+          Monitaide: Monitaide
+          Musiikki: Musiikki
+          Sirkus: Sirkus
+          Tanssi: Tanssi
+          Teatteri: Teatteri
+        '#required': true
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+      hankkeen_tai_toiminnan_lyhyt_esittelyteksti:
+        '#type': textarea
+        '#title': 'Hankkeen tai toiminnan lyhyt esittelyteksti'
+        '#help': 'Teksti voidaan julkaista tai sit&auml; voidaan k&auml;ytt&auml;&auml; esittelytekstin&auml; p&auml;&auml;t&ouml;ksen yhteydess&auml; sellaisenaan tai muokattuna.'
+        '#maxlength': 700
+        '#attributes':
+          class:
+            - webform--large
+        '#required': true
+        '#counter_type': character
+        '#counter_maximum': 700
+        '#counter_maximum_message': '%d/700 merkkiä jäljellä'
+    muut_samaan_tarkoitukseen_myonnetyt_avustukset:
+      '#type': webform_section
+      '#title': 'Muut samaan tarkoitukseen myönnetyt avustukset'
+      info_muut_samaan_tarkoitukseen_myonnetty:
+        '#type': processed_text
+        '#text': |
+          Ilmoita tähän ainoastaan avustukset, jotka on myönnetty muualta kuin Helsingin kaupungilta kuluvana ja kahtena edellisenä verovuotena.
+          <div class="hds-notification hds-notification--info">
+            <div class="hds-notification__content">
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
+              </div>
+            </div>
+          </div>
+        '#format': full_html
+      olemme_saaneet_muita_avustuksia:
+        '#type': radios
+        '#title': 'Olemme saaneet muita avustuksia'
+        '#required': true
+        '#description_display': before
+        '#options':
+          1: Kyllä
+          0: Ei
+      myonnetty_avustus:
+        '#type': webform_custom_composite
+        '#title': 'Myönnetty avustus'
+        '#title_display': before
+        '#states':
+          visible:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: 1
+          required:
+            ':input[name="olemme_saaneet_muita_avustuksia"]':
+              value: 1
+        '#multiple__header': false
+        '#multiple__item_label': 'myönnetty avustus'
+        '#multiple__no_items_message': 'Ei sy&ouml;tettyj&auml; arvoja. Lis&auml;&auml; uusi my&ouml;nnetty avustus alta.'
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää uusi myönnetty avustus'
+        '#element':
+          issuer:
+            '#type': select
+            '#options':
+              1: Valtio
+              3: EU
+              4: Muu
+              5: Säätiö
+              6: STEA
+            '#required': true
+            '#title': 'Avustuksen myöntäjä'
+          issuer_name:
+            '#type': textfield
+            '#required': true
+            '#title': 'Myöntäjän nimi'
+            '#attributes':
+              class:
+                - webform--large
+            '#help': 'Mikä taho avustusta on myöntänyt (esim. ministeriön nimi)'
+          year:
+            '#type': textfield
+            '#required': true
+            '#title': Vuosi
+            '#maxlength': 4
+            '#pattern': '^[0-9]*$'
+            '#attributes':
+              class:
+                - webform--small
+            '#pattern_error': 'Vain numeroita'
+          amount:
+            '#type': textfield
+            '#required': true
+            '#title': 'Myönnetyn avustuksen summa'
+            '#attributes':
+              class:
+                - webform--small
+            '#input_mask': '''alias'': ''currency'', ''prefix'': '''', ''suffix'': ''€'',''groupSeparator'': '' '',''radixPoint'':'','''
+          purpose:
+            '#type': textarea
+            '#title': 'Kuvaus käyttötarkoituksesta'
+            '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
+            '#maxlength': 1000
+            '#attributes':
+              class:
+                - webform--large
+            '#counter_type': character
+            '#counter_maximum': 1000
+            '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  3_yhteison_tiedot:
+    '#type': webform_wizard_page
+    '#title': '3. Yhteisön tiedot'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    jasenmaara:
+      '#type': webform_section
+      '#title': Jäsenmäärä
+      jasenmaara_fieldset:
+        '#type': fieldset
+        '#title': Jäsenmäärä
+        '#help': 'Jos yhteisöllä on jäseniä, merkitse ne tähän.'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        members_applicant_person_global:
+          '#type': number
+          '#title': 'Henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_person_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä henkilöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_global:
+          '#type': number
+          '#title': Yhteisöjäseniä
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+        members_applicant_community_local:
+          '#type': number
+          '#title': 'Helsinkiläisiä yhteisöjäseniä yhteensä'
+          '#maxlength': 7
+          '#pattern': '^[0-9]*$'
+          '#pattern_error': 'Vain numeroita'
+          '#size': 16
+          '#attributes':
+            class:
+              - webform--small
+    taiteellisen_toiminnan_tilat:
+      '#type': webform_section
+      '#title': 'Taiteellisen toiminnan tilat'
+      info_taiteellisen_toiminnan_tilat:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+            <div class="hds-notification__content">
+              <div class="hds-notification__label" role="heading" aria-level="2">
+                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
+                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
+              </div>
+            </div>
+          </div>
+          <p>Vastaa hakuhetken tilanteen mukaisesti.</p>
+        '#format': full_html
+      taiteellisen_toiminnan_tilaa_omistuksessa_tai_ymparivuotisesti_p:
+        '#type': radios
+        '#title': 'Taiteellisen toiminnan tilaa omistuksessa tai ympärivuotisesti päävuokralaisena'
+        '#wrapper_attributes':
+          class:
+            - webform-element-help--wrapper-short
+        '#help': 'Taiteellisen toiminnan tilalla tarkoitetaan t&auml;ss&auml; esitystilaa, n&auml;yttelytilaa tai erillist&auml; harjoittelutilaa tai muuta taiteellisen ty&ouml;skentelyn tilaa. Ei kuitenkaan esim. toimisto tai varasto.'
+        '#options':
+          1: Kyllä
+          0: Ei
+        '#required': true
+      tila:
+        '#type': premises_composite
+        '#title': Tila
+        '#multiple': true
+        '#states':
+          visible:
+            ':input[name="taiteellisen_toiminnan_tilaa_omistuksessa_tai_ymparivuotisesti_p"]':
+              value: '1'
+          required:
+            ':input[name="taiteellisen_toiminnan_tilaa_omistuksessa_tai_ymparivuotisesti_p"]':
+              value: '1'
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#premiseAddress__access': false
+        '#location__access': false
+        '#streetAddress__access': false
+        '#address__access': false
+        '#studentCount__access': false
+        '#specialStudents__access': false
+        '#groupCount__access': false
+        '#specialGroups__access': false
+        '#personnelCount__access': false
+        '#totalRent__access': false
+        '#rentTimeBegin__access': false
+        '#rentTimeEnd__access': false
+        '#free__access': false
+        '#isOthersUse__title': 'Tilaa tarjotaan muiden käyttöön (ilmaiseksi tai vuokralla)'
+        '#citySection__access': false
+        '#premiseSuitability__access': false
+  4_toiminta:
+    '#type': webform_wizard_page
+    '#title': '4. Toiminta'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    tiedot_opetuksesta:
+      '#type': webform_section
+      '#title': 'Tiedot opetuksesta'
+      markup_01:
+        '#type': webform_markup
+        '#markup': 'Oppilaat 20.9. Vain helsinkil&auml;iset 0-19 vuotiaat oppilaat.'
+      kaikki:
+        '#type': fieldset
+        '#title': Kaikki
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        varhaisian_opinnot:
+          '#type': number
+          '#title': 'Varhaisiän opinnot'
+        laaja_oppimaara_perusopinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä perusopinnot'
+        laaja_oppimaara_syventavat_opinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä syventävät opinnot'
+        yleinen_oppimaara:
+          '#type': number
+          '#title': 'Yleinen oppimäärä'
+      tytot:
+        '#type': fieldset
+        '#title': Tytöt
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        tytot_varhaisian_opinnot:
+          '#type': number
+          '#title': 'Varhaisiän opinnot'
+        tytot_laaja_oppimaara_perusopinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä perusopinnot'
+        tytot_laaja_oppimaara_syventavat_opinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä syventävät opinnot'
+        tytot_yleinen_oppimaara:
+          '#type': number
+          '#title': 'Yleinen oppimäärä'
+      pojat:
+        '#type': fieldset
+        '#title': Pojat
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        pojat_varhaisian_opinnot:
+          '#type': number
+          '#title': 'Varhaisiän opinnot'
+        pojat_laaja_oppimaara_perusopinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä perusopinnot'
+        pojat_laaja_oppimaara_syventavat_opinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä syventävät opinnot'
+        pojat_yleinen_oppimaara:
+          '#type': number
+          '#title': 'Yleinen oppimäärä'
+      koko_opetushenkiloston_lukumaara_20_9:
+        '#type': number
+        '#title': 'Koko opetushenkilöstön lukumäärä 20.9'
+      kuvaile_oppilaaksi_ottamisen_tapaa:
+        '#type': textarea
+        '#title': 'Kuvaile oppilaaksi ottamisen tapaa'
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      tehdaanko_oppilaitoksessanne_tarvittaessa_oppimaaran_tai_opetuks:
+        '#type': textarea
+        '#title': 'Tehdäänkö oppilaitoksessanne tarvittaessa oppimäärän tai opetuksen yksilöllistämistä?'
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      onko_vapaa_oppilaspaikkoja_montako_:
+        '#type': textarea
+        '#title': 'Onko vapaa oppilaspaikkoja? Montako?'
+      opetustunnit_helsingissa_edellisena_paattyneena_tilivuonna:
+        '#type': fieldset
+        '#title': 'Opetustunnit Helsingissä edellisenä päättyneenä tilivuonna'
+        '#attributes':
+          class:
+            - grants-fieldset
+            - grants-fieldset-short
+        opetustunnit_varhaisian_opinnot:
+          '#type': number
+          '#title': 'Varhaisiän opinnot'
+        opetustunnit_laaja_oppimaara_perusopinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä, perusopinnot'
+        opetustunnit_laaja_oppimaara_syventavat_opinnot:
+          '#type': number
+          '#title': 'Laaja oppimäärä syventävät opinnot'
+        opetustunnit_yleinen_oppimaara:
+          '#type': number
+          '#title': 'Yleinen oppimäärä'
+    helsingissa_jarjestettava:
+      '#type': webform_section
+      '#title': 'Helsingissä järjestettävä yleisölle avoin toiminta toteutettiin'
+      helsingissa_jarjestettava_tila:
+        '#type': premises_composite
+        '#title': Tila
+        '#multiple': true
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__add_more_input': false
+        '#premiseAddress__access': false
+        '#location__access': false
+        '#streetAddress__access': false
+        '#address__access': false
+        '#studentCount__access': false
+        '#specialStudents__access': false
+        '#groupCount__access': false
+        '#specialGroups__access': false
+        '#personnelCount__access': false
+        '#totalRent__access': false
+        '#rentTimeBegin__access': false
+        '#rentTimeEnd__access': false
+        '#free__access': false
+        '#isOthersUse__access': false
+        '#isOthersUse__title': 'Tilaa tarjotaan muiden käyttöön (ilmaiseksi tai vuokralla)'
+        '#isOwnedByApplicant__access': false
+  5_toiminnan_lahtokohdat:
+    '#type': webform_wizard_page
+    '#title': '5. Toiminnan lähtökohdat'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    toiminnan_sisallot:
+      '#type': webform_section
+      '#title': 'Toiminnan sisällöt'
+      toiminta_tasa_arvo:
+        '#type': textarea
+        '#title': 'Miten monimuotoisuus ja tasa-arvo toteutuu ja näkyy toiminnan järjestäjissä ja organisaatioissa sekä toiminnan sisällöissä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+    toiminnan_tavoittavuus:
+      '#type': webform_section
+      '#title': 'Toiminnan tavoittavuus'
+      toiminta_saavutettavuus:
+        '#type': textarea
+        '#title': 'Miten toiminta tehdään kaupunkilaiselle sosiaalisesti, kulttuurisesti, kielellisesti, taloudellisesti, fyysisesti, alueellisesti tai muutoin mahdollisimman saavutettavaksi? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+    toiminnan_jarjestaminen:
+      '#type': webform_section
+      '#title': 'Toiminnan järjestäminen'
+      toiminta_ekologisuus:
+        '#type': textarea
+        '#title': 'Miten ekologisuus huomioidaan toiminnan järjestämisessä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?'
+        '#maxlength': 1000
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+        '#attributes':
+          class:
+            - webform--large
+    toiminnan_kehittyminen:
+      '#type': webform_section
+      '#title': 'Toiminnan kehittyminen'
+      toiminta_tavoitteet:
+        '#type': textarea
+        '#title': 'Mitkä olivat keskeisimmät edelliselle kaudelle asetetut tavoitteet ja saavutettiinko ne?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_kaytetyt_keinot:
+        '#type': textarea
+        '#title': 'Millaisia keinoja käytetään itsearviointiin ja toiminnan kehittämiseen?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+      toiminta_tulevat_muutokset:
+        '#type': textarea
+        '#title': 'Mitkä ovat tulevalle vuodelle suunnitellut keskeisimmät muutokset toiminnassa ja sen järjestämisessä suhteessa aikaisempaan?'
+        '#maxlength': 1000
+        '#attributes':
+          class:
+            - webform--large
+        '#counter_type': character
+        '#counter_maximum': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
+  6_talous:
+    '#type': webform_wizard_page
+    '#title': '6. Talous'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
+    talousarvio:
+      '#type': webform_section
+      '#title': Talousarvio
+      processed_text:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Koskien sitä vuotta, jolle avustusta tällä hakemuksella haetaan</span></div>
+          </div>
+          </div>
+        '#format': full_html
+      organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_:
+        '#type': radios
+        '#required': true
+        '#title': 'Organisaatio kuuluu valtionosuusjärjestelmään (VOS)'
+        '#options':
+          1: Kyllä
+          0: Ei
+    suunnitellut_tulot:
+      '#type': webform_section
+      '#title': 'Suunnitellut tulot'
+      budget_static_income:
+        '#type': grants_budget_income_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#compensation__required': true
+        '#plannedStateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#plannedStateOperativeSubvention__required': true
+        '#otherCompensationFromCity__access': false
+        '#stateOperativeSubvention__access': false
+        '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#plannedOtherCompensations__required': true
+        '#sponsorships__required': true
+        '#entryFees__required': true
+        '#sales__required': true
+        '#financialFundingAndInterests__required': true
+        '#customerFees__access': false
+        '#donations__access': false
+        '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationType__access': false
+        '#incomeWithoutCompensations__access': false
+        '#ownFunding__access': false
+        '#plannedTotalIncome__access': false
+        '#otherCompensations__access': false
+        '#plannedTotalIncomeWithoutSubventions__access': false
+        '#plannedShareOfIncomeWithoutSubventions__access': false
+        '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__access': false
+    suunnitellut_menot_osio:
+      '#type': webform_section
+      '#title': 'Suunnitellut menot'
+      suunnitellut_menot:
+        '#type': grants_budget_cost_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#salaries__access': false
+        '#personnelSocialSecurityCosts__access': false
+        '#rentSum__access': false
+        '#materials__access': false
+        '#transport__access': false
+        '#food__access': false
+        '#pr__access': false
+        '#insurance__access': false
+        '#snacks__access': false
+        '#cleaning__access': false
+        '#premisesService__access': false
+        '#travel__access': false
+        '#heating__access': false
+        '#servicesTotal__access': false
+        '#water__access': false
+        '#electricity__access': false
+        '#suppliesTotal__access': false
+        '#admin__access': false
+        '#accounting__access': false
+        '#health__access': false
+        '#otherCostsTotal__access': false
+        '#services__access': false
+        '#supplies__access': false
+        '#useOfCustomerFeesTotal__access': false
+        '#netCosts__access': false
+        '#performerFees__access': false
+        '#otherFees__access': false
+        '#personnelSideCosts__access': false
+        '#generalCosts__access': false
+        '#permits__access': false
+        '#setsAndCostumes__access': false
+        '#security__access': false
+        '#costsWithoutDeferredItems__access': false
+        '#generalCostsTotal__access': false
+        '#showCosts__access': false
+        '#travelCosts__access': false
+        '#transportCosts__access': false
+        '#equipment__access': false
+        '#premises__access': false
+        '#marketing__access': false
+        '#totalCosts__access': false
+        '#allCostsTotal__access': false
+        '#plannedTotalCosts__required': true
+    toteutuneet_tulot_ja_menot:
+      '#type': webform_section
+      '#title': 'Toteutuneet tulot ja menot'
+      processed_text_01:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label">Edellisenä päättyneenä tilivuonna. Tilinpäätöksen mukaisesti.</div>
+          </div>
+          </div>
+        '#format': full_html
+      organisaatio_kuului_valtionosuusjarjestelmaan_vos_:
+        '#type': radios
+        '#required': true
+        '#title': 'Organisaatio kuului valtionosuusjärjestelmään (VOS)'
+        '#options':
+          1: Kyllä
+          0: Ei
+    toteutuneet_tulot:
+      '#type': webform_section
+      '#title': 'Toteutuneet tulot'
+      '#title_tag': h3
+      toteutuneet_tulot_data:
+        '#type': grants_budget_income_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#compensation__access': false
+        '#plannedStateOperativeSubvention__access': false
+        '#otherCompensationFromCity__help': 'Samaan toimitaan edelliselle päättyneelle tilivuodelle myönnetty avustus. '
+        '#otherCompensationFromCity__required': true
+        '#stateOperativeSubvention__help': 'Kirjaa muut kuin toiminta-avustukset muihin avustuksiin. '
+        '#stateOperativeSubvention__required': true
+        '#plannedOtherCompensations__access': false
+        '#sponsorships__access': false
+        '#entryFees__access': false
+        '#sales__access': false
+        '#financialFundingAndInterests__access': false
+        '#customerFees__access': false
+        '#donations__access': false
+        '#compensationFromCulturalAffairs__access': false
+        '#otherCompensationType__access': false
+        '#incomeWithoutCompensations__access': false
+        '#ownFunding__access': false
+        '#plannedTotalIncome__access': false
+        '#otherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#otherCompensations__required': true
+        '#plannedTotalIncomeWithoutSubventions__access': false
+        '#plannedShareOfIncomeWithoutSubventions__access': false
+        '#shareOfIncomeWithoutSubventions__access': false
+        '#totalIncomeWithoutSubventions__access': false
+        '#totalIncome__help': 'Kirjaa tähän kaikki tulot yhteensä, sisältäen myös jo aiemmissa kohdissa kirjatut avustukset.'
+        '#totalIncome__required': true
+    toteutuneet_menot_osio:
+      '#type': webform_section
+      '#title': 'Toteutuneet menot'
+      menot_yhteensa:
+        '#type': grants_budget_cost_static
+        '#title': '<empty>'
+        '#multiple': false
+        '#incomeGroup': general
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
+        '#multiple__sorting': false
+        '#multiple__operations': false
+        '#multiple__add_more': false
+        '#salaries__access': false
+        '#personnelSocialSecurityCosts__access': false
+        '#rentSum__access': false
+        '#materials__access': false
+        '#transport__access': false
+        '#food__access': false
+        '#pr__access': false
+        '#insurance__access': false
+        '#snacks__access': false
+        '#cleaning__access': false
+        '#premisesService__access': false
+        '#travel__access': false
+        '#heating__access': false
+        '#servicesTotal__access': false
+        '#water__access': false
+        '#electricity__access': false
+        '#suppliesTotal__access': false
+        '#admin__access': false
+        '#accounting__access': false
+        '#health__access': false
+        '#otherCostsTotal__access': false
+        '#services__access': false
+        '#supplies__access': false
+        '#useOfCustomerFeesTotal__access': false
+        '#netCosts__access': false
+        '#performerFees__access': false
+        '#otherFees__access': false
+        '#personnelSideCosts__access': false
+        '#generalCosts__access': false
+        '#permits__access': false
+        '#setsAndCostumes__access': false
+        '#security__access': false
+        '#costsWithoutDeferredItems__access': false
+        '#generalCostsTotal__access': false
+        '#showCosts__access': false
+        '#travelCosts__access': false
+        '#transportCosts__access': false
+        '#equipment__access': false
+        '#premises__access': false
+        '#marketing__access': false
+        '#totalCosts__required': true
+        '#allCostsTotal__access': false
+        '#plannedTotalCosts__access': false
+  lisatiedot_ja_liitteet:
+    '#type': webform_wizard_page
+    '#title': '7. Lisätiedot ja liitteet'
+    lisatietoja_hakemukseen_liittyen:
+      '#type': webform_section
+      '#title': 'Lisätietoja hakemukseen liittyen'
+      additional_information:
+        '#type': textarea
+        '#title': Lisätiedot
+        '#help': 'T&auml;h&auml;n voit tarvittaessa kirjoittaa lis&auml;tietoja tai muita perusteluja hakemukseen liittyen tai ilmoittaa perustietoihin tulleista muutoksista&nbsp;'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
+        '#cols': 63
+    liitteet:
+      '#type': webform_section
+      '#title': Liitteet
+      attachments_info:
+        '#type': webform_markup
+        '#markup': |-
+          Avustushakemuksen k&auml;sittely&auml; varten tulee toimittaa kaikki alla luetellut liitteet. Avustushakemus voidaan hyl&auml;t&auml;, jos liitteit&auml; ei ole toimitettu. Mik&auml;li joku liitteist&auml; puuttuu, kerro siit&auml; hakemuksen Lis&auml;selvitys liitteist&auml; -kohdassa.<br />
+          <br />
+          <strong>Vaaditut liitteet</strong><br />
+          Avustushakemuksen k&auml;sittely&auml; varten tarvitaan vahvistettuja, yhteis&ouml;n kokouksessaan hyv&auml;ksymi&auml; ja allekirjoittamia, liitteit&auml; edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilivuodelta sek&auml; liitteit&auml; sille toimintavuodelle, jolle avustusta haetaan. Edellist&auml; tilivuotta koskevat liitteet ovat: tilinp&auml;&auml;t&ouml;s, toimintakertomus ja tilin- tai toiminnantarkastuskertomus. Liitteet vuodelle, jolle avustusta haetaan ovat: talousarvio ja toimintasuunnitelma.<br />
+          <br />
+          Uusilta hakijoilta ja tapauksissa, joissa pankkiyhteystiedot ovat muuttuneet, tarvitaan hakijan Omiin tietoihin my&ouml;s tiliote tai vastaava asiakirja, josta selvi&auml;&auml; tilinomistajan nimi ja tilinumero. Uusilta hakijoilta ja tapauksissa, joissa s&auml;&auml;nn&ouml;t ovat muuttuneet edellisen hakemuksen j&auml;lkeen, tarvitaan my&ouml;s yhdistyksen s&auml;&auml;nn&ouml;t.<br />
+          <br />
+          <strong>Usean liitteen toimittaminen yhten&auml; tiedostona</strong><br />
+          Voit halutessasi toimittaa useampia liitteit&auml; yhten&auml; tiedostona Tilinp&auml;&auml;t&ouml;s tai talousarvio -liitekohdassa. Merkitse t&auml;ll&ouml;in muiden liiteotsikoiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.<br />
+          <br />
+          <strong>Helsingin kaupungille aiemmin toimitetut liitteet</strong><br />
+          Jos vaaditut liitteet on jo toimitettu toisen Helsingin kaupungille osoitetun avustushakemuksen liitteen&auml;, samoja liitteit&auml; ei tarvitse toimittaa uudelleen. Merkitse t&auml;ll&ouml;in toimitettujen liitteiden kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;. Yhteis&ouml;n vahvistettu tilinp&auml;&auml;t&ouml;s, toimintakertomus, toimintasuunnitelma ja talousarvio eiv&auml;t voi olla erilaisia eri hakemusten liitteen&auml;.
+      notification_attachments:
+        '#type': processed_text
+        '#text': |
+          <div class="hds-notification hds-notification--info">
+          <div class="hds-notification__content">
+          <div class="hds-notification__label"><span>Liitteiden sisältöä ei voi tarkastella jälkikäteen</span></div>
+          <div class="hds-notification__body">
+          <p>Huomioithan, että et pysty avaamaan liitteitä sen jälkeen, kun olet liittänyt ne lomakkeelle. Näet liitteestä ainoastaan sen tiedostonimen.</p>
+          <p>Vaikka et voi tarkastella liitteiden sisältä jälkikäteen, lomakkeelle liitetyt liitteet lähtevät lomakkeen muiden tietojen mukana avustushakemuksen käsittelijälle.</p>
+          </div>
+          </div>
+        '#format': full_html
+      yhteison_saannot:
+        '#type': grants_attachments
+        '#title': 'Yhteisön säännöt'
+        '#multiple': false
+        '#filetype': '7'
+        '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet'
+        '#title_display': ''
+        '#description__access': false
+      vahvistettu_tilinpaatos_edelliselta_paattyneelta_tilikaudelta_:
+        '#type': grants_attachments
+        '#title': 'Vahvistettu tilinpäätös (edelliseltä päättyneeltä tilikaudelta)'
+        '#multiple': false
+        '#filetype': '43'
+        '#help': |-
+          Tilinp&auml;&auml;t&ouml;ksen t&auml;ytyy sis&auml;lt&auml;&auml; v&auml;hint&auml;&auml;n tuloslaskelma ja tase. Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun ja allekirjoitetun tilinp&auml;&auml;t&ouml;ksen.<br />
+          <br />
+          Yhteis&ouml;n tilikausi voi olla kalenterivuosi tai jokin muu kausi. Yhdistysten kohdalla niiden omissa s&auml;&auml;nn&ouml;iss&auml; lukee, mik&auml; on yhdistyksen tilikausi.
+        '#title_display': ''
+        '#description__access': false
+      vahvistettu_toimintakertomus_edelliselta_paattyneelta_tilikaudel:
+        '#type': grants_attachments
+        '#title': 'Vahvistettu toimintakertomus (edelliseltä päättyneeltä tilikaudelta)'
+        '#multiple': false
+        '#filetype': '4'
+        '#help': |-
+          Yhdistys liitt&auml;&auml; t&auml;h&auml;n kohtaan yhdistyksen j&auml;senkokouksessa vahvistetun toimintakertomuksen.<br />
+          Jos toimintakertomus on osana tilinp&auml;&auml;t&ouml;st&auml; ja liititte sen jo tilinp&auml;&auml;t&ouml;ksen mukana lomakkeelle, sit&auml; ei tarvitse liitt&auml;&auml; t&auml;h&auml;n erikseen. Valitse t&auml;llaisessa tilanteessa toimintakertomuksen kohdalla &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.
+        '#title_display': ''
+        '#description__access': false
+      vahvistettu_tilin_tai_toiminnantarkastuskertomus_edelliselta_paa:
+        '#type': grants_attachments
+        '#title': 'Vahvistettu tilin- tai toiminnantarkastuskertomus (edelliseltä päättyneeltä tilikaudelta)'
+        '#multiple': false
+        '#filetype': '5'
+        '#help': |-
+          &quot;Liit&auml; t&auml;h&auml;n allekirjoitettu tilin- tai toiminnantarkastuskertomus yhteis&ouml;n edelliselt&auml; p&auml;&auml;ttyneelt&auml; tilikaudelta.<br />
+          Jos allekirjoitettu tilin- tai toiminnantarkastuskertomus on osa yhteis&ouml;nne tilinp&auml;&auml;t&ouml;st&auml; ja liitit sen jo lomakkeelle tilinp&auml;&auml;t&ouml;ksen kohdalla, valitse t&auml;ss&auml; kohdassa &rdquo;Liite on toimitettu yhten&auml; tiedostona tai toisen hakemuksen yhteydess&auml;&rdquo;.&quot;
+        '#title_display': ''
+        '#description__access': false
+      toimintasuunnitelma_sille_vuodelle_jolle_haet_avustusta_monivuot:
+        '#type': grants_attachments
+        '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta) '
+        '#multiple': false
+        '#filetype': '1'
+        '#help': 'Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n toimintasuunnitelma. , monivuotisissa koko avustuskaudelle sis&auml;lt&auml;en suunnitelman itsearviointity&ouml;kalusta ja tasa-arvo- ja yhtenvertaisuussuunnitelmasta)&nbsp;'
+        '#title_display': ''
+        '#description__access': false
+      talousarvio_sille_vuodelle_jolle_haet_avustusta_monivuotisissa_k:
+        '#type': grants_attachments
+        '#title': 'Talousarvio (sille vuodelle jolle haet avustusta) '
+        '#multiple': false
+        '#filetype': '2'
+        '#help': 'Talousarvio (sille vuodelle jolle haet avustusta) monivuotisissa koko avustuskaudelle)'
+        '#title_display': ''
+        '#description__access': false
+      extra_info:
+        '#type': textarea
+        '#title': 'Lisäselvitys liitteistä'
+        '#counter_type': character
+        '#attributes':
+          class:
+            - webform--large
+        '#maxlength': 5000
+        '#counter_maximum': 5000
+        '#counter_maximum_message': 'Max 5000 characters.'
+        '#cols': 63
+      muu_liite:
+        '#type': grants_attachments
+        '#title': 'Muu liite'
+        '#multiple': 10
+        '#filetype': '0'
+        '#title_display': before
+        '#multiple__item_label': liite
+        '#multiple__sorting': false
+        '#multiple__add': false
+        '#multiple__remove': false
+        '#multiple__add_more_input': false
+        '#multiple__add_more_button_label': 'Lisää liite'
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: false
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: true
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: true
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: true
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: true
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: '< Edellinen'
+  wizard_next_button_label: 'Seuraava >'
+  wizard_toggle: true
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 2
+  preview_label: '8. Vahvista, esikatsele ja lähetä'
+  preview_title: 'Vahvista, esikatsele ja lähetä'
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: false
+  preview_exclude_empty_checkbox: false
+  draft: all
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: none
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: true
+  confirmation_exclude_token: true
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: draft
+  purge_days: 365
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles:
+      - admin
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  grants_handler:
+    id: grants_handler
+    handler_id: grants_handler
+    label: 'Grants Handler'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      debug: true
+variants: {  }

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.country_codes.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.country_codes.yml
@@ -1,0 +1,14 @@
+uuid: 429db7f5-eec4-4556-85ef-5900eb847cf2
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: adQ16YGDPk7QfUKrfrC35o2sKdHEozdNtdpiH7CftQQ
+id: country_codes
+label: 'Country codes'
+category: Geographic
+likert: false
+options: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.country_names.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.country_names.yml
@@ -1,0 +1,14 @@
+uuid: 2284a7ec-2e9d-4cfa-92e1-c17d4ca16278
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: zsfFP124dAM-sJkuEfnwaA7DN6o3-IsaXLgdNmObbYg
+id: country_names
+label: 'Country names'
+category: Geographic
+likert: false
+options: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.days.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.days.yml
@@ -1,0 +1,21 @@
+uuid: ecc0a2da-fab8-48d9-9aa8-3c5feba46c04
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: YNrKbYrWWjeubUUM8AsQ19KnX7cU1elACR14CZJHmdg
+id: days
+label: Päivät
+category: 'Aika ja päiväys'
+likert: false
+options: |
+  Sunday: Sunday
+  Monday: Monday
+  Tuesday: Tuesday
+  Wednesday: Wednesday
+  Thursday: Thursday
+  Friday: Friday
+  Saturday: Saturday

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.education.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.education.yml
@@ -1,0 +1,18 @@
+uuid: 40ebc3d8-3466-45db-94c4-4ff62b5b0342
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: mII4acOv33s-j8PINywrCag4OITbeJGxdPO373dnHHw
+id: education
+label: Education
+category: Demographic
+likert: false
+options: |
+  High School: High School
+  Associate Degree: Associate Degree
+  Graduate or Professional Degree: Graduate or Professional Degree
+  Some College: Some College

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.employment_status.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.employment_status.yml
@@ -1,0 +1,19 @@
+uuid: 7a4dd1fb-49dc-42d5-8b48-4266af04f168
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: 8MCmsz_csdJkVItxI8g_s4zp2PM285YqCy_gWTzOLPw
+id: employment_status
+label: 'Employment status'
+category: Demographic
+likert: false
+options: |
+  'Full Time': 'Full Time'
+  'Part Time': 'Part Time'
+  'Military': 'Military'
+  Unemployed: Unemployed
+  Retired: Retired

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.ethnicity.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.ethnicity.yml
@@ -1,0 +1,22 @@
+uuid: b88e202f-7123-4408-b73b-1db8ee731ba3
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: pIPgrAC82wE2GAk1mOv2UvMYv71YQe4VT8667QIYdvI
+id: ethnicity
+label: Ethnicity
+category: Demographic
+likert: false
+options: |
+  Caucasian: Caucasian
+  'Latino/Hispanic': 'Latino/Hispanic'
+  'Middle Eastern': 'Middle Eastern'
+  African: African
+  Caribbean: Caribbean
+  'South Asian': 'South Asian'
+  'East Asian': 'East Asian'
+  Mixed: Mixed

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.gender.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.gender.yml
@@ -1,0 +1,42 @@
+uuid: 73b4a2bc-5308-4102-b4ac-604c69108615
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: yxhG0JmQs2HT-Ro6ZeDQboDc9ZWR4GglflTtyoqxK4A
+id: gender
+label: Sukupuoli
+category: Demographic
+likert: false
+options: |
+  Man: Man
+  Woman: Woman
+  Non-binary: Non-binary
+  Agender/Genderless: Agender/Genderless
+  Androgyne/Androgynous: Androgyne/Androgynous
+  Aporagender: Aporagender
+  Bigender: Bigender
+  Demi-agender: Demi-agender
+  Demi-boy: Demi-boy
+  Demi-fluid: Demi-fluid
+  Demi-girl: Demi-girl
+  Demi-gender: Demi-gender
+  Demi-non-binary: Demi-non-binary
+  Genderqueer: Genderqueer
+  Genderflux: Genderflux
+  Genderfluid: Genderfluid
+  Gender-indifferent: Gender-indifferent
+  Gender-neutral: Gender-neutral
+  Graygender: Graygender
+  Intergender: Intergender
+  Maverique: Maverique
+  Maxigender: Maxigender
+  Multigender/Polygender: Multigender/Polygender
+  Neutrois: Neutrois
+  Pangender/Omnigender: Pangender/Omnigender
+  Trigender: Trigender
+  Two-spirit: Two-spirit
+  'Prefer Not to Answer': 'Prefer Not to Answer'

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.industry.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.industry.yml
@@ -1,0 +1,53 @@
+uuid: a9f7df24-9802-4c30-9162-e20fde628557
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: s_SXZn2HbRGvTex-TLOCxz2oOnMYqtEZh8HD4_318QI
+id: industry
+label: Industry
+category: Demographic
+likert: false
+options: |
+  Accounting/Finance: Accounting/Finance
+  Advertising/Public Relations: Advertising/Public Relations
+  Aerospace/Aviation: Aerospace/Aviation
+  Arts/Entertainment/Publishing: Arts/Entertainment/Publishing
+  Automotive: Automotive
+  Banking/Mortgage: Banking/Mortgage
+  Business Development: Business Development
+  Business Opportunity: Business Opportunity
+  Clerical/Administrative: Clerical/Administrative
+  Construction/Facilities: Construction/Facilities
+  Consumer Goods: Consumer Goods
+  Customer Service: Customer Service
+  Education/Training: Education/Training
+  Energy/Utilities: Energy/Utilities
+  Engineering: Engineering
+  Government/Military: Government/Military
+  Healthcare: Healthcare
+  Hospitality/Travel: Hospitality/Travel
+  Human Resources: Human Resources
+  Installation/Maintenance: Installation/Maintenance
+  Insurance: Insurance
+  Internet: Internet
+  Law Enforcement/Security: Law Enforcement/Security
+  Legal: Legal
+  Management/Executive: Management/Executive
+  Manufacturing/Operations: Manufacturing/Operations
+  Marketing: Marketing
+  Non-Profit/Volunteer: Non-Profit/Volunteer
+  Pharmaceutical/Biotech: Pharmaceutical/Biotech
+  Professional Services: Professional Services
+  Real Estate: Real Estate
+  Restaurant/Food Service: Restaurant/Food Service
+  Retail: Retail
+  Sales: Sales
+  Science/Research: Science/Research
+  Skilled Labor: Skilled Labor
+  Technology: Technology
+  Telecommunications: Telecommunications
+  Transportation/Logistics: Transportation/Logistics

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.languages.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.languages.yml
@@ -1,0 +1,14 @@
+uuid: ab400150-6bbc-47ba-9223-22813ee31f74
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: mYH14Vi65Ixj10c_GFa7CipxU3D0Bt9wgo8zE8zjOfE
+id: languages
+label: Kielet
+category: Language
+likert: false
+options: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_agreement.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_agreement.yml
@@ -1,0 +1,19 @@
+uuid: 29a545a5-caaa-49fb-ac74-7f097c1adaf7
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: '-NQROvgYPm-rqn_e6mytSaxmdhSViUinffVfQhp7APs'
+id: likert_agreement
+label: 'Likert: Agreement'
+category: Likert
+likert: true
+options: |
+  1: 'Much Worse'
+  2: 'Somewhat Worse'
+  3: 'About the Same'
+  4: 'Somewhat Better'
+  5: 'Much Better'

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_comparison.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_comparison.yml
@@ -1,0 +1,19 @@
+uuid: 84cb8c77-36d9-4ff8-987a-fb1ff1907b65
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: gZCLESMdXmEZxHqnQFx7a0rUefrkVuFzHSMnWe0qioM
+id: likert_comparison
+label: 'Likert: Comparison'
+category: Likert
+likert: true
+options: |
+  1: Strongly Disagree
+  2: Disagree
+  3: Neutral
+  4: Agree
+  5: Strongly Agree

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_importance.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_importance.yml
@@ -1,0 +1,19 @@
+uuid: a2b47057-7bbe-415b-8c58-28d9fee2e204
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: Hbc8n5HtVZVs5fSBSpSbuY07CVvqkKP76csvRHN9pK8
+id: likert_importance
+label: 'Likert: Importance'
+category: Likert
+likert: true
+options: |
+  1: Not at all Important
+  2: Somewhat Important
+  3: Neutral
+  4: Important
+  5: Very Important

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_quality.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_quality.yml
@@ -1,0 +1,19 @@
+uuid: b7a1fc31-8728-431b-83c6-9b157ea36aa1
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: swmYtBVUbwq7aHJWWDN7ODByuvur9vMkexDC9h64NZ8
+id: likert_quality
+label: 'Likert: Quality'
+category: Likert
+likert: true
+options: |
+  1: Poor
+  2: Fair
+  3: Good
+  4: Very good
+  5: Excellent

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_satisfaction.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_satisfaction.yml
@@ -1,0 +1,19 @@
+uuid: f2b95198-f773-493c-b30a-fe3d1e332844
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: AKE2SNwCpl6Mu_cmbq9ZM2_cXxCikCVj1vcPE9oHWTs
+id: likert_satisfaction
+label: 'Likert: Satisfaction'
+category: Likert
+likert: true
+options: |
+  1: Very Unsatisfied
+  2: Unsatisfied
+  3: Neutral
+  4: Satisfied
+  5: Very Satisfied

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_ten_scale.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_ten_scale.yml
@@ -1,0 +1,24 @@
+uuid: 6c9b2c0b-1f52-42e7-a0e3-425c7aa029db
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: zEZX8JSVqznnFtqFfpuC593h3t1JDAZhF0Q3pvA229o
+id: likert_ten_scale
+label: 'Likert: Ten Scale'
+category: Likert
+likert: true
+options: |
+  1: 1
+  2: 2
+  3: 3
+  4: 4
+  5: 5
+  6: 6
+  7: 7
+  8: 8
+  9: 9
+  10: 10

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_would_you.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.likert_would_you.yml
@@ -1,0 +1,19 @@
+uuid: acec7eaa-b48c-416d-b43e-188dcda3d146
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: qBS2TmfAJB37Qn3TnrNM8x4AWimmDapcizzRllgo0fo
+id: likert_would_you
+label: 'Likert: Would You'
+category: Likert
+likert: true
+options: |
+  1: Definitely Not
+  2: Probably Not
+  3: Not Sure
+  4: Probably
+  5: Definitely

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.marital_status.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.marital_status.yml
@@ -1,0 +1,18 @@
+uuid: eba5654f-8926-4ccf-80b0-2dad15183f72
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: cjVDbAE5BlopGrY-tfxsxMoyEibwBBNgdQwDdxOSkow
+id: marital_status
+label: 'Marital status'
+category: Demographic
+likert: false
+options: |
+  Single: Single
+  Married: Married
+  Divorced: Divorced
+  Widowed: Widowed

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.months.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.months.yml
@@ -1,0 +1,26 @@
+uuid: 87fbd3df-58af-49d6-9f06-d36f5b84411b
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: pZJnuQkh9afNML5IcMuKTUC__vmHMFn66Qr5IWtedZ4
+id: months
+label: Kuukaudet
+category: 'Aika ja päiväys'
+likert: false
+options: |
+  January: January
+  February: February
+  March: March
+  April: April
+  May: May
+  June: June
+  July: July
+  August: August
+  September: September
+  October: October
+  November: November
+  December: December

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.phone_types.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.phone_types.yml
@@ -1,0 +1,17 @@
+uuid: cd394de1-f967-4415-acec-b55f23ede50b
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: LkO63Zl2cP_l9YdjzWI8dWoD9uD0pytkPiUiUM2bo9A
+id: phone_types
+label: 'Phone type'
+category: Demographic
+likert: false
+options: |
+  Home: Home
+  Office: Office
+  Cell: Cell

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.province_codes.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.province_codes.yml
@@ -1,0 +1,27 @@
+uuid: 3be6056f-cc54-4f98-8e4f-0c6ffa97b424
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: cR3A6XXinVGC9g5vLS-vVvTC2ppZXRNXLPWA8xBUMew
+id: province_codes
+label: 'Province codes'
+category: Geographic
+likert: false
+options: |
+  AB: Alberta
+  BC: 'British Columbia'
+  MB: Manitoba
+  NB: 'New Brunswick'
+  NL: 'Newfoundland and Labrador'
+  NS: 'Nova Scotia'
+  NT: 'Northwest Territories'
+  NU: Nunavut
+  'ON': Ontario
+  PE: 'Prince Edward Island'
+  QC: Quebec
+  SK: Saskatchewan
+  YT: Yukon

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.province_names.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.province_names.yml
@@ -1,0 +1,27 @@
+uuid: 6506860b-ec3f-4b50-a2b0-31aa34f5bbed
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: aaEeYBWoWETLKX2ivmZBpUAd3uPe2iPNydaxBuLPXKc
+id: province_names
+label: 'Province names'
+category: Geographic
+likert: false
+options: |
+  Alberta: Alberta
+  'British Columbia': 'British Columbia'
+  Manitoba: Manitoba
+  'New Brunswick': 'New Brunswick'
+  'Newfoundland and Labrador': 'Newfoundland and Labrador'
+  'Nova Scotia': 'Nova Scotia'
+  'Northwest Territories': 'Northwest Territories'
+  Nunavut: Nunavut
+  Ontario: Ontario
+  'Prince Edward Island': 'Prince Edward Island'
+  Quebec: Quebec
+  Saskatchewan: Saskatchewan
+  Yukon: Yukon

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.relationship.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.relationship.yml
@@ -1,0 +1,19 @@
+uuid: b549c8f6-76e0-47a4-9272-4e6351dd3737
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: 4J2RPG4JmsD4Fm1NlIQY0JHkrJ08UUl0qTF0_EjUxvw
+id: relationship
+label: Suhde
+category: Demographic
+likert: false
+options: |
+  Parent: Parent
+  'Significant Other': 'Significant Other'
+  Sibling: Sibling
+  Child: Child
+  Friend: Friend

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.sex.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.sex.yml
@@ -1,0 +1,16 @@
+uuid: 4591f477-a350-4956-8e49-cb8815394645
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: WRpxpwYpfcO_i0so7BV4QXxXlbPiSVppYmAV6DAz4c0
+id: sex
+label: Sex
+category: Demographic
+likert: false
+options: |
+  Male: Male
+  Female: Female

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.sex_icao.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.sex_icao.yml
@@ -1,0 +1,17 @@
+uuid: 78a68771-1feb-4ffb-9822-4371b01b7f88
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: 9mxo86dMII5OxkHl4mbe2l4AgQloOXuErOte57BU9IY
+id: sex_icao
+label: 'Sex - International Civil Aviation Organization (ICAO)'
+category: Demographic
+likert: false
+options: |
+  M: Male
+  F: Female
+  X: Unspecified

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.size.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.size.yml
@@ -1,0 +1,19 @@
+uuid: a6dc0280-410a-4f59-81d6-1ccac75f674d
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: RKkc6tf1VudvYiOtwPCf3Tp_EoA6fov6BFC34D7gMoQ
+id: size
+label: Koko
+category: 'Yleiset asetukset'
+likert: false
+options: |
+  Extra Small: Extra Small
+  Small: Small
+  Medium: Medium
+  Large: Large
+  Extra Large: Extra Large

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.state_codes.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.state_codes.yml
@@ -1,0 +1,66 @@
+uuid: 4ac8995e-482d-4e72-9bcc-9b80abab4efa
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: 8mYO8ewsZX3LVfNga69jXa0RNO0LNN8-EGkXLhSAMBU
+id: state_codes
+label: 'State codes'
+category: Geographic
+likert: false
+options: |
+  AL: Alabama
+  AK: Alaska
+  AZ: Arizona
+  AR: Arkansas
+  CA: California
+  CO: Colorado
+  CT: Connecticut
+  DE: Delaware
+  DC: 'District of Columbia'
+  FL: Florida
+  GA: Georgia
+  GU: Guam
+  HI: Hawaii
+  ID: Idaho
+  IL: Illinois
+  IN: Indiana
+  IA: Iowa
+  KS: Kansas
+  KY: Kentucky
+  LA: Louisiana
+  ME: Maine
+  MD: Maryland
+  MA: Massachusetts
+  MI: Michigan
+  MN: Minnesota
+  MS: Mississippi
+  MO: Missouri
+  MT: Montana
+  NE: Nebraska
+  NV: Nevada
+  NH: 'New Hampshire'
+  NJ: 'New Jersey'
+  NM: 'New Mexico'
+  NY: 'New York'
+  NC: 'North Carolina'
+  ND: 'North Dakota'
+  OH: Ohio
+  OK: Oklahoma
+  OR: Oregon
+  PA: Pennsylvania
+  RI: 'Rhode Island'
+  SC: 'South Carolina'
+  SD: 'South Dakota'
+  TN: Tennessee
+  TX: Texas
+  UT: Utah
+  VT: Vermont
+  VA: Virginia
+  WA: Washington
+  WV: 'West Virginia'
+  WI: Wisconsin
+  WY: Wyoming

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.state_names.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.state_names.yml
@@ -1,0 +1,65 @@
+uuid: a8aefeb1-17e7-46d0-81b9-b773525f6270
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: KfYqMSrFJ5iGtDzvy_rGUeRUJ4KyM7Xt-tWtYx9WjiM
+id: state_names
+label: 'State names'
+category: Geographic
+likert: false
+options: |
+  Alabama: Alabama
+  Alaska: Alaska
+  Arizona: Arizona
+  Arkansas: Arkansas
+  California: California
+  Colorado: Colorado
+  Connecticut: Connecticut
+  Delaware: Delaware
+  'District of Columbia': 'District of Columbia'
+  Florida: Florida
+  Georgia: Georgia
+  Hawaii: Hawaii
+  Idaho: Idaho
+  Illinois: Illinois
+  Indiana: Indiana
+  Iowa: Iowa
+  Kansas: Kansas
+  Kentucky: Kentucky
+  Louisiana: Louisiana
+  Maine: Maine
+  Maryland: Maryland
+  Massachusetts: Massachusetts
+  Michigan: Michigan
+  Minnesota: Minnesota
+  Mississippi: Mississippi
+  Missouri: Missouri
+  Montana: Montana
+  Nebraska: Nebraska
+  Nevada: Nevada
+  'New Hampshire': 'New Hampshire'
+  'New Jersey': 'New Jersey'
+  'New Mexico': 'New Mexico'
+  'New York': 'New York'
+  'North Carolina': 'North Carolina'
+  'North Dakota': 'North Dakota'
+  Ohio: Ohio
+  Oklahoma: Oklahoma
+  Oregon: Oregon
+  Pennsylvania: Pennsylvania
+  'Rhode Island': 'Rhode Island'
+  'South Carolina': 'South Carolina'
+  'South Dakota': 'South Dakota'
+  Tennessee: Tennessee
+  Texas: Texas
+  Utah: Utah
+  Vermont: Vermont
+  Virginia: Virginia
+  Washington: Washington
+  'West Virginia': 'West Virginia'
+  Wisconsin: Wisconsin
+  Wyoming: Wyoming

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.state_province_codes.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.state_province_codes.yml
@@ -1,0 +1,89 @@
+uuid: 45896a0e-fb0c-45d4-b086-22b2c7fdd9ae
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: ziWv9xVss1UBnP_R38EqduZOprwOAifpxjXhyOPzmys
+id: state_province_codes
+label: 'State/Province codes'
+category: Geographic
+likert: false
+options: |
+  AL: Alabama
+  AK: Alaska
+  AS: 'American Samoa'
+  AZ: Arizona
+  AR: Arkansas
+  AE: 'Armed Forces (Canada, Europe, Africa, or Middle East)'
+  AA: 'Armed Forces Americas'
+  AP: 'Armed Forces Pacific'
+  CA: California
+  CO: Colorado
+  CT: Connecticut
+  DE: Delaware
+  DC: 'District of Columbia'
+  FM: 'Federated States of Micronesia'
+  FL: Florida
+  GA: Georgia
+  GU: Guam
+  HI: Hawaii
+  ID: Idaho
+  IL: Illinois
+  IN: Indiana
+  IA: Iowa
+  KS: Kansas
+  KY: Kentucky
+  LA: Louisiana
+  ME: Maine
+  MH: 'Marshall Islands'
+  MD: Maryland
+  MA: Massachusetts
+  MI: Michigan
+  MN: Minnesota
+  MS: Mississippi
+  MO: Missouri
+  MT: Montana
+  NE: Nebraska
+  NV: Nevada
+  NH: 'New Hampshire'
+  NJ: 'New Jersey'
+  NM: 'New Mexico'
+  NY: 'New York'
+  NC: 'North Carolina'
+  ND: 'North Dakota'
+  MP: 'Northern Mariana Islands'
+  OH: Ohio
+  OK: Oklahoma
+  OR: Oregon
+  PW: Palau
+  PA: Pennsylvania
+  PR: 'Puerto Rico'
+  RI: 'Rhode Island'
+  SC: 'South Carolina'
+  SD: 'South Dakota'
+  TN: Tennessee
+  TX: Texas
+  UT: Utah
+  VT: Vermont
+  VI: 'Virgin Islands'
+  VA: Virginia
+  WA: Washington
+  WV: 'West Virginia'
+  WI: Wisconsin
+  WY: Wyoming
+  AB: Alberta
+  BC: 'British Columbia'
+  MB: Manitoba
+  NB: 'New Brunswick'
+  NL: 'Newfoundland and Labrador'
+  NS: 'Nova Scotia'
+  NT: 'Northwest Territories'
+  NU: Nunavut
+  'ON': Ontario
+  PE: 'Prince Edward Island'
+  QC: Quebec
+  SK: Saskatchewan
+  YT: Yukon

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.state_province_names.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.state_province_names.yml
@@ -1,0 +1,89 @@
+uuid: 0971f75a-b4c9-4015-8c74-3cdd02a5a86f
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: d4mxS_CxdzHZK4WaGQf1H3m-Uubm5HPbu9U4ydzscuo
+id: state_province_names
+label: 'State/Province names'
+category: Geographic
+likert: false
+options: |
+  Alabama: Alabama
+  Alaska: Alaska
+  'American Samoa': 'American Samoa'
+  Arizona: Arizona
+  Arkansas: Arkansas
+  'Armed Forces (Canada, Europe, Africa, or Middle East)': 'Armed Forces (Canada, Europe, Africa, or Middle East)'
+  'Armed Forces Americas': 'Armed Forces Americas'
+  'Armed Forces Pacific': 'Armed Forces Pacific'
+  California: California
+  Colorado: Colorado
+  Connecticut: Connecticut
+  Delaware: Delaware
+  'District of Columbia': 'District of Columbia'
+  'Federated States of Micronesia': 'Federated States of Micronesia'
+  Florida: Florida
+  Georgia: Georgia
+  Guam: Guam
+  Hawaii: Hawaii
+  Idaho: Idaho
+  Illinois: Illinois
+  Indiana: Indiana
+  Iowa: Iowa
+  Kansas: Kansas
+  Kentucky: Kentucky
+  Louisiana: Louisiana
+  Maine: Maine
+  'Marshall Islands': 'Marshall Islands'
+  Maryland: Maryland
+  Massachusetts: Massachusetts
+  Michigan: Michigan
+  Minnesota: Minnesota
+  Mississippi: Mississippi
+  Missouri: Missouri
+  Montana: Montana
+  Nebraska: Nebraska
+  Nevada: Nevada
+  'New Hampshire': 'New Hampshire'
+  'New Jersey': 'New Jersey'
+  'New Mexico': 'New Mexico'
+  'New York': 'New York'
+  'North Carolina': 'North Carolina'
+  'North Dakota': 'North Dakota'
+  'Northern Mariana Islands': 'Northern Mariana Islands'
+  Ohio: Ohio
+  Oklahoma: Oklahoma
+  Oregon: Oregon
+  Palau: Palau
+  Pennsylvania: Pennsylvania
+  'Puerto Rico': 'Puerto Rico'
+  'Rhode Island': 'Rhode Island'
+  'South Carolina': 'South Carolina'
+  'South Dakota': 'South Dakota'
+  Tennessee: Tennessee
+  Texas: Texas
+  Utah: Utah
+  Vermont: Vermont
+  'Virgin Islands': 'Virgin Islands'
+  Virginia: Virginia
+  Washington: Washington
+  'West Virginia': 'West Virginia'
+  Wisconsin: Wisconsin
+  Wyoming: Wyoming
+  Alberta: Alberta
+  'British Columbia': 'British Columbia'
+  Manitoba: Manitoba
+  'New Brunswick': 'New Brunswick'
+  'Newfoundland and Labrador': 'Newfoundland and Labrador'
+  'Nova Scotia': 'Nova Scotia'
+  'Northwest Territories': 'Northwest Territories'
+  Nunavut: Nunavut
+  Ontario: Ontario
+  'Prince Edward Island': 'Prince Edward Island'
+  Quebec: Quebec
+  Saskatchewan: Saskatchewan
+  Yukon: Yukon

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.time_zones.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.time_zones.yml
@@ -1,0 +1,14 @@
+uuid: 6f90b0a6-71b0-4974-8a30-46ae5ff2996a
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: 8rVcRXLnTAEoWs7zl8du-7RIUnayqUcGYnvb3JT21-o
+id: time_zones
+label: Aikavyöhykkeet
+category: 'Aika ja päiväys'
+likert: false
+options: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.titles.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.titles.yml
@@ -1,0 +1,19 @@
+uuid: 00bd951c-836a-4cbe-9459-db524ce6dd39
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: PEUoedWrfYEX7oZ8CcOukfBTVxar1cPSROX8534esuU
+id: titles
+label: Otsikot
+category: Demographic
+likert: false
+options: |
+  Miss: Miss
+  Ms: Ms
+  Mr: Mr
+  Mrs: Mrs
+  Dr: Dr

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.translations.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.translations.yml
@@ -1,0 +1,14 @@
+uuid: 96d9b4ab-3b3d-4abb-a072-33db3b94ad0e
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: Mb_L3vE-0IBZH5s2rjpk2LNn0QHClQP9AARQdCmVLt4
+id: translations
+label: Käännökset
+category: Language
+likert: false
+options: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform_options.yes_no.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform_options.yes_no.yml
@@ -1,0 +1,16 @@
+uuid: d7825d75-e095-40ef-9c9b-cbe10b214ec1
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: W88NYg31DbaVNQx1Uir_dwwXHVtF09QOq4VBGsH1Snk
+id: yes_no
+label: Kyllä/Ei
+category: 'Yleiset asetukset'
+likert: false
+options: |
+  Yes: Yes
+  No: No

--- a/public/modules/custom/grants_metadata/config/install/grants_metadata.settings.yml
+++ b/public/modules/custom/grants_metadata/config/install/grants_metadata.settings.yml
@@ -8,8 +8,8 @@ third_party_options:
     KASKO: KASKO
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
-    unregistered_community: 'Rekisteröitymätön yhdistys tai ryhmä'
-    private_person: 'Yksityishenkilö'
+    unregistered_community: 'Rekisteröitymätön yhteisö tai ryhmä'
+    private_person: Yksityishenkilö
   application_types:
     29:
       id: ECONOMICGRANTAPPLICATION
@@ -18,25 +18,152 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\YleisavustusHakemusDefinition
         definitionId: grants_metadata_yleisavustushakemus
       labels:
-        fi: 'Kaupunginhallituksen yleisavustushakemus'
-        en: 'EN Kaupunginhallituksen yleisavustushakemus'
-        sv: 'SV Kaupunginhallituksen yleisavustushakemus'
-
+        fi: 'Kaupunginhallitus, yleisavustushakemus'
+        en: 'City Board, general grant application'
+        sv: 'Stadsstyrelsen, allmän bidragsansökan'
+    48:
+      id: KUVAPROJ
+      code: KUVAPROJ
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\KuvaProjektiDefinition
+        definitionId: grants_metadata_kaskoyleis
+      labels:
+        fi: 'Taide ja kulttuuri, projektiavustus'
+        en: 'Arts and culture, project grant'
+        sv: 'Konst och kultur, projektstöd'
+    49:
+      id: KUVAKEHA
+      code: KUVAKEHA
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\KuvaKehaDefinition
+        definitionId: grants_metadata_kaskoyleis
+      labels:
+        fi: 'Taide ja kulttuuri: kehittämisavustus'
+        en: 'EN Taide ja kulttuuri: kehittämisavustus'
+        sv: 'SV Taide ja kulttuuri: kehittämisavustus'
+    51:
+      id: KASKOYLEIS
+      code: KASKOYLEIS
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\KaskoYleisavustusDefinition
+        definitionId: grants_metadata_kaskoyleis
+      labels:
+        fi: 'Kasvatus ja koulutus, yleisavustushakemus'
+        en: 'Education, general grant application'
+        sv: 'Fostran och utbildning, allmän bidragsansökan'
+    47:
+      id: KUVATOIM
+      code: KUVATOIM
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\KuvaToimintaDefinition
+        definitionId: grants_metadata_kuvatoiminta
+      labels:
+        fi: 'Taide ja kulttuuri: toiminta-avustus'
+        en: 'EN Taide ja kulttuuri: toiminta-avustus'
+        sv: 'SV Taide ja kulttuuri: toiminta-avustus'
+    59:
+      id: LIIKUNTATAPAHTUMA
+      code: LIIKUNTATAPAHTUMA
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\LiikuntaTapahtumaDefinition
+        definitionId: grants_metadata_liikuntatapahtuma
+      labels:
+        fi: 'Liikunta, tapahtuma-avustushakemus'
+        en: 'Sports, grant application for events'
+        sv: 'Idrott, ansökan om evenemangsbidrag'
+    66:
+      id: NUORTOIMPALKENNAKKO
+      code: NUORTOIMPALKENNAKKO
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\NuorisoToimintaEnnakkoDefinition
+        definitionId: grants_metadata_nuortoimennakko
+      labels:
+        fi: 'Nuorisopalvelu, toiminta- ja palkkausavustus ennakkohakemus'
+        en: 'Youth service, operations and employment grant advance application'
+        sv: 'Ungdomstjänst, förskottsansökan om verksamhets- och anställningsbidrag'
+    56:
+      id: LIIKUNTAYLEIS
+      code: LIIKUNTAYLEIS
+      dataDefinition:
+        definitionClass: \Drupal\grants_metadata\TypedData\Definition\LiikuntaYleisDefinition
+        definitionId: grants_metadata_liikuntayleis
+      labels:
+        fi: 'Liikunta, yleisavustushakemus'
+        en: 'Sports, general grant application'
+        sv: 'Idrott, allmän bidragsansökan'
+    50:
+      id: KUVAPERUS
+      code: KUVAPERUS
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\KuvaPerusDefinition
+        definitionId: grants_metadata_kuvaperus
+      labels:
+        fi: 'Taide ja kulttuuri, taiteen perusopetus'
+        en: 'Arts and culture, basic arts education grants'
+        sv: 'Konst och kultur, stöd för grundläggande konstundervisning'
+    53:
+      id: KASKOIPLISA
+      code: KASKOIPLISA
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\KaskoIltapaivaLisaDefinition
+        definitionId: grants_metadata_kaskoiplisa
+      labels:
+        fi: 'Kasvatus ja koulutus: Iltapäivätoiminnan harkinnanvarainen lisäavustushakemus'
+        en: 'Education, supplementary discretionary grant application for afternoon activities'
+        sv: 'Fostran och utbildning, ansökan om extra bidrag enligt behovsprövning för eftermiddagsverksamhet'
+    65:
+      id: NUORLOMALEIR
+      code: NUORLOMALEIR
+      dataDefinition:
+        definitionClass: Drupal\grants_metadata\TypedData\Definition\NuorisoLomaDefinition
+        definitionId: grants_metadata_nuorisoloma
+      labels:
+        fi: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
+        en: 'Holiday camp grants for youth activities'
+        sv: 'Ungdomsverksamhet, lägerunderstöd under skollovstider'
   application_statuses:
-    DRAFT: DRAFT,
-    SENT: SENT,
-    SUBMITTED: SUBMITTED,
-    # Vastaanotettu
-    RECEIVED: RECEIVED,
-    PENDING: PENDING,
-    # Käsittelyssä
-    PROCESSING: PROCESSING,
-    # Valmis
-    READY: READY,
-    # Valmis
-    DONE: DONE,
-    REJECTED: REJECTED,
-    DELETED: DELETED,
-    CANCELED: CANCELED,
-    CANCELLED: CANCELLED,
-    CLOSED: CLOSED,
+    DRAFT: DRAFT
+    SENT: SENT
+    SUBMITTED: SUBMITTED
+    RECEIVED: RECEIVED
+    PENDING: PENDING
+    PROCESSING: PROCESSING
+    READY: READY
+    DONE: DONE
+    REJECTED: REJECTED
+    DELETED: DELETED
+    CANCELED: CANCELED
+    CANCELLED: CANCELLED
+    CLOSED: CLOSED
+  subvention_types:
+    1: 'Operating grant'
+    2: 'Wage subsidy'
+    4: 'Project grant'
+    5: 'Rent subsidy'
+    6: 'General grant'
+    7: 'Education grant for unemployed'
+    8: 'Interests and installments'
+    9: Other
+    11: 'Transport subsidy'
+    12: Leiriavustus
+    13: 'Exemption from payments compensation'
+    14: 'Extra grant'
+    15: 'Navigation map grant'
+    17: 'Grant for operations development'
+    29: 'Capacity buildning grant / The Helsinki Model'
+    31: 'Start grant'
+    32: 'Subsidy for use of space'
+    34: 'Basic art education'
+    35: Varhaiskasvatus
+    36: 'Vapaa sivistystyö'
+    37: 'Event grant'
+    38: 'Small grant'
+    39: 'Immigrant integration grant'
+    40: 'Culture and leisure: application for subsidy'
+    41: Laitosavustus
+    42: 'Grant for other associations promoting physical activity'
+    43: 'Targeted sports grant'
+    44: Kehittämisavustus
+    45: 'Helsingin mallin kehittämisavustus'
+    46: 'Taiteen perusopetuksen kehittämisavustus'
+langcode: en

--- a/public/modules/custom/grants_metadata/src/GrantsConverterService.php
+++ b/public/modules/custom/grants_metadata/src/GrantsConverterService.php
@@ -43,4 +43,17 @@ class GrantsConverterService {
     return $retval;
   }
 
+  /**
+   * Extract & process subvention amount field value.
+   *
+   * @param array $value
+   *   Value from JSON data.
+   *
+   * @return string
+   *   Processed field value.
+   */
+  public function extractSubventionAmount(array $value): string {
+    return str_replace('.', ',', $value['value']);
+  }
+
 }

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -37,6 +37,19 @@ trait ApplicationDefinitionTrait {
         'method' => 'extractDataForWebform',
       ]);
 
+    $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
+      ->setLabel('compensationArray')
+      ->setSetting('jsonPath', [
+        'compensation',
+        'compensationInfo',
+        'compensationArray',
+      ])
+      ->addConstraint('NotBlank')
+      ->setRequired(TRUE)
+      ->setSetting('formSettings', [
+        'formElement' => 'subventions',
+      ]);
+
     /*
      * Registered community
      */

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/CompensationTypeDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/CompensationTypeDefinition.php
@@ -42,6 +42,10 @@ class CompensationTypeDefinition extends ComplexDataDefinitionBase {
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToFloat',
         ])
+        ->setSetting('webformValueExtracter', [
+          'service' => 'grants_metadata.converter',
+          'method' => 'extractSubventionAmount',
+        ])
         ->setSetting('typeOverride', [
           'dataType' => 'string',
           'jsonType' => 'float',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoYleisavustusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoYleisavustusDefinition.php
@@ -4,7 +4,6 @@ namespace Drupal\grants_metadata\TypedData\Definition;
 
 use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 use Drupal\Core\TypedData\DataDefinition;
-use Drupal\Core\TypedData\ListDataDefinition;
 
 /**
  * Define Yleisavustushakemus data.
@@ -61,14 +60,6 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
           'compensation',
           'activitiesInfoArray',
           'membersApplicantCommunityGlobal',
-        ]);
-
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
         ]);
 
       $info['compensation_purpose'] = DataDefinition::create('string')

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaKehaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaKehaDefinition.php
@@ -29,14 +29,6 @@ class KuvaKehaDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ]);
-
       $info['ensisijainen_taiteen_ala'] = DataDefinition::create('string')
         ->setLabel('Ensisijainen taiteenala')
         ->setSetting('jsonPath', [

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
@@ -29,15 +29,6 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      // 2. Avustustiedot.
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ]);
-
       $info['ensisijainen_taiteen_ala'] = DataDefinition::create('string')
         ->setLabel('Ensisijainen taiteenala')
         ->setSetting('jsonPath', [

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -29,19 +29,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ])
-        ->addConstraint('NotBlank')
-        ->setRequired(TRUE)
-        ->setSetting('formSettings', [
-          'formElement' => 'subventions',
-        ]);
-
       $info['ensisijainen_taiteen_ala'] = DataDefinition::create('string')
         ->setLabel('Ensisijainen taiteenala')
         ->setSetting('jsonPath', [

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -29,16 +29,6 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      /* Avustustiedot */
-
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ]);
-
       $info['tulevat_vuodet_joiden_ajalle_monivuotista_avustusta_on_haettu_ta'] = DataDefinition::create('string')
         ->setLabel('Tulevat vuodet joiden ajalle monivuotista avustusta haetaan tai on myönnetty')
         ->setSetting('jsonPath', [

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTapahtumaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTapahtumaDefinition.php
@@ -4,7 +4,6 @@ namespace Drupal\grants_metadata\TypedData\Definition;
 
 use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 use Drupal\Core\TypedData\DataDefinition;
-use Drupal\Core\TypedData\ListDataDefinition;
 use Drupal\grants_budget_components\TypedData\Definition\GrantsBudgetInfoDefinition;
 
 /**
@@ -28,14 +27,6 @@ class LiikuntaTapahtumaDefinition extends ComplexDataDefinitionBase {
       foreach ($this->getBaseProperties() as $key => $property) {
         $info[$key] = $property;
       }
-
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ]);
 
       // Section 2. Participants.
       $info['20_men'] = DataDefinition::create('integer')

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaYleisDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaYleisDefinition.php
@@ -4,7 +4,6 @@ namespace Drupal\grants_metadata\TypedData\Definition;
 
 use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 use Drupal\Core\TypedData\DataDefinition;
-use Drupal\Core\TypedData\ListDataDefinition;
 
 /**
  * Define Yleisavustushakemus data.
@@ -27,14 +26,6 @@ class LiikuntaYleisDefinition extends ComplexDataDefinitionBase {
       foreach ($this->getBaseProperties() as $key => $property) {
         $info[$key] = $property;
       }
-
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ]);
 
       $info['compensation_purpose'] = DataDefinition::create('string')
         ->setLabel('')

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoLomaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoLomaDefinition.php
@@ -4,7 +4,6 @@ namespace Drupal\grants_metadata\TypedData\Definition;
 
 use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 use Drupal\Core\TypedData\DataDefinition;
-use Drupal\Core\TypedData\ListDataDefinition;
 use Drupal\grants_budget_components\TypedData\Definition\GrantsBudgetInfoDefinition;
 
 /**
@@ -28,14 +27,6 @@ class NuorisoLomaDefinition extends ComplexDataDefinitionBase {
       foreach ($this->getBaseProperties() as $key => $property) {
         $info[$key] = $property;
       }
-
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ]);
 
       $info['budgetInfo'] = GrantsBudgetInfoDefinition::create('grants_budget_info')
         ->setSetting('propertyStructureCallback', [

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoToimintaEnnakkoDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoToimintaEnnakkoDefinition.php
@@ -28,14 +28,6 @@ class NuorisoToimintaEnnakkoDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
-        ]);
-
       $info['subventionsPreviousYear'] = ListDataDefinition::create('grants_metadata_compensation_previous_year')
         ->setLabel('compensationArray')
         ->setSetting('fullItemValueCallback', [

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/YleisavustusHakemusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/YleisavustusHakemusDefinition.php
@@ -4,7 +4,6 @@ namespace Drupal\grants_metadata\TypedData\Definition;
 
 use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 use Drupal\Core\TypedData\DataDefinition;
-use Drupal\Core\TypedData\ListDataDefinition;
 
 /**
  * Define Yleisavustushakemus data.
@@ -61,14 +60,6 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
           'compensation',
           'activitiesInfoArray',
           'membersApplicantCommunityGlobal',
-        ]);
-
-      $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-        ->setLabel('compensationArray')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'compensationInfo',
-          'compensationArray',
         ]);
 
       $info['compensation_purpose'] = DataDefinition::create('string')

--- a/public/modules/custom/grants_premises/src/GrantsPremisesService.php
+++ b/public/modules/custom/grants_premises/src/GrantsPremisesService.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\TypedData\DataDefinitionInterface;
 use Drupal\Core\TypedData\ListInterface;
 use Drupal\grants_metadata\AtvSchema;
+use Drupal\webform\Entity\Webform;
 
 /**
  * Useful tools for premises fields.
@@ -110,8 +111,16 @@ class GrantsPremisesService {
 
   /**
    * Get meta field data to webform page and section parts.
+   *
+   * @param \Drupal\webform\Entity\Webform|null $webform
+   *   Webform.
+   * @param \Drupal\Core\TypedData\ListInterface $property
+   *   Element property.
+   *
+   * @return array
+   *   Metadata
    */
-  private function getWebformMeta($webform, $property): array {
+  private function getWebformMeta(? Webform $webform, ListInterface $property): array {
 
     if (empty($webform)) {
       return [


### PR DESCRIPTION
# [AU-1372](https://helsinkisolutionoffice.atlassian.net/browse/AU-1372)
<!-- What problem does this solve? -->

There was an error in subventions' amounts that did not respect dots, it removed the dot altogether making value to go 100 times. Meaning that 3,33 became 333,00. 

## What was done
<!-- Describe what was done -->

* Had to add custom value extracter for any given value field to support this without hard coding
* Refactor subventions data definition to a trait so that all definitions use same specs.
* Add this new value extracter to subventions' amount field 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1372-avustus-amount-100times`
  * `make fresh` && `make drush gwi`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill many different applications and use decimals in all of subvention values. 345,66 for example
* [ ] See that theres no errors and values get saved in correct format
* [ ] Make sure applications go all the way to avustus2 with correct values staying in subvention amounts.



[AU-1372]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ