### PR TITLE
AU-1552: Remove delivered later / in other file from NUORISO forms

### DIFF
--- a/conf/cmi/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -355,7 +355,10 @@ elements: |-
         '#filetype': '7'
         '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet'
         '#title_display': before
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       projektisuunnitelma_liite:
         '#type': grants_attachments
         '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta)'
@@ -363,7 +366,10 @@ elements: |-
         '#filetype': '1'
         '#help': 'Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n toimintasuunnitelma.'
         '#title_display': before
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       projektin_talousarvio:
         '#type': grants_attachments
         '#title': 'Talousarvio (sille vuodelle jolle haet avustusta) '
@@ -371,7 +377,10 @@ elements: |-
         '#filetype': '2'
         '#help': 'Talousarvio (sille vuodelle jolle haet avustusta)'
         '#title_display': before
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       extra_info:
         '#type': textarea
         '#title': 'Lisäselvitys liitteistä'

--- a/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -643,21 +643,30 @@ elements: |-
         '#filetype': '7'
         '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet.'
         '#title_display': ''
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       projektisuunnitelma_liite:
         '#type': grants_attachments
         '#title': Projektisuunnitelma
         '#multiple': false
         '#filetype': '19'
         '#title_display': ''
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       projektin_talousarvio:
         '#type': grants_attachments
         '#title': 'Projektin talousarvio'
         '#multiple': false
         '#filetype': '2'
         '#title_display': ''
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       extra_info:
         '#type': textarea
         '#title': 'Lisäselvitys liitteistä'

--- a/conf/cmi/webform.webform.nuorlomaleir.yml
+++ b/conf/cmi/webform.webform.nuorlomaleir.yml
@@ -335,7 +335,10 @@ elements: |-
         '#filetype': '7'
         '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet.'
         '#title_display': ''
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       leiri_excel:
         '#type': grants_attachments
         '#title': Leiri-excel
@@ -343,7 +346,10 @@ elements: |-
         '#filetype': '0'
         '#help': 'T&auml;yt&auml; t&auml;m&auml; pakollinen liite huolellisesti.'
         '#title_display': ''
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       toimintasuunnitelma:
         '#type': grants_attachments
         '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta)'
@@ -351,7 +357,10 @@ elements: |-
         '#filetype': '1'
         '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n toimintasuunnitelma. </span></span></span>'
         '#title_display': before
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       talousarvio:
         '#type': grants_attachments
         '#title': 'Talousarvio (sille vuodelle jolle haet avustusta)'
@@ -359,7 +368,10 @@ elements: |-
         '#filetype': '2'
         '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n koko yhteis&ouml;n talousarvio.</span></span></span>'
         '#title_display': before
+        '#attachment__required': true
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       extra_info:
         '#type': textarea
         '#title': 'Lisäselvitys liitteistä'

--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -408,9 +408,6 @@ class GrantsAttachments extends WebformCompositeBase {
    * @param array $form
    *   The form.
    *
-   * @return bool|null
-   *   Success or not.
-   *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public static function validateAttachmentRequired(array &$element, FormStateInterface $form_state, array &$form) {

--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -402,15 +402,13 @@ class GrantsAttachments extends WebformCompositeBase {
    * Validate attachment required requirement.
    *
    * @param array $element
-   *   Element tobe validated.
+   *   Element to be validated.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   Form state.
    * @param array $form
    *   The form.
-   *
-   * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public static function validateAttachmentRequired(array &$element, FormStateInterface $form_state, array &$form) {
+  public static function validateAttachmentRequired(array &$element, FormStateInterface $form_state, array &$form): void {
     $triggeringElement = $form_state->getTriggeringElement();
 
     if (str_contains($triggeringElement['#name'], 'button')) {
@@ -431,7 +429,7 @@ class GrantsAttachments extends WebformCompositeBase {
    * Validate & upload file attachment.
    *
    * @param array $element
-   *   Element tobe validated.
+   *   Element to be validated.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   Form state.
    * @param array $form


### PR DESCRIPTION
and add check for required attachment field value

# [AU-1552](https://helsinkisolutionoffice.atlassian.net/browse/AU-1552)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed delivered later / included in other file selection for attachments in NUORISO forms.
* Made Attachment required in those form and added additional validation for such us case.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1552-nuoriso-attachment-requirements`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Test NUORISO forms and see that checkboxces are gone and you are required to add an attachment



[AU-1552]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ