### PR TITLE
fix: AU-1440 summation field change event

### DIFF
--- a/public/modules/custom/grants_webform_summation_field/js/summation_field.js
+++ b/public/modules/custom/grants_webform_summation_field/js/summation_field.js
@@ -44,8 +44,8 @@
               myEle.getAttribute('type').toLowerCase() == 'text'
               || myEle.getAttribute('type').toLowerCase() == 'number'))
             || myEle.tagName === 'textarea'.toLowerCase()) {
-            myEle.addEventListener('keypress', (event) => {
-              var ev = new Event('change');
+            myEle.addEventListener('keyup', (event) => {
+              var ev = new Event(eventType);
               myEle.dispatchEvent(ev);
             })
           }

--- a/public/modules/custom/grants_webform_summation_field/src/Element/GrantsWebformSummationField.php
+++ b/public/modules/custom/grants_webform_summation_field/src/Element/GrantsWebformSummationField.php
@@ -63,7 +63,7 @@ class GrantsWebformSummationField extends FormElement {
     if (isset($element['#form_item'])) {
       $formItem = $element['#form_item'];
     }
-    if ($formItem === 'hsidden') {
+    if ($formItem === 'hidden') {
       $element['#title_display'] = 'none';
       $element['#description_display'] = 'none';
       $element['#attributes']['readonly'] = 'readonly';

--- a/public/modules/custom/grants_webform_summation_field/src/Element/GrantsWebformSummationField.php
+++ b/public/modules/custom/grants_webform_summation_field/src/Element/GrantsWebformSummationField.php
@@ -63,7 +63,7 @@ class GrantsWebformSummationField extends FormElement {
     if (isset($element['#form_item'])) {
       $formItem = $element['#form_item'];
     }
-    if ($formItem === 'hidden') {
+    if ($formItem === 'hsidden') {
       $element['#title_display'] = 'none';
       $element['#description_display'] = 'none';
       $element['#attributes']['readonly'] = 'readonly';


### PR DESCRIPTION
# [AU-1440](https://helsinkisolutionoffice.atlassian.net/browse/AU-1440)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Summation field is now tied to keyup, not keypress.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1440-summation-field-change-event`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in, go to a form, to page 2
* [ ] use development tools to unhide the summation field (it has a display: none -property, remove ti)
* [ ] change the value of the subvention type on the page
* [ ] See that the summation field value changes
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
