### PR TITLE
fix: AU-1566: Fixed profile links for the application search

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -564,7 +564,7 @@ class GrantsProfileFormPrivatePerson extends GrantsProfileFormBase {
 
     $applicationSearchLink = Link::createFromRoute(
       $this->t('Application search'),
-      'view.application_search.page_1',
+      'view.application_search_search_api.search_page',
       [],
       [
         'attributes' => [

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -516,7 +516,7 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
 
     $applicationSearchLink = Link::createFromRoute(
       $this->t('Application search'),
-      'view.application_search.page_1',
+      'view.application_search_search_api.search_page',
       [],
       [
         'attributes' => [

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -539,7 +539,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
 
     $applicationSearchLink = Link::createFromRoute(
       $this->t('Application search'),
-      'view.application_search.page_1',
+      'view.application_search_search_api.search_page',
       [],
       [
         'attributes' => [


### PR DESCRIPTION
# [AU-1566](https://helsinkisolutionoffice.atlassian.net/browse/AU-1566)

## What was done
This pull request implements a minor fix for "Application search" links on user profiles. 

## How to install
Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-1566-profile-link-fix`
  * `make fresh`
  * `make drush-cr`

## How to test
- [ ] Login with a test user and edit the profile page with all the different roles. You should be presented with a working link to the Application search after saving the profile page.


[AU-1566]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ