### PR TITLE
fix: AU-1485: change name of Nuorisotoimi to Nuorisotoiminta

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -128,7 +128,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\NuorisoLomaDefinition
         definitionId: grants_metadata_nuorisoloma
       labels:
-        fi: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
+        fi: 'Nuorisotoiminta, loma-aikojen leiriavustushakemus'
         en: 'Holiday camp grants for youth activities'
         sv: 'Ungdomsverksamhet, lägerunderstöd under skollovstider'
     60:

--- a/conf/cmi/webform.webform.nuorlomaleir.yml
+++ b/conf/cmi/webform.webform.nuorlomaleir.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: nuorlomaleir
-title: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
+title: 'Nuorisotoiminta, loma-aikojen leiriavustushakemus'
 description: NUORLOMALEIR
 category: ''
 elements: |-

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: nuorlomaleir
-title: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
+title: 'Nuorisotoiminta, loma-aikojen leiriavustushakemus'
 description: NUORLOMALEIR
 category: ''
 elements: |-

--- a/public/modules/custom/grants_metadata/config/install/grants_metadata.settings.yml
+++ b/public/modules/custom/grants_metadata/config/install/grants_metadata.settings.yml
@@ -118,7 +118,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\NuorisoLomaDefinition
         definitionId: grants_metadata_nuorisoloma
       labels:
-        fi: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
+        fi: 'Nuorisotoiminta, loma-aikojen leiriavustushakemus'
         en: 'Holiday camp grants for youth activities'
         sv: 'Ungdomsverksamhet, lägerunderstöd under skollovstider'
     60:


### PR DESCRIPTION
# [AU-1485](https://helsinkisolutionoffice.atlassian.net/browse/AU-1485)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* "Nuorisotoimi, loma-aikojen leiriavustushakemus: Muutetaan hakemuksen nimi Nuorisotoiminta, loma-aikojen leiriavustushakemus"

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1485-change-name-of-loma-aikojen-leiriavustushakemus`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as admin
* [ ] Make "Nuorisotoiminta, loma-aikojen leiriavustushakemus" continuous so you can visit it 
* [ ] See that the name is "Nuorisotoiminta", not "Nuorisotoimi"
* [ ] Log in as registered community
* [ ] `/fi/uusi-hakemus/nuorlomaleir`
* [ ] See that the name is "Nuorisotoiminta", not "Nuorisotoimi"
* [ ] Check that code follows our standards


[AU-1485]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ