### PR TITLE
fix. AU-1562: Fix Liikunta Tapahtuma radiobutton values to booleans

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
@@ -92,26 +92,41 @@ elements: |
     '#counter_maximum_message': '%d/3000 characters left'
   equality_radios:
     '#title': 'The event promotes equality and non-discrimination'
+    '#options':
+      1: 'Yes'
+      0: 'No'
   equality_how:
     '#title': 'How?'
     '#counter_maximum_message': '%d/1000 characters left'
   inclusion_radios:
     '#title': 'The event promotes inclusion and communality'
+    '#options':
+      1: 'Yes'
+      0: 'No'
   inclusion_how:
     '#title': 'How?'
     '#counter_maximum_message': '%d/1000 characters left'
   environment_radios:
     '#title': 'The event takes environmental matters into account'
+    '#options':
+      1: 'Yes'
+      0: 'No'
   environment_how:
     '#title': 'How?'
     '#counter_maximum_message': '%d/1000 characters left'
   exercise_radios:
     '#title': 'The event inspires new people to take up independent or guided sports activities'
+    '#options':
+      1: 'Yes'
+      0: 'No'
   exercise_how:
     '#title': 'How?'
     '#counter_maximum_message': '%d/1000 characters left'
   activity_radios:
     '#title': 'The event inspires people to be more actively in their daily lives'
+    '#options':
+      1: 'Yes'
+      0: 'No'
   activity_how:
     '#title': 'How?'
     '#counter_maximum_message': '%d/1000 characters left'

--- a/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
@@ -103,26 +103,41 @@ elements: |
     '#counter_maximum_message': '%d/3000 tecken kvar'
   equality_radios:
     '#title': 'Evenemanget främjar likvärdighet och jämlikhet'
+    '#options':
+      1: Ja
+      0: Nej
   equality_how:
     '#title': 'Hur?'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   inclusion_radios:
     '#title': 'Evenemanget främjar delaktighet och social gemenskap'
+    '#options':
+      1: Ja
+      0: Nej
   inclusion_how:
     '#title': 'Hur?'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   environment_radios:
     '#title': 'Miljöfrågor har beaktats vid evenemanget'
+    '#options':
+      1: Ja
+      0: Nej
   environment_how:
     '#title': 'Hur?'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   exercise_radios:
     '#title': 'Evenemanget inspirerar nya utövare att delta i självständig eller handledd motion'
+    '#options':
+      1: Ja
+      0: Nej
   exercise_how:
     '#title': 'Hur?'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   activity_radios:
     '#title': 'Evenemanget uppmuntrar människor till en fysiskt aktiv vardag'
+    '#options':
+      1: Ja
+      0: Nej
   activity_how:
     '#title': 'Hur?'
     '#counter_maximum_message': '%d/1000 tecken kvar'

--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -118,7 +118,7 @@ elements: |-
       '#states':
         visible:
           ':input[name="applicant_type"]':
-            'value': registered_community
+            value: registered_community
       community_address:
         '#type': community_address_composite
         '#title': 'Yhteisön osoite'
@@ -130,7 +130,7 @@ elements: |-
         '#states':
           visible:
             ':input[name="applicant_type"]':
-              'value': registered_community
+              value: registered_community
     tilinumero:
       '#type': webform_section
       '#title': Tilinumero
@@ -161,7 +161,6 @@ elements: |-
         '#multiple__add': false
         '#multiple__add_more_input': false
         '#multiple__add_more_button_label': 'Lisää henkilö'
-
         '#wrapper_attributes':
           class:
             - community_officials_wrapper
@@ -325,7 +324,9 @@ elements: |-
       equality_radios:
         '#type': radios
         '#title': 'Tapahtuma edistää yhdenvertaisuutta ja tasa-arvoa'
-        '#options': yes_no
+        '#options':
+          1: Kyllä
+          0: Ei
         '#options_display': side_by_side
       equality_how:
         '#type': textarea
@@ -339,11 +340,13 @@ elements: |-
         '#states':
           visible:
             ':input[name="equality_radios"]':
-              value: 'Yes'
+              value: '1'
       inclusion_radios:
         '#type': radios
         '#title': 'Tapahtuma edistää osallisuutta ja yhteisöllisyyttä'
-        '#options': yes_no
+        '#options':
+          1: Kyllä
+          0: Ei
         '#options_display': side_by_side
       inclusion_how:
         '#type': textarea
@@ -357,11 +360,13 @@ elements: |-
         '#states':
           visible:
             ':input[name="inclusion_radios"]':
-              value: 'Yes'
+              value: '1'
       environment_radios:
         '#type': radios
         '#title': 'Tapahtumassa on huomioitu ympäristöasiat'
-        '#options': yes_no
+        '#options':
+          1: Kyllä
+          0: Ei
         '#options_display': side_by_side
       environment_how:
         '#type': textarea
@@ -374,11 +379,13 @@ elements: |-
         '#states':
           visible:
             ':input[name="environment_radios"]':
-              value: 'Yes'
+              value: '1'
       exercise_radios:
         '#type': radios
         '#title': 'Tapahtuma innostaa uusia harrastajia omatoimisen tai ohjatun liikunnan pariin'
-        '#options': yes_no
+        '#options':
+          1: Kyllä
+          0: Ei
         '#options_display': side_by_side
       exercise_how:
         '#type': textarea
@@ -391,11 +398,13 @@ elements: |-
         '#states':
           visible:
             ':input[name="exercise_radios"]':
-              value: 'Yes'
+              value: '1'
       activity_radios:
         '#type': radios
         '#title': 'Tapahtuma innostaa ihmisiä arkiaktiivisuuteen'
-        '#options': yes_no
+        '#options':
+          1: Kyllä
+          0: Ei
         '#options_display': side_by_side
       activity_how:
         '#type': textarea
@@ -408,7 +417,7 @@ elements: |-
         '#states':
           visible:
             ':input[name="activity_radios"]':
-              value: 'Yes'
+              value: '1'
     tapahtuma_ajankohta:
       '#type': webform_section
       '#title': Tapahtuma-ajankohta

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTapahtumaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTapahtumaDefinition.php
@@ -204,7 +204,7 @@ class LiikuntaTapahtumaDefinition extends ComplexDataDefinitionBase {
           ],
         ]);
 
-      $info['equality_radios'] = DataDefinition::create('string')
+      $info['equality_radios'] = DataDefinition::create('boolean')
         ->setLabel('Tapahtuma edistää yhdenvertaisuutta ja tasa-arvoa?')
         ->setSetting('jsonPath', [
           'compensation',
@@ -226,7 +226,7 @@ class LiikuntaTapahtumaDefinition extends ComplexDataDefinitionBase {
           'eventEqualityText',
         ]);
 
-      $info['inclusion_radios'] = DataDefinition::create('string')
+      $info['inclusion_radios'] = DataDefinition::create('boolean')
         ->setLabel('Tapahtuma edistää osallisuutta ja yhteisöllisyyttä?')
         ->setSetting('jsonPath', [
           'compensation',
@@ -248,7 +248,7 @@ class LiikuntaTapahtumaDefinition extends ComplexDataDefinitionBase {
           'eventCommunalText',
         ]);
 
-      $info['environment_radios'] = DataDefinition::create('string')
+      $info['environment_radios'] = DataDefinition::create('boolean')
         ->setLabel('Tapahtumassa on huomioitu ympäristöasiat?')
         ->setSetting('jsonPath', [
           'compensation',
@@ -270,7 +270,7 @@ class LiikuntaTapahtumaDefinition extends ComplexDataDefinitionBase {
           'eventEnvironmentText',
         ]);
 
-      $info['exercise_radios'] = DataDefinition::create('string')
+      $info['exercise_radios'] = DataDefinition::create('boolean')
         ->setLabel('Tapahtuma innostaa uusia harrastajia omatoimisen tai ohjatun liikunnan pariin?')
         ->setSetting('jsonPath', [
           'compensation',
@@ -292,7 +292,7 @@ class LiikuntaTapahtumaDefinition extends ComplexDataDefinitionBase {
           'eventNewPeopleActivatingText',
         ]);
 
-      $info['activity_radios'] = DataDefinition::create('string')
+      $info['activity_radios'] = DataDefinition::create('boolean')
         ->setLabel('Tapahtuma innostaa ihmisiä arkiaktiivisuuteen?')
         ->setSetting('jsonPath', [
           'compensation',


### PR DESCRIPTION
# [AU-1562](https://helsinkisolutionoffice.atlassian.net/browse/AU-1562)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed radiobutton values to 0 / 1 instead of Kyllä / Ei

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1562-boolean-field-values`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Start a new Liikunta Tapahtuma application and goto page 2.
* [ ] Check some radiobuttons and make sure that they are saved as 0 and 1 in ATV document.
* [ ] Radiobutton values are returned correctly, when editing draft. 



[AU-1562]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ