### PR TITLE
AU-1561: Pattern to compensation component

### DIFF
--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -64,6 +64,7 @@ class CompensationsComposite extends WebformCompositeBase {
       '#title' => t('Subvention amount'),
       '#input_mask' => "'alias': 'currency', 'prefix': '', 'suffix': '€','groupSeparator': ' ','radixPoint':','",
       '#attributes' => ['class' => ['input--borderless']],
+      '#pattern' => '[0-9, ]+€',
       '#element_validate' => [
         '\Drupal\grants_handler\Element\CompensationsComposite::validateAmount',
         '\Drupal\grants_handler\Element\CompensationsComposite::validateRequiredFields',


### PR DESCRIPTION
# [AU-1561](https://helsinkisolutionoffice.atlassian.net/browse/AU-1561)
<!-- What problem does this solve? -->

## What was done

Add a pattern to compensation element, so user can't add negative number etc.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1561-subvention-character-validation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that you can't continue the webform if pattern is not met.



[AU-1561]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ