### PR TITLE
AU-1568: Remove official requirement from registered profile form

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -1179,12 +1179,6 @@ rtf, txt, xls, xlsx, zip.'),
   public function validateOfficials(array $values, FormStateInterface $formState): void {
     if (array_key_exists('officialWrapper', $values)) {
 
-      if (empty($values["officialWrapper"])) {
-        $elementName = 'officialWrapper]';
-        $formState->setErrorByName($elementName, $this->t('You must add one official'));
-        return;
-      }
-
       foreach ($values["officialWrapper"] as $key => $official) {
 
         if ((empty($official["role"]) || $official["role"] == 0)) {


### PR DESCRIPTION
# [AU-1568](https://helsinkisolutionoffice.atlassian.net/browse/AU-1568)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1568-registered-profile-form-change`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check registered community profile form can be saved without an official data.



[AU-1568]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ