### PR TITLE
fix: AU-1391: fix liikunta tapahtuma buttons

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
@@ -27,12 +27,12 @@ elements: |
     '#title': Address
   community_address:
     '#title': Address
-    '#description': 'Select the address. The addresses are maintained in your data.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
   tilinumero:
     '#title': 'Account number'
   bank_account:
     '#title': 'Account number'
-    '#description': 'Select the account number. The account numbers are maintained in your data.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
     '#account_number__title': ''
   toiminnasta_vastaavat_henkilot:
     '#title': 'Persons responsible for operations'
@@ -172,6 +172,8 @@ elements: |
     '#draft__label': 'Save as Draft'
     '#wizard_prev__label': '< Previous'
     '#wizard_next__label': 'Preview >'
+    '#preview_prev__label': '< Previous'
+    '#preview_next__label': 'Preview >'
     '#delete__label': 'Delete draft'
 settings:
   wizard_prev_button_label: '< Previous'

--- a/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
@@ -27,12 +27,12 @@ elements: |
     '#title': Address
   community_address:
     '#title': Address
-    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
+    '#help': 'If you want to add, delete or change address information, save the application as a draft and go to maintain the address information in your own data.'
   tilinumero:
     '#title': 'Account number'
   bank_account:
     '#title': 'Account number'
-    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
+    '#help': 'If you want to add, delete or change account number information, save the application as a draft and go to maintain the account number information in your own data.'
     '#account_number__title': ''
   toiminnasta_vastaavat_henkilot:
     '#title': 'Persons responsible for operations'

--- a/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
@@ -29,7 +29,7 @@ elements: |
     '#title': Adress
   community_address:
     '#title': Gemenskapsadress
-    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
+    '#help': 'Om du vill l&auml;gga till, ta bort eller &auml;ndra adressuppgifter, spara ans&ouml;kan som ett utkast och g&aring; till att beh&aring;lla adressuppgifterna i dina egna uppgifter.'
     '#community_address_select__title': 'Välj adress'
     '#community_street__title': Gatuadress
     '#community_post_code__title': Postnummer
@@ -39,7 +39,7 @@ elements: |
     '#title': Kontonummer
   bank_account:
     '#title': Kontonummer
-    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
+    '#help': 'Om du vill l&auml;gga till, radera eller &auml;ndra kontonummerinformation, spara applikationen som ett utkast och g&aring; till att beh&aring;lla kontonummerinformationen i din egen data.'
     '#account_number_select__title': 'Välj ett kontonummer'
     '#account_number__title': ''
   toiminnasta_vastaavat_henkilot:

--- a/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
@@ -29,7 +29,7 @@ elements: |
     '#title': Adress
   community_address:
     '#title': Gemenskapsadress
-    '#description': 'V&auml;lj en adress, adresser sparas i v&aring;r egen data.'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa osoitetietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n osoitetietoa omiin tietoihin.'
     '#community_address_select__title': 'Välj adress'
     '#community_street__title': Gatuadress
     '#community_post_code__title': Postnummer
@@ -39,7 +39,7 @@ elements: |
     '#title': Kontonummer
   bank_account:
     '#title': Kontonummer
-    '#description': 'V&auml;lj ett kontonummer; kontonumren redigeras i dina uppgifter.&nbsp;'
+    '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa tilinumerotietoa tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n tilinumerotietoa omiin tietoihin.'
     '#account_number_select__title': 'Välj ett kontonummer'
     '#account_number__title': ''
   toiminnasta_vastaavat_henkilot:
@@ -60,7 +60,7 @@ elements: |
     '#title': 'Uppgifter om understödet'
   acting_year:
     '#title': 'Ansökan galter år'
-    '#help': 'Observera att grunder för beviljande för olika understödsformer kan ändras årligen.'
+    '#help': 'Observera att grunder f&ouml;r beviljande f&ouml;r olika underst&ouml;dsformer kan &auml;ndras &aring;rligen.'
   avustuslajit:
     '#title': Understödsformer
   subventions:
@@ -193,6 +193,8 @@ elements: |
     '#draft__label': 'Spara som oavslutat'
     '#wizard_prev__label': '< Tidigare'
     '#wizard_next__label': 'Nästa >'
+    '#preview_prev__label': '< Tidigare'
+    '#preview_next__label': 'För förhandsvisning >'
     '#delete__label': 'Radera oavslutat'
 settings:
   wizard_prev_button_label: '< Tidigare'


### PR DESCRIPTION
# [AU-1391](https://helsinkisolutionoffice.atlassian.net/browse/AU-1391)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed button translations in liikunta tapahtuma

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1391-buttons`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the translations are correct

[AU-1391]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ