### PR TITLE
feature: AU-1448: Audit module update for grants project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_atv": "0.9.9",
-        "drupal/helfi_audit_log": "^0.9",
+        "drupal/helfi_audit_log": "dev-feature/AU-1448-update-hook-fix-incorrect-data",
         "drupal/helfi_azure_fs": "^1.1",
         "drupal/helfi_drupal_tools": "dev-main",
         "drupal/helfi_formtool_embed": "dev-develop",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_atv": "0.9.9",
-        "drupal/helfi_audit_log": "dev-feature/AU-1448-update-hook-fix-incorrect-data",
+        "drupal/helfi_audit_log": "^0.9",
         "drupal/helfi_azure_fs": "^1.1",
         "drupal/helfi_drupal_tools": "dev-main",
         "drupal/helfi_formtool_embed": "dev-develop",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad2e81b468340f095f56112f18181546",
+    "content-hash": "be22fe10796be08f8912501ae0a5eedf",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5507,16 +5507,16 @@
         },
         {
             "name": "drupal/helfi_audit_log",
-            "version": "0.9.7",
+            "version": "dev-feature/AU-1448-update-hook-fix-incorrect-data",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log.git",
-                "reference": "6b426d0bf8070b6e94a031df65818bba2e601f25"
+                "reference": "b6008288cece3514b6400f8a63a82fd0b32ab486"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/6b426d0bf8070b6e94a031df65818bba2e601f25",
-                "reference": "6b426d0bf8070b6e94a031df65818bba2e601f25",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/b6008288cece3514b6400f8a63a82fd0b32ab486",
+                "reference": "b6008288cece3514b6400f8a63a82fd0b32ab486",
                 "shasum": ""
             },
             "require-dev": {
@@ -5529,10 +5529,10 @@
             ],
             "description": "Helfi - Audit log",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/0.9.7",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/feature/AU-1448-update-hook-fix-incorrect-data",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/issues"
             },
-            "time": "2023-08-01T07:09:21+00:00"
+            "time": "2023-08-17T09:57:45+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",
@@ -20811,6 +20811,7 @@
     "stability-flags": {
         "drupal/block_field": 5,
         "drupal/content_access": 15,
+        "drupal/helfi_audit_log": 20,
         "drupal/helfi_drupal_tools": 20,
         "drupal/helfi_formtool_embed": 20,
         "drupal/helfi_platform_config": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be22fe10796be08f8912501ae0a5eedf",
+    "content-hash": "b416f12170ba56adbe99d178fd6341e3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -5507,16 +5507,16 @@
         },
         {
             "name": "drupal/helfi_audit_log",
-            "version": "dev-feature/AU-1448-update-hook-fix-incorrect-data",
+            "version": "0.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log.git",
-                "reference": "b6008288cece3514b6400f8a63a82fd0b32ab486"
+                "reference": "7c45dc9c0907f69e405ff2fa79bd833eb3babb4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/b6008288cece3514b6400f8a63a82fd0b32ab486",
-                "reference": "b6008288cece3514b6400f8a63a82fd0b32ab486",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-audit-log/zipball/7c45dc9c0907f69e405ff2fa79bd833eb3babb4a",
+                "reference": "7c45dc9c0907f69e405ff2fa79bd833eb3babb4a",
                 "shasum": ""
             },
             "require-dev": {
@@ -5529,10 +5529,10 @@
             ],
             "description": "Helfi - Audit log",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/feature/AU-1448-update-hook-fix-incorrect-data",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/tree/0.9.8",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-audit-log/issues"
             },
-            "time": "2023-08-17T09:57:45+00:00"
+            "time": "2023-08-23T07:07:39+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",
@@ -20811,7 +20811,6 @@
     "stability-flags": {
         "drupal/block_field": 5,
         "drupal/content_access": 15,
-        "drupal/helfi_audit_log": 20,
         "drupal/helfi_drupal_tools": 20,
         "drupal/helfi_formtool_embed": 20,
         "drupal/helfi_platform_config": 20,


### PR DESCRIPTION
### 🚨Requires helfi audit log - release 🚨

# [AU-1448](https://helsinkisolutionoffice.atlassian.net/browse/AU-1448)
<!-- What problem does this solve? -->

Helfi audit log module update.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1448-audit-log-update`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run make fresh / or import a database dump (+ drush updb)
* [ ] Update hook should run automatically and print something along this: `Helfi - Audit logs: Fixed 2565 records`
* [ ] Check that older `date_time` and `date_time_epoch` are now correct
### 🚨Requires helfi audit log - release 🚨

[AU-1448]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ