### PR TITLE
AU-1385: Change liikunta tapahtuma acting years

### DIFF
--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -18,12 +18,9 @@ third_party_settings:
     applicationTargetGroup: '26'
     applicationOpen: '2023-02-18T09:28:04'
     applicationClose: '2023-11-24T09:28:11'
-    applicationActingYearsType: fixed
-    applicationActingYears:
-      2023: '2023'
-      2024: '2024'
-      2025: '2025'
-    applicationActingYearsNextCount: ''
+    applicationActingYearsType: current_and_next_x_years
+    applicationActingYears: {  }
+    applicationActingYearsNextCount: '1'
     applicationContinuous: 0
     disableCopying: 0
 weight: 0


### PR DESCRIPTION
# [AU-1385](https://helsinkisolutionoffice.atlassian.net/browse/AU-1385)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1385-liikuntatapahtuma-years`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that liikunta tapahtuma application year selection now allows current and next year only.




[AU-1385]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ