### PR TITLE
fix: AU-1256: unregistered community always has required Community Officials and other roles don't

### DIFF
--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -34,12 +34,17 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public static function getCompositeElements(array $element): array {
+    /** @var \Drupal\grants_profile\GrantsProfileService $grantsProfileService */
+    $grantsProfileService = \Drupal::service('grants_profile.service');
+
+    $profileType = $grantsProfileService->getApplicantType();
 
     $elements = [];
 
     $elements['community_officials_select'] = [
       '#type' => 'select',
       '#title' => t('Select official'),
+      '#required' => ($profileType === 'unregistered_community'),
       '#after_build' => [[get_called_class(), 'buildOfficialOptions']],
       '#options' => [],
       '#attributes' => [

--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -34,17 +34,21 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public static function getCompositeElements(array $element): array {
-    /** @var \Drupal\grants_profile\GrantsProfileService $grantsProfileService */
-    $grantsProfileService = \Drupal::service('grants_profile.service');
+    $is_required = false;
+    if (\Drupal::currentUser()->isAuthenticated()) {
+      /** @var \Drupal\grants_profile\GrantsProfileService $grantsProfileService */
+      $grantsProfileService = \Drupal::service('grants_profile.service');
 
-    $profileType = $grantsProfileService->getApplicantType();
+      $profileType = $grantsProfileService->getApplicantType();
 
+      $is_required = ($profileType === 'unregistered_community');
+    }
     $elements = [];
 
     $elements['community_officials_select'] = [
       '#type' => 'select',
       '#title' => t('Select official'),
-      '#required' => ($profileType === 'unregistered_community'),
+      '#required' => $is_required,
       '#after_build' => [[get_called_class(), 'buildOfficialOptions']],
       '#options' => [],
       '#attributes' => [

--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -34,7 +34,7 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public static function getCompositeElements(array $element): array {
-    $is_required = false;
+    $is_required = FALSE;
     if (\Drupal::currentUser()->isAuthenticated()) {
       /** @var \Drupal\grants_profile\GrantsProfileService $grantsProfileService */
       $grantsProfileService = \Drupal::service('grants_profile.service');


### PR DESCRIPTION
# [AU-1256](https://helsinkisolutionoffice.atlassian.net/browse/AU-1256)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Hardcode into the Community Official component that always forces it to be required when with Unregistered community and not required if not.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1256-required-field-for-unregistered`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as private person
* [ ] Go to new kuva projektiavustus
* [ ] Check that the community officials component isn't visible on page one
* [ ] navigate to page 2 and see that there is no error about a required community officials field
* [ ] Save, send the form. See that these functions work.
* [ ] Change role to registered community.
* [ ] Go to new kuva projektiavustus
* [ ] Check that the community officials component is visible but not requried on page one
* [ ] Add a new community official so you have two of them and see that neither are required.
* [ ] navigate to page 2 and see that there is no error about a required community officials field
* [ ] Save, send the form. See that these functions work.
* [ ] Change role to unregistered community
* [ ] Go to new kuva projektiavustus
* [ ] Check that the community officials component is visible and required on page one
* [ ] Add a new community official so you have two of them and see that both are required.
* [ ] Don't select one of them but navigate to page 2 via the pager and see that there is an error about a required community officials field
* [ ] Check that code follows our standards


[AU-1256]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ