### PR TITLE
fix: AU-1609: Remove duplicated/wrong VOS mappings from KUVA Toiminta

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -676,31 +676,6 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
           'toiminta_tulevat_muutokset',
         ]);
 
-      $info['organisaatio_kuuluu_valtionosuusjarjestelmaan'] = DataDefinition::create('boolean')
-        ->setLabel('Organisaatio kuuluu valtionosuusjärjestelmään (VOS).')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'budgetInfo',
-          'budgetInfoArray',
-          'isPartOfVOS',
-        ])
-        ->setSetting('typeOverride', [
-          'dataType' => 'string',
-          'jsonType' => 'bool',
-        ]);
-      $info['organisaatio_kuului_valtionosuusjarjestelmaan'] = DataDefinition::create('boolean')
-        ->setLabel('Organisaatio kuului valtionosuusjärjestelmään (VOS).')
-        ->setSetting('jsonPath', [
-          'compensation',
-          'budgetInfo',
-          'budgetInfoArray',
-          'wasPartOfVOS',
-        ])
-        ->setSetting('typeOverride', [
-          'dataType' => 'string',
-          'jsonType' => 'bool',
-        ]);
-
       $info['budgetInfo'] = GrantsBudgetInfoDefinition::create('grants_budget_info')
         ->setSetting('propertyStructureCallback', [
           'service' => 'grants_budget_components.service',


### PR DESCRIPTION
# [AU-1609](https://helsinkisolutionoffice.atlassian.net/browse/AU-1609)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove duplicate/wrong VOS mappings.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1609-fix-duplicate-vos`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Start a new KUVA Toiminta application, check VOS radio buttons in Talous page and then save as draft. Check that the ATV document has both only once in the document.


[AU-1609]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ