### PR TITLE
AU-1343 Translate attachment field labels for print view

### DIFF
--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -11,6 +11,7 @@ use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\Core\TypedData\TypedDataManager;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\grants_attachments\AttachmentHandler;
+use Drupal\grants_attachments\Element\GrantsAttachments as GrantsAttachmentsElement;
 use Drupal\grants_attachments\Plugin\WebformElement\GrantsAttachments;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
@@ -785,6 +786,16 @@ class AtvSchema {
             is_array($value) &&
             self::numericKeys($value)) {
             if ($propertyType == 'list') {
+              /* All attachments are saved into same array
+               * despite their name in webform. We can not
+               * get actual webform elements for translated
+               * label so we use webform element defining class
+               *  directly.
+               */
+              if ($propertyName == 'attachments') {
+                $webformMainElement = [];
+                $webformMainElement['#webform_composite_elements'] = GrantsAttachmentsElement::getCompositeElements([]);
+              }
               foreach ($property as $itemIndex => $item) {
                 $fieldValues = [];
                 $propertyItem = $item->getValue();
@@ -793,7 +804,12 @@ class AtvSchema {
                 foreach ($itemValueDefinitions as $itemName => $itemValueDefinition) {
                   // Backup label.
                   $label = $itemValueDefinition->getLabel();
-                  if (
+                  // File name has no visible label in the webform so we
+                  // need to manually handle it.
+                  if ($itemName == 'fileName') {
+                    $label = $this->t('File name');
+                  }
+                  elseif (
                     isset($webformMainElement['#webform_composite_elements'][$itemName]['#title']) &&
                     !is_string($webformMainElement['#webform_composite_elements'][$itemName]['#title'])
                   ) {


### PR DESCRIPTION
# [AU-1343](https://helsinkisolutionoffice.atlassian.net/browse/AU-1343)
<!-- What problem does this solve? -->
Translate attachments fields for print view

## What was done
<!-- Describe what was done -->

Attachments must be handled in a special way in order for translations to work. Comments added between code.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1343-attachment-field-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Fill an application in Finnish and save it as a draft. Include at least one attachment or bank account.
View the application in print view. Fields for attachments are now in Finnish. 



[AU-1343]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ