### PR TITLE
fix: AU-1422: add translations to applicant

### DIFF
--- a/conf/cmi/language/en/field.storage.node.field_hakijatyyppi.yml
+++ b/conf/cmi/language/en/field.storage.node.field_hakijatyyppi.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: 'Registered community'
+    -
+      label: 'Unregistered community or group'
+    -
+      label: 'Private person'

--- a/conf/cmi/language/sv/field.storage.node.field_hakijatyyppi.yml
+++ b/conf/cmi/language/sv/field.storage.node.field_hakijatyyppi.yml
@@ -1,0 +1,8 @@
+settings:
+  allowed_values:
+    -
+      label: 'Registrerad gemenskap'
+    -
+      label: 'Icke-registrerad förening eller verksamhetsgrupp'
+    -
+      label: Privatperson


### PR DESCRIPTION
# [AU-1422](https://helsinkisolutionoffice.atlassian.net/browse/AU-1422)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add translations to applicant

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1422-applicant-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that in Application Search -page Applicant-field values are translated
* [ ] Check that everything works overall


[AU-1422]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ