### PR TITLE
fix: AU-1586: make applicant_type appear programmatically

### DIFF
--- a/public/modules/custom/grants_webform_summation_field/grants_webform_summation_field.module
+++ b/public/modules/custom/grants_webform_summation_field/grants_webform_summation_field.module
@@ -54,4 +54,9 @@ function grants_webform_summation_field_webform_submission_view_alter(array &$bu
   }
 
   $entity->setElementData('avustukset_summa', $subventionsTotalAmount);
+
+  /** @var \Drupal\grants_profile\GrantsProfileService $grantsProfileService */
+  $grantsProfileService = Drupal::service('grants_profile.service');
+  $entity->setElementData('applicant_type', $grantsProfileService->getApplicantType());
+
 }


### PR DESCRIPTION
# [AU-1586](https://helsinkisolutionoffice.atlassian.net/browse/AU-1586)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added applicant_type to root of the webform so it can always be found where it should

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works: Go to form, select address, save as draft, see that osoite is there
* [ ] Check that code follows our standards


[AU-1586]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ