### PR TITLE
feat:AU-1556: Added date validation to the Liikunta tapahtuma-avustushakemus Webform

### DIFF
--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -118,7 +118,7 @@ elements: |-
       '#states':
         visible:
           ':input[name="applicant_type"]':
-            'value': registered_community
+            value: registered_community
       community_address:
         '#type': community_address_composite
         '#title': 'Yhteisön osoite'
@@ -130,7 +130,7 @@ elements: |-
         '#states':
           visible:
             ':input[name="applicant_type"]':
-              'value': registered_community
+              value: registered_community
     tilinumero:
       '#type': webform_section
       '#title': Tilinumero
@@ -161,7 +161,6 @@ elements: |-
         '#multiple__add': false
         '#multiple__add_more_input': false
         '#multiple__add_more_button_label': 'Lisää henkilö'
-
         '#wrapper_attributes':
           class:
             - community_officials_wrapper
@@ -416,11 +415,13 @@ elements: |-
         '#type': date
         '#title': Alkaa
         '#required': true
+        '#date_date_min': today
         '#datepicker': true
       paattyy:
         '#type': date
         '#title': Päättyy
         '#required': true
+        '#date_date_min': today
         '#datepicker': true
   tapahtuman_talousarvio:
     '#type': webform_wizard_page

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\grants_metadata\Validator\EndDateValidator;
 use Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\webform\Entity\Webform;
@@ -467,5 +468,19 @@ function grants_metadata_preprocess_block(&$variables) {
 
     $variables["content"]["#cache"]["max-age"] = 0;
     $variables["elements"]["#cache"]["max-age"] = 0;
+  }
+}
+
+/**
+ * Implements hook_webform_element_alter().
+ */
+function grants_metadata_webform_element_alter(array &$element, FormStateInterface $form_state, array $context): void {
+  if (isset($element['#webform_id'])) {
+    if ($element['#webform_id'] === 'liikunta_tapahtuma--paattyy') {
+      $element['#element_validate'][] = [
+        EndDateValidator::class,
+        'validate',
+      ];
+    }
   }
 }

--- a/public/modules/custom/grants_metadata/src/Validator/EndDateValidator.php
+++ b/public/modules/custom/grants_metadata/src/Validator/EndDateValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\grants_metadata\Validator;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * The EndDateValidator class.
+ */
+class EndDateValidator {
+
+  /**
+   * The machine name of the start date element.
+   */
+  const START_DATE_ELEMENT_ID = 'alkaa';
+
+  /**
+   * The machine name of the end date element.
+   */
+  const END_DATE_ELEMENT_ID = 'paattyy';
+
+  /**
+   * Validate an end date.
+   *
+   * @param array $element
+   *   The form element to process.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state.
+   * @param array $form
+   *   The complete form structure.
+   */
+  public static function validate(array &$element, FormStateInterface $formState, array &$form): void {
+    $startDateValue = $formState->getValue(self::START_DATE_ELEMENT_ID);
+    $endDateValue = $formState->getValue(self::END_DATE_ELEMENT_ID);
+    $startDate = strtotime($startDateValue);
+    $endDate = strtotime($endDateValue);
+    $tOpts = ['context' => 'grants_metadata'];
+
+    // Skip this particular validation if we don't have either value.
+    if (!$endDate || !$startDate) {
+      return;
+    }
+
+    // Check that the end dates is after the start date.
+    if ($endDate < $startDate) {
+      $formState->setError($element, t('The end date must come after the start date.', [], $tOpts));
+    }
+  }
+
+}

--- a/public/modules/custom/grants_metadata/translations/override/fi.po
+++ b/public/modules/custom/grants_metadata/translations/override/fi.po
@@ -48,6 +48,9 @@ msgstr "Onko hakemus jatkuva"
 msgid "Disable copying for this application"
 msgstr "Poista hakemuksen kopiointi käytöstä"
 
+msgid "The end date must come after the start date."
+msgstr "Päättymispäivän on oltava alkamispäivän jälkeen."
+
 
 
 

--- a/public/modules/custom/grants_metadata/translations/override/sv.po
+++ b/public/modules/custom/grants_metadata/translations/override/sv.po
@@ -1,0 +1,16 @@
+# Swedish translation of City of Helsinki Grants Metadata module
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2021-05-31 11:00+0300\n"
+"PO-Revision-Date: 2022-10-12 11:00+0300\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+msgid "The end date must come after the start date."
+msgstr "Slutdatumet måste komma efter startdatumet."

--- a/public/themes/custom/hdbt_subtheme/dist/js/restrictedDatepicker.min.js
+++ b/public/themes/custom/hdbt_subtheme/dist/js/restrictedDatepicker.min.js
@@ -1,0 +1,1 @@
+!function(t,Drupal){"use strict";Drupal.behaviors.restrictedDatepicker={attach:function(a,e){t(document).ready((function(){const a=t("#edit-tapahtuma-ajankohta #edit-alkaa"),e=t("#edit-tapahtuma-ajankohta #edit-paattyy");a.length&&e.length&&a.datepicker("option","onSelect",(function(t){e.datepicker("option","minDate",t)}))}))}}}(jQuery,Drupal);

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.libraries.yml
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.libraries.yml
@@ -10,3 +10,11 @@ global-scripting:
     dist/js/common.min.js: {}
   dependencies:
     - core/drupal
+
+restricted-datepicker:
+  js:
+    dist/js/restrictedDatepicker.min.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - jquery_ui_datepicker/datepicker

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -506,6 +506,11 @@ function hdbt_subtheme_form_alter(&$form, FormStateInterface $form_state, $form_
   if ($form_id == 'openid_connect_login_form') {
     $form['openid_connect_client_tunnistamo_login']['#value'] = t('Log in');
   }
+
+  // Attach the restricted-datepicker library to the "liikunta_tapahtuma" form.
+  if (str_contains($form_id, 'liikunta_tapahtuma')) {
+    $form['#attached']['library'][] = 'hdbt_subtheme/restricted-datepicker';
+  }
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -508,7 +508,7 @@ function hdbt_subtheme_form_alter(&$form, FormStateInterface $form_state, $form_
   }
 
   // Attach the restricted-datepicker library to the "liikunta_tapahtuma" form.
-  if (str_contains($form_id, 'liikunta_tapahtuma')) {
+  if (str_contains($form_id, 'webform_submission_liikunta_tapahtuma')) {
     $form['#attached']['library'][] = 'hdbt_subtheme/restricted-datepicker';
   }
 }

--- a/public/themes/custom/hdbt_subtheme/src/js/restrictedDatepicker.js
+++ b/public/themes/custom/hdbt_subtheme/src/js/restrictedDatepicker.js
@@ -1,0 +1,28 @@
+(function ($, Drupal) {
+
+  'use strict';
+
+  /**
+   * The restrictedDatepicker behavior.
+   *
+   * This behavior dynamically changes the "minDate" value
+   * on an "end date" field based on the selected date value
+   * on a "start date" field.
+   */
+  Drupal.behaviors.restrictedDatepicker = {
+    attach: function(context, settings) {
+
+      $(document).ready(function() {
+        const startDate = $("#edit-tapahtuma-ajankohta #edit-alkaa");
+        const endDate = $("#edit-tapahtuma-ajankohta #edit-paattyy");
+
+        if (startDate.length && endDate.length) {
+          startDate.datepicker("option", "onSelect", function (selectedDate) {
+            endDate.datepicker("option", "minDate", selectedDate);
+          });
+        }
+
+      });
+    }
+  };
+})(jQuery, Drupal);


### PR DESCRIPTION
# [AU-1556](https://helsinkisolutionoffice.atlassian.net/browse/AU-1556)

## What was done
This pull request implements date validation to the `Liikunta tapahtuma-avustushakemus` Webforms `alkaa` and `paattyy`  date fields. The selected dates can no longer be set to dates in the past, and the "end date" field has to have a date that is the same or greater than the start date.

## How to install
Make sure your instance is up and running on the correct branch.
  * `git checkout feature/AU-1556-date-field-logic`
  * `make fresh`
  * `make drush-cr`

## How to test
- Import the form configurations with `drush gwi`.
- Open up the forms with `drush gwco`.
- Test the `Liikunta tapahtuma-avustushakemus` Webforms `alkaa` and `paattyy` date fields.

[AU-1556]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ