### PR TITLE
AU-1477: Fixed an issue with Webfrom translation importing

### DIFF
--- a/public/modules/custom/grants_webform_import/src/Commands/WebformImportCommands.php
+++ b/public/modules/custom/grants_webform_import/src/Commands/WebformImportCommands.php
@@ -345,12 +345,9 @@ class WebformImportCommands extends DrushCommands {
         $name = Path::getFilenameWithoutExtension($file);
         $configFileValue = $parser->parse(file_get_contents($file));
 
-        /** @var \Drupal\language\Config\LanguageConfigOverride $languageOverride */
-        $languageOverride = \Drupal::languageManager()->getLanguageConfigOverride($language, $name);
-        $languageOverrideValue = $languageOverride->get();
-
-        // Check that we have config values and language overrides.
-        if (!$configFileValue || !$languageOverrideValue) {
+        // Check that we have config values.
+        if (!$configFileValue) {
+          $this->output()->writeln("Configuration not found.");
           continue;
         }
 
@@ -368,6 +365,8 @@ class WebformImportCommands extends DrushCommands {
           continue;
         }
 
+        /** @var \Drupal\language\Config\LanguageConfigOverride $languageOverride */
+        $languageOverride = \Drupal::languageManager()->getLanguageConfigOverride($language, $name);
         $languageOverride->setData($configFileValue);
         $languageOverride->save();
         $this->output()


### PR DESCRIPTION
# [AU-1477](https://helsinkisolutionoffice.atlassian.net/browse/AU-1477)

## What was done
This pull request implements a fix for the` WebformImportCommands.php` drush command. Previously, a Webform that did not have any existing translations would not get its translations imported when the command was run. Now, the translations get imported even if no translations exist from before.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-1477-translation-import-fix`
  * `make fresh`
  * `make drush-cr`

## How to test

Run the command `drush gwi `and check that all the translations get imported successfully.


[AU-1477]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ