### PR TITLE
fix: AU-1474 change hidden avustukset-summa to a hidden field instead of display:none

### DIFF
--- a/public/modules/custom/grants_webform_summation_field/src/Element/GrantsWebformSummationField.php
+++ b/public/modules/custom/grants_webform_summation_field/src/Element/GrantsWebformSummationField.php
@@ -63,13 +63,13 @@ class GrantsWebformSummationField extends FormElement {
     if (isset($element['#form_item'])) {
       $formItem = $element['#form_item'];
     }
+    $element['#type'] = 'text_field';
     if ($formItem === 'hidden') {
+      $element['#type'] = 'hidden';
       $element['#title_display'] = 'none';
       $element['#description_display'] = 'none';
       $element['#attributes']['readonly'] = 'readonly';
-      $element['#attributes']['style'] = 'display:none;';
     }
-    $element['#type'] = 'text_field';
     if (isset($element['#data_type'])) {
       $summationType = $element['#data_type'];
     }


### PR DESCRIPTION
# [AU-1474](https://helsinkisolutionoffice.atlassian.net/browse/AU-1474)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Avustukset Summa -field is now hidden if set to hidden

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1474-hide-avustukset-summa`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in
* [ ] Navigate to a form with conditionals depending on avustukset_summa - Kuva Projekti, where there are fields on page 5 that are shown if sum is large enough.
* [ ] navigatie to page 5, see that fields are hidden
* [ ] Navigate to subvention amounts section, set it to a value that causes changes
* [ ] go back to page 5, see changes in the number of fields
* [ ] Check that code follows our standards


[AU-1474]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ