### PR TITLE
fix: AU-1457: Hidden fields do not need titles if they are not to be displayed on preview

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
+++ b/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
@@ -66,7 +66,6 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     $elements['applicantType'] = [
       '#type' => 'hidden',
       '#value' => $selectedRoleData["type"],
-      '#title' => t('Applicant type'),
     ];
     $elements['applicant_type'] = [
       '#type' => 'hidden',


### PR DESCRIPTION
# [AU-1457](https://helsinkisolutionoffice.atlassian.net/browse/AU-1457)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed title from a hidden field to make it disappear from preview

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1457-applicant-type-translation-in-preview`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in.
* [ ] Go to form
* [ ] Go to preview.
* [ ] See that there is no "Applicant type" in Hakijan tiedot
* [ ] Save form
* [ ] See that there is no "Applicant type in Hakijan tiedot.
* [ ] Check that code follows our standards


[AU-1457]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ