### PR TITLE
fix: AU-1579: Handle issuer name case in submission load phase

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -442,23 +442,6 @@ function grants_handler_webform_element_alter(array &$element, FormStateInterfac
       }
     }
 
-    // Hacky fix for issues with camelCase keys with Custom component keys.
-    // Set issuerName value to issuer_name field and unset camelCase.
-    if (isset($element['#webform_key']) && ($element['#webform_key'] == 'myonnetty_avustus' || $element['#webform_key'] == 'haettu_avustus_tieto')) {
-      $newValues = [];
-      if (isset($element["#default_value"])) {
-        foreach ($element["#default_value"] as $default) {
-          $new = $default;
-          if (isset($default['issuerName'])) {
-            $new['issuer_name'] = $default['issuerName'];
-            unset($new['issuerName']);
-          }
-          $newValues[] = $new;
-        }
-      }
-      $element["#default_value"] = $newValues;
-    }
-
     // For some reason this selection cannot be done in address composite class.
     // so we'll need to hack this here.
     // @todo Can the composite default value be added here?

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -162,6 +162,22 @@ class AtvSchema {
       }
     }
 
+    // Fix for issuer_name vs. issuerName case.
+    if (isset($typedDataValues['myonnetty_avustus'])) {
+      foreach ($typedDataValues['myonnetty_avustus'] as $key => $avustus) {
+        if (isset($avustus['issuerName'])) {
+          $typedDataValues['myonnetty_avustus'][$key]['issuer_name'] = $avustus['issuerName'];
+        }
+      }
+    }
+    if (isset($typedDataValues['haettu_avustus_tieto'])) {
+      foreach ($typedDataValues['haettu_avustus_tieto'] as $key => $avustus) {
+        if (isset($avustus['issuerName'])) {
+          $typedDataValues['haettu_avustus_tieto'][$key]['issuer_name'] = $avustus['issuerName'];
+        }
+      }
+    }
+
     $community_address = [];
     if (isset($typedDataValues['community_street'])) {
       $community_address['community_street'] = $typedDataValues['community_street'];


### PR DESCRIPTION
# [AU-1579](https://helsinkisolutionoffice.atlassian.net/browse/AU-1579)
<!-- What problem does this solve? -->

Issuer name tieto ei latautunut näkyviin hakemusta katsoessa.

## What was done
<!-- Describe what was done -->

Tee kentän nimen muutos kun webform submission ladataan eikä form alter hookissa.

WebformDataExtracter käyttö on teknisesti mahdollista mutta koska ongelmakenttä on komposiitin sisällä ja ATVSchema hyödyntää kentän nimeä dataa mankeloidessa se vaatisi tätä toteutusta monimutkaisemman ratkaisun. 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1579-issuer-name-case`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Testaa lomakkeella jossa on 

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1579]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ