### PR TITLE
fix: AU-1475: fix the AJAX attachment thing with form_alter before the hierarchy is changed

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -752,38 +752,64 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
     foreach ($form['elements'] as $page_name => $page_contents) {
       $page_prefetched = FALSE;
       $page_required = FALSE;
-      if ($page_name === 'actions') {
-        break;
-      }
-      foreach ($form['elements'][$page_name] as $section_key => $section_contents) {
-        if (!strstr($section_key, '#') && is_array($section_contents)) {
-          foreach ($section_contents as $element_key => $element_contents) {
-            if (!strstr($element_key, '#') && is_array($element_contents)) {
-              if (array_key_exists('#required', $element_contents) && $element_contents['#required'] === TRUE) {
-                $page_required = TRUE;
-              }
-              if (array_key_exists('#type', $element_contents) &&
-                ($element_contents['#type'] === 'community_address_composite' ||
-                  $element_contents['#type'] === 'community_officials_composite' ||
-                  $element_contents['#type'] === 'bank_account_composite' ||
-                  $element_key === 'community_purpose'
-                )
-              ) {
-                $page_prefetched = TRUE;
-              }
-              if ($page_required && $page_prefetched) {
-                break 2;
+      if ($page_contents['#type'] === 'container') {
+        foreach ($form['elements'][$page_name] as $section_key => $section_contents) {
+          if (!strstr($section_key, '#') && is_array($section_contents)) {
+            foreach ($section_contents as $element_key => $element_contents) {
+              if (!strstr($element_key, '#') && is_array($element_contents)) {
+                if (array_key_exists('#required', $element_contents) && $element_contents['#required'] === TRUE) {
+                  $page_required = TRUE;
+                }
+                if (array_key_exists('#type', $element_contents) &&
+                  ($element_contents['#type'] === 'community_address_composite' ||
+                    $element_contents['#type'] === 'community_officials_composite' ||
+                    $element_contents['#type'] === 'bank_account_composite' ||
+                    $element_key === 'community_purpose'
+                  )
+                ) {
+                  $page_prefetched = TRUE;
+                }
+                if ($page_required && $page_prefetched) {
+                  break 2;
+                }
               }
             }
           }
         }
-      }
 
-      if (!$isClosed && $page_required) {
-        $form['elements'][$page_name] = array_merge($required_fields_info_element, $form['elements'][$page_name]);
-      }
-      if (!$isClosed && $page_prefetched) {
-        $form['elements'][$page_name] = array_merge($infoelement, $form['elements'][$page_name]);
+        $infoelement = [
+          'omat_tiedot_page_infobox_' . $page_name => [
+            '#theme' => 'hds_notification',
+            '#type' => 'notification',
+            '#class' => '',
+            '#label' => t('Some information fetched from personal information'),
+            '#body' => t('Check the information on the form before sending the application. You can change your own information from personal information section of the site.'),
+          ],
+        ];
+
+        if (!$isClosed) {
+          $required_fields_info_element = [];
+          $required_fields_info_element['#title'] = $page_contents['#title'];
+          $required_fields_info_element['#type'] = $page_contents['#type'];
+
+          $required_fields_info_element['required_fields_infobox'] = [
+                '#theme' => 'hds_notification',
+                '#type' => 'notification',
+                '#label' => t('Fill in the fields to all the questions that you can answer.'),
+                '#body' => t('Fields marked with * are mandatory information that you must fill in in order to save and send the information.'),
+                '#class' => 'notification-margin-bottom',
+          ];
+
+          // Drupal wants things in a order when returning from an AJAX call.
+          // These are re-merged to the array below.
+          unset($page_contents['#title']);
+          unset($page_contents['#type']);
+          $form['elements'][$page_name] = array_merge($required_fields_info_element, $form['elements'][$page_name]);
+
+          if ($page_prefetched) {
+            $form['elements'][$page_name] = array_merge($infoelement, $form['elements'][$page_name]);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
# [AU-1475](https://helsinkisolutionoffice.atlassian.net/browse/AU-1475)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* The lisätiedot ja liitteet error that happened when the new notification about required fields was displayed is fixed.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1475-fix-ajax-file-errors`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as registered community
* [ ] go to taiteen perusopetus form
* [ ] go to page 7, lisätiedot ja liitteet
* [ ] see that there is a notification about required fields being marked with an asterisk on the page
* [ ] add an attachment
* [ ] see that the form saves/sends correctly
* [ ] Check that code follows our standards


[AU-1475]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ