### PR TITLE
fix: AU-1377: Move description to before in Liikunta yleis

### DIFF
--- a/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
@@ -254,6 +254,7 @@ elements: |-
         '#title': 'Lyhyt kuvaus haettavan avustuksen käyttötarkoituksista'
         '#description': 'Kerro mit&auml; tarkoitusta varten avustusta haetaan, erittele tarvittaessa eri k&auml;ytt&ouml;kohteet.'
         '#help': 'Kohdeavustuksen osalta tarkemmat tiedot kysyt&auml;&auml;n Webropol-lomakkeella (pakollinen liite)'
+        '#description_display': before
         '#maxlength': 5000
         '#required': true
         '#counter_type': character


### PR DESCRIPTION
# [AU-1377](https://helsinkisolutionoffice.atlassian.net/browse/AU-1377)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* move a description in a form to a proper place

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1377-description-location`
  * `make fresh`
  * `make drush-gwi`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to liikunnan yleisavustus (may need tweaking of settings to make it visible locally)
* [ ] See that on page 2 the käyttötarkoitus description is displayed before the textarea
* [ ] Check that code follows our standards


[AU-1377]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ