### PR TITLE
fix: AU-1496: Move notification outside of checkbox in preview page

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -799,11 +799,11 @@ function grants_handler_webform_submission_form_alter(&$form, FormStateInterface
           $required_fields_info_element['#type'] = $page_contents['#type'];
 
           $required_fields_info_element['required_fields_infobox'] = [
-                '#theme' => 'hds_notification',
-                '#type' => 'notification',
-                '#label' => t('Fill in the fields to all the questions that you can answer.'),
-                '#body' => t('Fields marked with * are mandatory information that you must fill in in order to save and send the information.'),
-                '#class' => 'notification-margin-bottom',
+            '#theme' => 'hds_notification',
+            '#type' => 'notification',
+            '#label' => t('Fill in the fields to all the questions that you can answer.'),
+            '#body' => t('Fields marked with * are mandatory information that you must fill in in order to save and send the information.'),
+            '#class' => 'notification-margin-bottom',
           ];
 
           // Drupal wants things in a order when returning from an AJAX call.

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -921,11 +921,12 @@ function grants_handler_preprocess_webform_submission_data(&$variables) {
     ];
     $terms_info_rendered = Markup::create(render($terms_info));
     // Add html for checkbox.
-    $variables['confirm_texts'][] = '<div class="terms_block">' . $render . '</div><div class="hds-checkbox">
+    $variables['confirm_texts'][] = '<div class="terms_block">' . $render . '</div>
       ' . $terms_info_rendered . '
-      <input type="checkbox" id="' . $htmlId . '" required="required" class="hds-checkbox__input" />
-      <label for="' . $htmlId . '"  class="hds-checkbox__label">' . $translatedTitle . '</label>
-    </div>';
+      <div class="hds-checkbox">
+        <input type="checkbox" id="' . $htmlId . '" required="required" class="hds-checkbox__input" />
+        <label for="' . $htmlId . '"  class="hds-checkbox__label">' . $translatedTitle . '</label>
+      </div>';
   }
 }
 


### PR DESCRIPTION
# [AU-1496](https://helsinkisolutionoffice.atlassian.net/browse/AU-1496)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Notification is no longer inside the checkbox element at the bottom of the preview page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1496-accept-terms-checkbox`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] log in, fill a form, go to the preview page
* [ ] scroll to the bottom. click on the checkbox about accepting the terms and see that the check appears inside the checkbox instead of on top of the notification above it.
* [ ] Check that code follows our standards


[AU-1496]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ