### PR TITLE
fix: AU-1411: Use correct translationinterface in print page

### DIFF
--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -8,6 +8,8 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\StringTranslation\TranslationManager;
 use Drupal\webform\Entity\Webform;
+use Drupal\webform\WebformTranslationManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Returns responses for Webform Printify routes.
@@ -28,18 +30,24 @@ class GrantsWebformPrintController extends ControllerBase {
   protected $languageManager;
 
   /**
-   * Constructs an AdminLanguageRender object.
-   *
-   * @param \Drupal\Core\Language\LanguageManagerInterface $languageManager
-   *   The language manager.
-   * @param \Drupal\Core\StringTranslation\TranslationManager $translationManager
-   *   The translation manager.
+   * @param LanguageManagerInterface $languageManager
+   * @param WebformTranslationManager $translationManager
    */
-  public function __construct(LanguageManagerInterface $languageManager, TranslationManager $translationManager) {
+  public function __construct(LanguageManagerInterface $languageManager, WebformTranslationManager $translationManager) {
     $this->languageManager = $languageManager;
     $this->translationManager = $translationManager;
 
   }
+
+  /**
+   * @param ContainerInterface $container
+   * @return GrantsWebformPrintController
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('language_manager'),
+      $container->get('webform.translation_manager'),
+    );  }
 
   /**
    * Builds the response.


### PR DESCRIPTION
# [AU-1411](https://helsinkisolutionoffice.atlassian.net/browse/AU-1411)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Use webform's translation interface instead of symphony's in GrantsWebformPrintController

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1411-printti-rikki`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that `/en/tietoja-avustuksista/yleisavustushakemus/tulosta` works
* [ ] Check the other translations
* [ ] Check other forms
* [ ] Check that code follows our standards


[AU-1411]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ