### PR TITLE
fix: AU-1577: removed extra full stop from sentence

### DIFF
--- a/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -57,7 +57,7 @@ elements: |
   subventions:
     '#title': Understödsform
   markup:
-    '#markup': '<p>V&auml;lj den underst&ouml;dsform som du ans&ouml;ker. Du kan ocks&aring; v&auml;lja b&aring;da om du ans&ouml;ker om b&aring;da. Ange ocks&aring; h&auml;r hur mycket underst&ouml;d ni ans&ouml;ker.. Ange beloppet i heltal och i euro. Ans&ouml;kningsbeloppet anges separat f&ouml;r b&aring;da underst&ouml;dsformerna.</p>'
+    '#markup': '<p>V&auml;lj den underst&ouml;dsform som du ans&ouml;ker. Du kan ocks&aring; v&auml;lja b&aring;da om du ans&ouml;ker om b&aring;da. Ange ocks&aring; h&auml;r hur mycket underst&ouml;d ni ans&ouml;ker. Ange beloppet i heltal och i euro. Ans&ouml;kningsbeloppet anges separat f&ouml;r b&aring;da underst&ouml;dsformerna.</p>'
   edellisen_avustuksen_kayttoselvitys:
     '#title': 'Redovisning om det tidigare understödet'
   yhdistyksen_kuluvan_vuoden_toiminta_avustus:


### PR DESCRIPTION
# [AU-1577](https://helsinkisolutionoffice.atlassian.net/browse/AU-1577)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Dot was removed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1577-extra-dot`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See that the change on Nuorisotoimi: toiminta ja palkkausavustus swedish version is implemented
* [ ] Check that code follows our standards


[AU-1577]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ