### PR TITLE
fix: AU-1578: add translations to subvention types

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -185,7 +185,7 @@ third_party_options:
     8: 'Interests and installments'
     9: Other
     11: 'Transport subsidy'
-    12: Leiriavustus
+    12: 'Camp grant'
     13: 'Exemption from payments compensation'
     14: 'Extra grant'
     15: 'Navigation map grant'
@@ -194,18 +194,18 @@ third_party_options:
     31: 'Start grant'
     32: 'Subsidy for use of space'
     34: 'Basic art education'
-    35: Varhaiskasvatus
-    36: 'Vapaa sivistystyö'
+    35: 'Early childhood education'
+    36: 'Liberal adult education'
     37: 'Event grant'
     38: 'Small grant'
     39: 'Immigrant integration grant'
     40: 'Culture and leisure: application for subsidy'
-    41: Laitosavustus
+    41: 'Institution and foundation grants'
     42: 'Grant for other associations promoting physical activity'
     43: 'Targeted sports grant'
-    44: Kehittämisavustus
-    45: 'Helsingin mallin kehittämisavustus'
-    46: 'Taiteen perusopetuksen kehittämisavustus'
+    44: 'Capacity building grant'
+    45: 'Capacity building grant / The Helsinki Model'
+    46: 'Basic art education'
 langcode: en
 config_import_ignore:
   - 53

--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -205,7 +205,7 @@ third_party_options:
     43: 'Targeted sports grant'
     44: 'Capacity building grant'
     45: 'Capacity building grant / The Helsinki Model'
-    46: 'Basic art education'
+    46: 'Capacity building grant for basic art education'
 langcode: en
 config_import_ignore:
   - 53


### PR DESCRIPTION
# [AU-1578](https://helsinkisolutionoffice.atlassian.net/browse/AU-1578)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* add translations to subvention types

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1578-leiriavustus`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that subventions are translated in subventions field in application

[AU-1578]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ