### PR TITLE
fix: AU-1458: Fix KUVA Perus realized premises mapping

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
@@ -454,7 +454,7 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
         ->setLabel('Tilat')
         ->setSetting('jsonPath', [
           'compensation',
-          'communityInfo',
+          'activityInfo',
           'realizedPremisesArray',
         ])
         ->setSetting('fullItemValueCallback', [


### PR DESCRIPTION
# [AU-1458](https://helsinkisolutionoffice.atlassian.net/browse/AU-1458)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Wrong mapping caused realized premises to disappear after sending to avus2

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1458-fix-kuva-perus-premise-mapping`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Start new KUVA PERUS application
* [ ] Fill the application and after sending it to avus2 and after status is received -> check that realized premises is still in the application.

(Previously this data will disappear)



[AU-1458]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ