### PR TITLE
fix: AU-1277: Handle translations for applicant details

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
+++ b/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
@@ -65,6 +65,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     $elements['applicantType'] = [
       '#type' => 'hidden',
       '#value' => $selectedRoleData["type"],
+      '#title' => t('Applicant type'),
     ];
     $elements['applicant_type'] = [
       '#type' => 'hidden',

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -545,6 +545,15 @@ class AtvSchema {
               $sectionWeight = array_search($sectionId, $elementKeys);
               // Finally the element itself.
               $label = $property['label'];
+              if (isset($webformMainElement['#webform_composite_elements'][$name]['#title'])) {
+                $titleElement = $webformMainElement['#webform_composite_elements'][$name]['#title'];
+                if (is_string($titleElement)) {
+                  $label = $titleElement;
+                }
+                else {
+                  $label = $titleElement->render();
+                }
+              }
               $weight = array_search($name, $elementKeys);
               $hidden = in_array($name, $hiddenFields);
               $page = [


### PR DESCRIPTION
# [AU-1277](https://helsinkisolutionoffice.atlassian.net/browse/AU-1277)
<!-- What problem does this solve? -->

Hakijan tiedot komponentin käännökset tulostusnäkymässä

## What was done
<!-- Describe what was done -->

* Käsittele data ATVSchema luokassa

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout Ufeature/AU-1277-applicant-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

- Täytä lomake ja tallenna se draft-tilassa
- Avaa tulostusnäkymä
- Varmista että hakijan tiedot -osiossa kenttien nimet ovat käännetty

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1277]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ