### PR TITLE
AU-1406: Allow submitted application to be edited when application period is closed

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -358,10 +358,8 @@ class ApplicationHandler {
    * application period is over, unless handler has changed the status
    * to processing or something else.
    *
-   * @param \Drupal\webform\Entity\WebformSubmission|null $submission
+   * @param \Drupal\webform\Entity\WebformSubmission|null $webform_submission
    *   Submission in question.
-   * @param string $status
-   *   If no object is available, do text comparison.
    *
    * @return bool
    *   Is submission editable?

--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -352,6 +352,35 @@ class ApplicationHandler {
   }
 
   /**
+   * Check if given submission is allowed to have changes.
+   *
+   * User should be allowed to edit their submission, even if the
+   * application period is over, unless handler has changed the status
+   * to processing or something else.
+   *
+   * @param \Drupal\webform\Entity\WebformSubmission|null $submission
+   *   Submission in question.
+   * @param string $status
+   *   If no object is available, do text comparison.
+   *
+   * @return bool
+   *   Is submission editable?
+   */
+  public static function isSubmissionChangesAllowed(WebformSubmission $webform_submission): bool {
+
+    $submissionData = $webform_submission->getData();
+    $status = $submissionData['status'];
+    $applicationStatuses = self::getApplicationStatuses();
+
+    $isOpen = self::isApplicationOpen($webform_submission->getWebform());
+    if (!$isOpen && $status === $applicationStatuses['DRAFT']) {
+      return FALSE;
+    }
+
+    return self::isSubmissionEditable($webform_submission);
+  }
+
+  /**
    * Check if given submission is allowed to be edited.
    *
    * @param \Drupal\webform\Entity\WebformSubmission|null $submission

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -614,7 +614,7 @@ class GrantsHandler extends WebformHandlerBase {
       WebformArrayHelper::removeValue($form['actions']['draft']['#submit'], '::rebuild');
     }
 
-    if (!ApplicationHandler::isApplicationOpen($webform_submission->getWebform())) {
+    if (!ApplicationHandler::isSubmissionChangesAllowed($webform_submission)) {
       $this->messenger()
         ->addError('Application period is closed, no further editing is allowed.');
       $form['#disabled'] = TRUE;

--- a/public/modules/custom/grants_handler/templates/application-list-item.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list-item.html.twig
@@ -53,9 +53,6 @@
               <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
               <span>{{ "This application is not open"|t }}</span>
             </div>
-            <div class="hds-notification__body">
-              {{ "You can't send the application, but you can continue filling and saving as a draft." }}
-            </div>
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
# [AU-1406](https://helsinkisolutionoffice.atlassian.net/browse/AU-1406)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Allow application to be modified if status is withing parameters, but application is no longer open.
 **(Further webform status checks to implemented later)**

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1406-application-changes-while-period-over`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Select and application and go through the process
* [ ] Modify the end date to past and check if you can still modify the submitted application
* [ ] You should not be able to create completely new application or submit drafts.
* [ ] You can hard code some statuses to the function if you want to check how the logic behaves with different statuses.



[AU-1406]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ