### PR TITLE
fix: AU-XX: Fix translation of select options on preview print page

### DIFF
--- a/public/modules/custom/grants_webform_import/src/Routing/JsonapiLimitingRouteSubscriber.php
+++ b/public/modules/custom/grants_webform_import/src/Routing/JsonapiLimitingRouteSubscriber.php
@@ -19,10 +19,11 @@ class JsonapiLimitingRouteSubscriber extends RouteSubscriberBase {
   protected function alterRoutes(RouteCollection $collection) {
     // Limit access to all jsonapi routes with an extra permission.
     foreach ($collection as $route) {
-        $defaults = $route->getDefaults();
-        if (!empty($defaults['_is_jsonapi'])) {
-          $route->setRequirement('_role', 'json_api_user');
-        }
+      $defaults = $route->getDefaults();
+      if (!empty($defaults['_is_jsonapi'])) {
+        $route->setRequirement('_role', 'json_api_user');
       }
+    }
   }
+
 }

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -320,7 +320,7 @@ class GrantsWebformPrintController extends ControllerBase {
     }
     return $element['#description'];
   }
-  
+
   /**
    * Checks if a translated title field exists and returns it.
    *

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -320,8 +320,7 @@ class GrantsWebformPrintController extends ControllerBase {
     }
     return $element['#description'];
   }
-
-
+  
   /**
    * Checks if a translated title field exists and returns it.
    *

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -333,7 +333,7 @@ class GrantsWebformPrintController extends ControllerBase {
    *   Selected translated field.
    */
   public function getTranslatedOptions(array $element, array $translatedFields): array {
-    if (!empty($translatedFields[$element['#id']]) && is_array($translatedFields[$element['#id']]['#options'])) {
+    if (!empty($translatedFields[$element['#id']]) && isset($translatedFields[$element['#id']]['#options']) && is_array($translatedFields[$element['#id']]['#options'])) {
       return $translatedFields[$element['#id']]['#options'];
     }
     return $element['#options'];

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -264,7 +264,7 @@ class GrantsWebformPrintController extends ControllerBase {
       if ($element['#type'] === 'select' || $element['#type'] === 'checkboxes' || $element['#type'] === 'radios') {
         $element['#type'] = 'markup';
         $element['#markup'] = '<p><strong>' . $this->getTranslatedTitle($element, $translatedFields) . '</strong><br>';
-        foreach ($element['#options'] as $key => $value) {
+        foreach ($this->getTranslatedOptions($element, $translatedFields) as $key => $value) {
           $element['#markup'] .= '▢ ' . $value . '<br>';
         }
         $element['#markup'] .= '<br></p>';
@@ -319,6 +319,25 @@ class GrantsWebformPrintController extends ControllerBase {
       return $translatedFields[$element['#id']]['#help'];
     }
     return $element['#description'];
+  }
+
+
+  /**
+   * Checks if a translated title field exists and returns it.
+   *
+   * @param array $element
+   *   Element to check.
+   * @param array $translatedFields
+   *   Translated fields.
+   *
+   * @return array
+   *   Selected translated field.
+   */
+  public function getTranslatedOptions(array $element, array $translatedFields): array {
+    if (!empty($translatedFields[$element['#id']]) && is_array($translatedFields[$element['#id']]['#options'])) {
+      return $translatedFields[$element['#id']]['#options'];
+    }
+    return $element['#options'];
   }
 
 }


### PR DESCRIPTION
# AU-XX
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* GrantsWebformPrintController didn't translate select options, leading in Finnish text when printing select elements in urls like "/sv/tietoja-avustuksista/taide_ja_kulttuuriavustukset_tai/tulosta". Now they are translated.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-fix-preview-selects`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Navigate to /sv/tietoja-avustuksista/taide_ja_kulttuuriavustukset_tai/tulosta (you may need to update the taide perusopetus form settings to make it open if it's not open yet)
* [ ] See that "Huvudsaklig konstart" field options are translated.
* [ ] Check that code follows our standards
