### PR TITLE
fix: AU-1427: change notification text about required fields

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -744,7 +744,8 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
         [
           '#theme' => 'hds_notification',
           '#type' => 'notification',
-          '#label' => t('Fields marked with an asterisk * are required, that need to be filled before saving.'),
+          '#label' => t('Fill in the fields to all the questions that you can answer.'),
+          '#body' => t('Fields marked with * are mandatory information that you must fill in in order to save and send the information.'),
           '#class' => 'notification-margin-bottom',
         ],
     ];
@@ -777,7 +778,7 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
           }
         }
       }
-      if (!$isClosed && $page_required) {
+      if (!$isClosed) {
         $form['elements'][$page_name] = array_merge($required_fields_info_element, $form['elements'][$page_name]);
       }
       if (!$isClosed && $page_prefetched) {

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -52,6 +52,12 @@ msgstr "Tarkistathan lomakkeella olevat tiedot ennen hakemuksen lähettämistä.
 msgid "Fields marked with an asterisk * are required, that need to be filled before saving."
 msgstr "Tähdellä * merkityt kentät ovat pakollisia tietoja, jotka sinun on täytettävä ennen tietojen tallentamista."
 
+msgid "Fill in the fields to all the questions that you can answer."
+msgstr "Täytä kaikki kentät joihin voit vastata."
+
+msgid "Fields marked with * are mandatory information that you must fill in in order to save and send the information."
+msgstr "Tähdellä * merkityt kentät ovat pakollisia tietoja, jotka sinun on täytettävä jotta tiedot voidaan tallentaa ja lähettää."
+
 msgid 'Subvention name'
 msgstr 'Avustuslaji'
 

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -193,6 +193,12 @@ msgstr "Byt roll"
 msgid "Fields marked with an asterisk * are required, that need to be filled before saving."
 msgstr "Fält markerade med * är obligatoriska uppgifter som du måste fylla i innan du sparar informationen."
 
+msgid "Fill in the fields to all the questions that you can answer."
+msgstr "Fyll i alla fält som du kan svara på."
+
+msgid "Fields marked with * are mandatory information that you must fill in in order to save and send the information."
+msgstr "Fält markerade med * är obligatoriska uppgifter som du måste fylla i innan du sparar informationen."
+
 msgid "Some information fetched from personal information"
 msgstr "Viss information hämtad från personlig information"
 


### PR DESCRIPTION
# [AU-1427](https://helsinkisolutionoffice.atlassian.net/browse/AU-1427)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change notification text about required fields

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1427-notification-text`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this notification is on every page and it has correct text

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/4c20e027-dca7-48d7-b6ca-f1ae47329671)


[AU-1427]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ