### PR TITLE
fix: AU-xxx: Search api primary key patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,9 @@
                 "Secure cookies": "https://www.drupal.org/files/issues/2022-11-25/3308456-11.patch",
                 "Module fix": "patches/autologout-fix-configuration.patch",
                 "Modal related issues": "https://www.drupal.org/files/issues/2023-04-25/autologout.2023-04-25.patch"
+            },
+            "drupal/search_api": {
+                "Primary key fix": "patches/search_api_primary_key.patch"
             }
         },
         "drupal-scaffold": {

--- a/patches/search_api_primary_key.patch
+++ b/patches/search_api_primary_key.patch
@@ -1,5 +1,5 @@
 diff --git a/modules/search_api_db/src/Plugin/search_api/backend/Database.php b/modules/search_api_db/src/Plugin/search_api/backend/Database.php
-index 223d69ad..a38103e5 100644
+index 223d69ad..25aabf1b 100644
 --- a/modules/search_api_db/src/Plugin/search_api/backend/Database.php
 +++ b/modules/search_api_db/src/Plugin/search_api/backend/Database.php
 @@ -850,12 +850,9 @@ class Database extends BackendPluginBase implements AutocompleteBackendInterface
@@ -17,11 +17,13 @@ index 223d69ad..a38103e5 100644
        $this->database->schema()->createTable($db['table'], $table);
        $this->dbmsCompatibility->alterNewTable($db['table'], $type);
      }
-@@ -920,6 +917,7 @@ class Database extends BackendPluginBase implements AutocompleteBackendInterface
+@@ -920,7 +917,8 @@ class Database extends BackendPluginBase implements AutocompleteBackendInterface
 
      // Add a covering index for field tables.
      if ($new_table && $type == 'field') {
-+      $this->database->schema()->dropPrimaryKey($db['table']);
-       $this->database->schema()->addPrimaryKey($db['table'], ['item_id', $column]);
+-      $this->database->schema()->addPrimaryKey($db['table'], ['item_id', $column]);
++      $sql = "ALTER TABLE `{$table['name']}` DROP PRIMARY KEY, ADD PRIMARY KEY (  `item_id`, `{$column}` )";
++      $this->database->query($sql);
      }
    }
+

--- a/patches/search_api_primary_key.patch
+++ b/patches/search_api_primary_key.patch
@@ -1,0 +1,27 @@
+diff --git a/modules/search_api_db/src/Plugin/search_api/backend/Database.php b/modules/search_api_db/src/Plugin/search_api/backend/Database.php
+index 223d69ad..a38103e5 100644
+--- a/modules/search_api_db/src/Plugin/search_api/backend/Database.php
++++ b/modules/search_api_db/src/Plugin/search_api/backend/Database.php
+@@ -850,12 +850,9 @@ class Database extends BackendPluginBase implements AutocompleteBackendInterface
+             'not null' => TRUE,
+           ],
+         ],
++        'primary key' => ['item_id']
+       ];
+-      // For the denormalized index table, add a primary key right away. For
+-      // newly created field tables we first need to add the "value" column.
+-      if ($type === 'index') {
+-        $table['primary key'] = ['item_id'];
+-      }
++
+       $this->database->schema()->createTable($db['table'], $table);
+       $this->dbmsCompatibility->alterNewTable($db['table'], $type);
+     }
+@@ -920,6 +917,7 @@ class Database extends BackendPluginBase implements AutocompleteBackendInterface
+
+     // Add a covering index for field tables.
+     if ($new_table && $type == 'field') {
++      $this->database->schema()->dropPrimaryKey($db['table']);
+       $this->database->schema()->addPrimaryKey($db['table'], ['item_id', $column]);
+     }
+   }


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Patch for search_api module. Platform is using Invisible Primary Keys if table is created without PKs and search_api is trying to add these afterwards.
