### PR TITLE
AU-1490: Disable custom health_check module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/filename_transliteration": "^1.0",
         "drupal/hdbt": "^4.0",
         "drupal/hdbt_admin": "^1.0",
+        "drupal/health_check": "^3.0",
         "drupal/helfi_atv": "0.9.9",
         "drupal/helfi_audit_log": "^0.9",
         "drupal/helfi_azure_fs": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b416f12170ba56adbe99d178fd6341e3",
+    "content-hash": "41415c9ee846ed35c16eceb32eefabff",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -60,7 +60,6 @@ module:
   grants_audit_log: 0
   grants_budget_components: 0
   grants_front_banner: 0
-  grants_healtz: 0
   grants_industries: 0
   grants_mandate: 0
   grants_metadata: 0


### PR DESCRIPTION
# [AU-1490](https://helsinkisolutionoffice.atlassian.net/browse/AU-1490)
<!-- What problem does this solve? -->

Somehow our custom endpoints for health checks respond with incorrect response code when in maintenance mode. This tries to fix that by installing contrib health_check module.

## What was done
<!-- Describe what was done -->

* Custom module disable
* Contrib module update & enable

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1490]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ