### PR TITLE
fix: AU-1563: add missing issuer name to saved form page

### DIFF
--- a/public/modules/custom/grants_handler/templates/webform-submission-data.html.twig
+++ b/public/modules/custom/grants_handler/templates/webform-submission-data.html.twig
@@ -20,8 +20,6 @@
 ]
 %}
 
-Teasdlkgjasdkfljf
-
 <div{{ attributes.addClass(classes) }}>
     {{ elements }}
 </div>

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/OtherCompensationDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/OtherCompensationDefinition.php
@@ -31,6 +31,13 @@ class OtherCompensationDefinition extends ComplexDataDefinitionBase {
           'issuerName',
         ]);
       // ->addConstraint('NotBlank')
+      $info['issuer_name'] = DataDefinition::create('string')
+        // ->setRequired(TRUE)
+        ->setLabel('issuer_name')
+        ->setSetting('jsonPath', [
+          'issuer_name',
+        ]);
+      // ->addConstraint('NotBlank')
       $info['year'] = DataDefinition::create('string')
         // ->setRequired(TRUE)
         ->setLabel('Year issued')


### PR DESCRIPTION
# [AU-1563](https://helsinkisolutionoffice.atlassian.net/browse/AU-1563)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Did a thing that made issuer name visible on saved form page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1563-missing-issuer-name`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] See that the forms still go through to Avustus2 properly and come back properly from there (which they might not do, since this is a hack over a wild hack)
* [ ] Check that code follows our standards


[AU-1563]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ