### PR TITLE
fix: AU-XX: Initialize applicant info when document is created.

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
+++ b/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
@@ -203,6 +203,8 @@ class ApplicantInfoComposite extends WebformCompositeBase {
    *   ELements.
    * @param \Drupal\helfi_atv\AtvDocument $grantsProfile
    *   Profile data.
+   *
+   * @throws \Drupal\helfi_helsinki_profiili\TokenExpiredException
    */
   protected static function getUnregisteredForm(array &$elements, AtvDocument $grantsProfile) {
 

--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -108,7 +108,7 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
       '' => '- ' . t('Select') . ' -',
     ];
 
-    if ($profileData['officials']) {
+    if (isset($profileData['officials'])) {
       $persons = $profileData['officials'];
     }
     else {


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

There's some strange issues with applications going to get assigned for incorrect ytunnus, and this is a try to tackle that. By adding applicant info details to applications in init phase.
