### PR TITLE
feat: AU-1581: Add target group filter for content view

### DIFF
--- a/conf/cmi/language/en/views.view.content.yml
+++ b/conf/cmi/language/en/views.view.content.yml
@@ -1,25 +1,13 @@
-label: Content
 description: 'Find and manage content.'
 display:
   default:
     display_title: Default
     display_options:
-      title: Content
       fields:
-        title:
-          label: Title
         type:
           label: 'Content type'
-          separator: ', '
-        name:
-          label: Author
         status:
           label: Status
-          settings:
-            format_custom_false: Unpublished
-            format_custom_true: Published
-        changed:
-          label: Updated
         operations:
           label: Operations
       pager:
@@ -34,15 +22,10 @@ display:
           submit_button: Filter
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
-          sort_asc_label: Asc
-          sort_desc_label: Desc
       empty:
         area_text_custom:
           content: 'No content available.'
       filters:
-        title:
-          expose:
-            label: Title
         type:
           expose:
             label: 'Content type'
@@ -51,19 +34,11 @@ display:
             label: Status
           group_info:
             label: 'Published status'
-            group_items:
-              1:
-                title: Published
-              2:
-                title: Unpublished
-        langcode:
+        field_target_group_target_id_entityreference_filter:
           expose:
-            label: Language
+            label: 'Target group'
   page_1:
     display_title: Page
     display_options:
-      menu:
-        title: Content
       tab_options:
-        title: Content
         description: 'Find and manage content'

--- a/conf/cmi/language/sv/views.view.content.yml
+++ b/conf/cmi/language/sv/views.view.content.yml
@@ -8,7 +8,6 @@ display:
           label: Titel
         type:
           label: Innehållstyp
-          separator: ', '
         name:
           label: Författare
         status:
@@ -58,6 +57,9 @@ display:
         langcode:
           expose:
             label: Språk
+        field_target_group_target_id_entityreference_filter:
+          expose:
+            label: Målgrupp
     display_title: Förvald
   page_1:
     display_title: Sida

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -2,8 +2,12 @@ uuid: 3a26b1f5-fc1c-4d47-8faf-dd51e61c3fa4
 langcode: fi
 status: true
 dependencies:
+  config:
+    - views.view.kohderyhmat
   module:
+    - entityreference_filter
     - node
+    - taxonomy
     - user
 _core:
   default_config_hash: 9-2iisPYYsVrKKdCr6KjJUxQpLrdV8WzmG82vdEbnCk
@@ -532,6 +536,60 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        field_target_group_target_id_entityreference_filter:
+          id: field_target_group_target_id_entityreference_filter
+          table: node__field_target_group
+          field: field_target_group_target_id_entityreference_filter
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: entityreference_filter_view_result
+          operator: or
+          value: null
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_target_group_target_id_entityreference_filter_op
+            label: Kohderyhmä
+            description: ''
+            use_operator: false
+            operator: field_target_group_target_id_entityreference_filter_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_target_group_target_id_entityreference_filter
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              json_api_user: '0'
+              read_only: '0'
+              helsinkiprofiili: '0'
+              content_producer_industry: '0'
+              content_producer: '0'
+              grants_producer: '0'
+              ad_user: '0'
+              grants_admin: '0'
+              admin: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          reference_display: 'kohderyhmat:entity_reference_1'
+          reference_arguments: ''
+          hide_empty_filter: true
       filter_groups:
         operator: AND
         groups:
@@ -623,6 +681,15 @@ display:
           admin_label: author
           plugin_id: standard
           required: true
+        field_target_group:
+          id: field_target_group
+          table: node__field_target_group
+          field: field_target_group
+          relationship: none
+          group_type: group
+          admin_label: 'field_target_group: Taxonomy term'
+          plugin_id: standard
+          required: false
       show_admin_links: false
       display_extenders: {  }
     cache_metadata:
@@ -635,7 +702,8 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - taxonomy_term_list
   page_1:
     id: page_1
     display_title: Sivu
@@ -668,4 +736,5 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - taxonomy_term_list

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -7,7 +7,6 @@ dependencies:
   module:
     - entityreference_filter
     - node
-    - taxonomy
     - user
 _core:
   default_config_hash: 9-2iisPYYsVrKKdCr6KjJUxQpLrdV8WzmG82vdEbnCk
@@ -681,15 +680,6 @@ display:
           admin_label: author
           plugin_id: standard
           required: true
-        field_target_group:
-          id: field_target_group
-          table: node__field_target_group
-          field: field_target_group
-          relationship: none
-          group_type: group
-          admin_label: 'field_target_group: Taxonomy term'
-          plugin_id: standard
-          required: false
       show_admin_links: false
       display_extenders: {  }
     cache_metadata:

--- a/conf/cmi/views.view.kohderyhmat.yml
+++ b/conf/cmi/views.view.kohderyhmat.yml
@@ -1,0 +1,241 @@
+uuid: f989c9a2-4ea2-43f8-8b74-af5c2c4bdddd
+langcode: fi
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.target_group
+  module:
+    - taxonomy
+    - user
+id: kohderyhmat
+label: Kohderyhmät
+module: views
+description: ''
+tag: ''
+base_table: taxonomy_term_field_data
+base_field: tid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      fields:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          convert_spaces: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Merkintöjä sivua kohti'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- Kaikki -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Käytä
+          reset_button: false
+          reset_button_label: Palauta
+          exposed_sorts_label: Lajittele
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: taxonomy_term_field_data
+          field: status
+          entity_type: taxonomy_term
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+          operator: in
+          value:
+            target_group: target_group
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  entity_reference_1:
+    id: entity_reference_1
+    display_title: Entiteettiviittaus
+    display_plugin: entity_reference
+    position: 1
+    display_options:
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+      rendering_language: '***LANGUAGE_language_content***'
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }


### PR DESCRIPTION
# [AU-1581](https://helsinkisolutionoffice.atlassian.net/browse/AU-1581)
<!-- What problem does this solve? -->

Sisällöntuottajien on helpompi löytää oikea sisältö

## What was done
<!-- Describe what was done -->

Lisää entiteettiviittausnäkymä kohdyryhmille ja käytä sitä kohderyhmäsuodattimen lisäämiseen SIsältö-näkymään.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout AU-1581-target-group-filter`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Mene sisältönäkymään ja varmista että suodatin toimii järkevästi.



[AU-1581]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ