### PR TITLE
AU-1383: Remove duplicate error message from the first page of application

### DIFF
--- a/public/modules/custom/grants_handler/src/Element/CommunityAddressComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityAddressComposite.php
@@ -131,13 +131,6 @@ class CommunityAddressComposite extends WebformCompositeBase {
     $element['#options'] = $options;
     $element['#default_value'] = $defaultDelta;
 
-    $errorStorage = $form_state->getStorage();
-
-    if (isset($errorStorage['errors']['community_address'])) {
-      $element['#attributes']['class'][] = 'has-error';
-      $element['#attributes']['error_label'] = $errorStorage['errors']['community_address']['label'];
-    }
-
     if ($profileType === 'private_person') {
       $element['#required'] = FALSE;
     }


### PR DESCRIPTION
# [AU-1383](https://helsinkisolutionoffice.atlassian.net/browse/AU-1383)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove duplicate error display.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1383-fix-duplicate-error-message`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] As registered community, start a new application process - do not insert any info to the first page and move to the 2nd page.
* [ ] Move back to the first page and see that address component is not showing 2 errors as described in ticket.




[AU-1383]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ