### PR TITLE
fix: AU-1479: Make attachments optional

### DIFF
--- a/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -644,6 +644,8 @@ elements: |-
         '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet.'
         '#title_display': ''
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       projektisuunnitelma_liite:
         '#type': grants_attachments
         '#title': Projektisuunnitelma
@@ -651,6 +653,8 @@ elements: |-
         '#filetype': '19'
         '#title_display': ''
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       projektin_talousarvio:
         '#type': grants_attachments
         '#title': 'Projektin talousarvio'
@@ -658,6 +662,8 @@ elements: |-
         '#filetype': '2'
         '#title_display': ''
         '#description__access': false
+        '#isDeliveredLater__access': false
+        '#isIncludedInOtherFile__access': false
       extra_info:
         '#type': textarea
         '#title': 'Lisäselvitys liitteistä'


### PR DESCRIPTION
# [AU-1479](https://helsinkisolutionoffice.atlassian.net/browse/AU-1479)
<!-- What problem does this solve? -->

Tee nuorisotoiminnan projektiavustushakemuksen liitteistä ei-pakollisia.

Tämä on melko yksikertainen ratkaisu pakollisuuden poistoon. Keskustellaan tästä yhdessä koska jos tästä tekee monimutkaisemman niin liitetiedostojen käsittelyn kompleksisuus kasvaa reilusti hyvin pienen hyödyn takia.

## What was done
<!-- Describe what was done -->

Konfiguroi webform niin että haluttu tila saavutetaan.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1479-attachment-not-required`
  * `drush gwi --force` jotta lomakkeet päivittyvät
  * Mene https://hel-fi-drupal-grant-applications.docker.so/en/form/nuorisotoiminta-projektiavustush



[AU-1479]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ