### PR TITLE
fix: AU-1564, AU-1565: Text fixes for taiteen perusopetus

### DIFF
--- a/public/modules/custom/grants_budget_components/translations/sv.po
+++ b/public/modules/custom/grants_budget_components/translations/sv.po
@@ -42,7 +42,7 @@ msgstr "Statligt driftsbidrag (€)"
 
 msgctxt "grants_budget_components"
 msgid "Other compensations (€)"
-msgstr "Övriga ersättningar (€)"
+msgstr "Övriga understöd (€)"
 
 msgctxt "grants_budget_components"
 msgid "Total income (€)"
@@ -122,11 +122,11 @@ msgstr "%name kan inte vara tomt när %pair har ett värde"
 
 msgctxt "grants_budget_components"
 msgid "Planned total costs (€)"
-msgstr "SV Planerade totalkostnader (€)"
+msgstr "Planerade totalkostnader (€)"
 
 msgctxt "grants_budget_components"
 msgid "Planned state operative subvention (€)"
-msgstr "SV Statens driftsstöd (€)"
+msgstr "Statens driftsstöd (€)"
 
 msgctxt "grants_budget_components"
 msgid "Financial funding and interests (€)"


### PR DESCRIPTION
# [AU-1564](https://helsinkisolutionoffice.atlassian.net/browse/AU-1564), [AU-1565](https://helsinkisolutionoffice.atlassian.net/browse/AU-1565)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Swedish translations were broken

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1564-kuva-taiteen-perusopetus-fixes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards
