### PR TITLE
fix/AU-1488: Added postal code checking to the grants premises component

### DIFF
--- a/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
@@ -72,6 +72,9 @@ class PremisesComposite extends WebformCompositeBase {
       '#type' => 'textfield',
       '#title' => t('Post Code', [], $tOpts),
       '#size' => 10,
+      '#maxlength' => 8,
+      '#pattern' => '^(FI-)?[0-9]{5}$',
+      '#pattern_error' => t('Enter a valid post code.', [], $tOpts),
       '#required' => TRUE,
     ];
 

--- a/public/modules/custom/grants_premises/translations/fi.po
+++ b/public/modules/custom/grants_premises/translations/fi.po
@@ -139,3 +139,7 @@ msgstr "Muu kaupungin omistama tila"
 msgctxt "grants_premises"
 msgid "Unknown"
 msgstr "Ei tietoa"
+
+msgctxt "grants_premises"
+msgid "Enter a valid post code."
+msgstr "Syötä postinumero."

--- a/public/modules/custom/grants_premises/translations/sv.po
+++ b/public/modules/custom/grants_premises/translations/sv.po
@@ -136,3 +136,7 @@ msgstr "Övriga utrymmen som ägs av staden"
 msgctxt "grants_premises"
 msgid "Unknown"
 msgstr "Okänd"
+
+msgctxt "grants_premises"
+msgid "Enter a valid post code."
+msgstr "Ange ett giltigt postnummer."


### PR DESCRIPTION
# [AU-1488](https://helsinkisolutionoffice.atlassian.net/browse/AU-1488)

## What was done

This pull request implements a minor change to the "**Grants premises**" component. The length of the postal code in said component was never check in any way. The implemented change checks the postal codes formatting and length.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-1488-grants-premises-postal-code`
  * `make fresh`
  * `make drush-cr`

## How to test
- Login as a test user and go to the "**Taide- ja kulttuuriavustukset, taiteen perusopetus**" form.
- Find the postal code field on pages 3 and 4, and check that you can only enter a valid postal code (FI-12345 or 12345). 

[AU-1488]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ