### PR TITLE
fix: AU-1488: Changes to the postal code error message

### DIFF
--- a/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
@@ -71,7 +71,7 @@ class PlaceOfOperationComposite extends WebformCompositeBase {
       '#title' => t('Post Code', [], $tOpts),
       '#maxlength' => 8,
       '#pattern' => '^(FI-)?[0-9]{5}$',
-      '#pattern_error' => t('Enter a valid post code.', [], $tOpts),
+      '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
       '#suffix' => '</div>',
       '#wrapper_attributes' => [
         'class' => ['place-of-operation-group__location--post-code'],

--- a/public/modules/custom/grants_place_of_operation/translations/fi.po
+++ b/public/modules/custom/grants_place_of_operation/translations/fi.po
@@ -85,7 +85,7 @@ msgid "Only numbers."
 msgstr "Syötä pelkkiä numeroita."
 
 msgctxt "grants_place_of_operation"
-msgid "Enter a valid post code."
-msgstr "Syötä postinumero."
+msgid "Use the format FI-XXXXX or enter a five-digit postcode."
+msgstr "Käytä muotoa FI-XXXXX tai syötä postinumero viisinumeroisena."
 
 

--- a/public/modules/custom/grants_place_of_operation/translations/sv.po
+++ b/public/modules/custom/grants_place_of_operation/translations/sv.po
@@ -85,7 +85,7 @@ msgid "Only numbers."
 msgstr "Ange bara siffror."
 
 msgctxt "grants_place_of_operation"
-msgid "Enter a valid post code."
-msgstr "Ange ett giltigt postnummer."
+msgid "Use the format FI-XXXXX or enter a five-digit postcode."
+msgstr "Använd formen FI-XXXXX eller ange ett femsiffrigt postnummer."
 
 

--- a/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
@@ -74,7 +74,7 @@ class PremisesComposite extends WebformCompositeBase {
       '#size' => 10,
       '#maxlength' => 8,
       '#pattern' => '^(FI-)?[0-9]{5}$',
-      '#pattern_error' => t('Enter a valid post code.', [], $tOpts),
+      '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
       '#required' => TRUE,
     ];
 

--- a/public/modules/custom/grants_premises/translations/fi.po
+++ b/public/modules/custom/grants_premises/translations/fi.po
@@ -141,8 +141,8 @@ msgid "Unknown"
 msgstr "Ei tietoa"
 
 msgctxt "grants_premises"
-msgid "Enter a valid post code."
-msgstr "Syötä postinumero."
+msgid "Use the format FI-XXXXX or enter a five-digit postcode.."
+msgstr "Käytä muotoa FI-XXXXX tai syötä postinumero viisinumeroisena."
 
 msgctxt "rent_income_composite"
 msgid "Sports facility"

--- a/public/modules/custom/grants_premises/translations/sv.po
+++ b/public/modules/custom/grants_premises/translations/sv.po
@@ -138,8 +138,8 @@ msgid "Unknown"
 msgstr "Okänd"
 
 msgctxt "grants_premises"
-msgid "Enter a valid post code."
-msgstr "Ange ett giltigt postnummer."
+msgid "Use the format FI-XXXXX or enter a five-digit postcode."
+msgstr "Använd formen FI-XXXXX eller ange ett femsiffrigt postnummer."
 
 msgctxt "rent_income_composite"
 msgid "Sports facility"


### PR DESCRIPTION
# [AU-1488](https://helsinkisolutionoffice.atlassian.net/browse/AU-1488)

## What was done

This pull request changes the postal code error message displayed in the  "**Grants premises**" component.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-1488-postal-code-error-message`
  * `make fresh`
  * `make drush-cr`

## How to test
- [ ] Review the changed postal code error messages.

[AU-1488]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ