### PR TITLE
fix: AU-XX: fix malformed translation string

### DIFF
--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -464,5 +464,5 @@ msgstr "Tutustuthan ohjeistukseen t채ll채 sivulla ennen hakemukselle siirtymist�
 msgid "Are you applying for a start grant?"
 msgstr "Haetko starttiavustusta?"
 
-msgid "You must apply for the @subventionType"
-msgstr "@subventionType on m채채ritelty pakolliseksi hakea"
+msgid 'You must apply for the "@subventionType"'
+msgstr '@subventionType on m채채ritelty pakolliseksi hakea'

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -226,8 +226,8 @@ msgstr 'Det gick inte att ta bort utkastet. Detta formulär är för närvarande
 msgid "Are you applying for a start grant?"
 msgstr "Ansöker du om Sportunderstöd?"
 
-msgid "You must apply for the "@subventionType"
-msgstr "Du måste ansöka om "@subventionType"
+msgid 'You must apply for the "@subventionType"'
+msgstr 'Du måste ansöka om "@subventionType"'
 
 msgid "Application"
 msgstr "Ansökan"


### PR DESCRIPTION
# AU-XX
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed a malformed swedish translation string and made the finnish version match the way the other languages were written.
## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-fix-translation-bug`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `drush locale:check; drush locale:update; drush cr` just in case (in `make shell`)
* [ ] Log in as admin
* [ ] Create a form with a required subvention type (or alter a current one to have a required subvention type)
* [ ] Log in as user
* [ ] Go fill the form and to the page with subventions.
* [ ] Leave the required subvention type empty
* [ ] navigate to another page, see that the error about the required subvention type is in Finnish and corect
* [ ] Switch language to Swedish and do the same
* [ ] Switch language to English and do the same
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
