### PR TITLE
fix: AU-1589: Remove datepicker from liikunnan tapahtuma-avustus

### DIFF
--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -456,13 +456,11 @@ elements: |-
         '#title': Alkaa
         '#required': true
         '#date_date_min': today
-        '#datepicker': true
       paattyy:
         '#type': date
         '#title': Päättyy
         '#required': true
         '#date_date_min': today
-        '#datepicker': true
   tapahtuman_talousarvio:
     '#type': webform_wizard_page
     '#title': '3. Tapahtuman talousarvio'


### PR DESCRIPTION
# [AU-1589](https://helsinkisolutionoffice.atlassian.net/browse/AU-1589)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed javascript datepicker from liikunnan tapahtuma-avustus

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1589-calender-liikunta`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Liikunnan tapahtuma-avustus, page 2, see that the datepicker is browser default, not a jquery monstrosity
* [ ] Check that code follows our standards


[AU-1589]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ