### PR TITLE
fix: AU-1585: Application listin fix

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -691,7 +691,7 @@ class ApplicationHandler {
    * @return \Drupal\webform\Entity\Webform
    *   Webform object.
    */
-  public static function getWebformFromApplicationNumber(string $applicationNumber): Webform {
+  public static function getWebformFromApplicationNumber(string $applicationNumber): ?Webform {
     // Explode number.
     $exploded = explode('-', $applicationNumber);
     // Get serial.
@@ -727,6 +727,9 @@ class ApplicationHandler {
       return FALSE;
     });
 
+    if (!$webform) {
+      return NULL;
+    }
     return reset($webform);
   }
 
@@ -762,6 +765,10 @@ class ApplicationHandler {
 
     $submissionSerial = self::getSerialFromApplicationNumber($applicationNumber);
     $webform = self::getWebformFromApplicationNumber($applicationNumber);
+
+    if (!$webform) {
+      return NULL;
+    }
 
     $result = \Drupal::entityTypeManager()
       ->getStorage('webform_submission')
@@ -1745,6 +1752,11 @@ class ApplicationHandler {
 
       if (array_key_exists($document->getType(), ApplicationHandler::getApplicationTypes())) {
         $submissionObject = self::submissionObjectFromApplicationNumber($document->getTransactionId(), $document);
+
+        if (!$submissionObject) {
+          continue;
+        }
+
         $submissionData = $submissionObject->getData();
         $ts = strtotime($submissionData['form_timestamp_created'] ?? '');
         if ($themeHook !== '') {

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -1148,7 +1148,9 @@ class AtvSchema {
 
         // If value is an array, then we need to return desired element value.
         if ($value['ID'] == $elementName) {
-          $retval = htmlspecialchars_decode($value['value'] ?? '');
+          // Make sure that the element value is a string.
+          $parseValue = is_string($value['value']) ? $value['value'] : '';
+          $retval = htmlspecialchars_decode($parseValue);
 
           if ($type == 'boolean') {
             if ($retval == 'true') {


### PR DESCRIPTION
# [AU-1585](https://helsinkisolutionoffice.atlassian.net/browse/AU-1585)
## What was done

This pull request implements a fix for the "**Oma asiointi**" application listing page. The pull request fixes an issue where corrupted ATV data would break the whole listing and not display any applications at all.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout AU-1585-application-listing-fix`
  * `make fresh`
  * `make drush-cr`

## How to test
To test this pull request you need to reach a state of "corrupted ATV data". If you data is already corrupted, then you can ignore these steps.
1. Checkout the branch `feature/AU-1465-nuoriso-toiminta-id63`.
2. Set the `APP_ENV` value to `localo` in the` local.settings.php` file.
3. Run `make fresh`.
4. Fill in and submit the form "**Nuorisopalvelu: toiminta- ja palkkausavustushakemus**" with the `210281-9988` & `Maanrakennus Ari Eerola T:m` user combination.
5. Your data should now be corrupt.

Now return to the branch `AU-1585-application-listing-fix` and run `make fresh`. View the application listing and check that it displays applications. Also, submit a new application and check that the listing gets updated.


[AU-1585]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ