### PR TITLE
fix: AU-1380: add tooltip to liikunnan tapahtuma

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
@@ -49,6 +49,7 @@ elements: |
     '#title': 'Grant details'
   acting_year:
     '#title': 'Year for which I am applying for a grant'
+    '#help': 'Please note that eligibility criteria for different grants might change from year to year.'
   avustuslajit:
     '#title': 'Types of grant'
   subventions:

--- a/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
@@ -60,6 +60,7 @@ elements: |
     '#title': 'Uppgifter om understödet'
   acting_year:
     '#title': 'Ansökan galter år'
+    '#help': 'Observera att grunder för beviljande för olika understödsformer kan ändras årligen.'
   avustuslajit:
     '#title': Understödsformer
   subventions:

--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -182,6 +182,7 @@ elements: |-
           2022: '2022'
           2023: '2023'
           2024: '2024'
+        '#help': 'Huomioithan, että avustusten kriteerit saattavat muuttua vuosittain.'
         '#required': true
     avustuslajit:
       '#type': webform_section


### PR DESCRIPTION
# [AU-1380](https://helsinkisolutionoffice.atlassian.net/browse/AU-1380)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Tooltip fix

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1380-tooltip-to-liikunnan-tapahtuma`
  * `make fresh`
* Go remove webform confs from config ignore in the admin interface
* Run `make drush-cim`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to Liikunnan Tapahtuma-avustus page 2
* [ ] See that the tooltip is there correctly and without typos
* [ ] Switch to english. Do the same.
* [ ] Switch to swedish. Do the same.
* [ ] Check that code follows our standards


[AU-1380]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ