### PR TITLE
fix: AU-1544: Create node revision on Webform config import

### DIFF
--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -9,6 +9,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\webform\Entity\Webform;
 
@@ -61,7 +62,6 @@ function grants_metadata__validate_third_party_settings(array &$form, FormStateI
  * Implements hook_webform_presave().
  */
 function grants_metadata_webform_presave(Webform $entity) {
-
   // Get third aprty settings.
   $thirdPartySettings = $entity->getThirdPartySettings('grants_metadata');
 
@@ -88,10 +88,17 @@ function grants_metadata_webform_presave(Webform $entity) {
     // Update node values from 3rd party settings.
     grants_metadata_set_node_values($page, $status, $thirdPartySettings);
     try {
-      // Save node.
+      // Create a revision and save the node.
+      $save_time = \Drupal::time()->getCurrentTime();
+      $storage =\Drupal::entityTypeManager()->getStorage('node');
+      $author = $page->getOwnerId();
+      $page->setRevisionLogMessage('Revision created programmatically.');
+      $page->setRevisionCreationTime($save_time);
+      $page->setRevisionUserId($author);
+      $page = $storage->createRevision($page);
       $page->save();
       \Drupal::messenger()
-        ->addStatus(t('Service page @nodetitle updated', ['@nodetitle' => $page->label()]));
+        ->addStatus(t('Service page @nodetitle updated. Revision created.', ['@nodetitle' => $page->label()]));
     }
     catch (EntityStorageException $e) {
       \Drupal::messenger()

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -9,7 +9,6 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
-use Drupal\node\NodeInterface;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\webform\Entity\Webform;
 
@@ -90,7 +89,7 @@ function grants_metadata_webform_presave(Webform $entity) {
     try {
       // Create a revision and save the node.
       $save_time = \Drupal::time()->getCurrentTime();
-      $storage =\Drupal::entityTypeManager()->getStorage('node');
+      $storage = \Drupal::entityTypeManager()->getStorage('node');
       $author = $page->getOwnerId();
       $page->setRevisionLogMessage('Revision created programmatically.');
       $page->setRevisionCreationTime($save_time);


### PR DESCRIPTION
# [AU-1544](https://helsinkisolutionoffice.atlassian.net/browse/AU-1544)

## What was done

This pull request implements a minor change to the `hook_webform_presave` hook in `grants_metadata.module`. The change makes it so that a new node revision is automatically created when a node is saved after Webform configurations have been imported.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-1544-config-import-node-revision`
  * `make fresh`
  * `make drush-cr`

## How to test
- Run `drush gwco`. Check that a service page whose Webform was updated has a new revision.
- Wait a minute or so and run `drush gwi`. Check that a service page whose Webform was updated has a new revision.

[AU-1544]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ