### PR TITLE
fix: AU-1606: hide applicant type from print form

### DIFF
--- a/public/modules/custom/grants_handler/templates/grants-handler-print-atv-document.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-handler-print-atv-document.html.twig
@@ -64,14 +64,16 @@
               <div class="details-section-divider">
                 <h2>{{ page.label }}</h2>
                 <div class="grants-profile--extrainfo">
-                  {% for key, section in page.sections %}
+                  {% for key2, section in page.sections %}
                     <section class="js-form-item form-item js-form-wrapper form-wrapper webform-section">
                       <div class="webform-section-grid-wrapper">
                         <h3 class="webform-section-title">{{ section.label }}</h3>
                         <dl class="webform-section-contents">
-                          {% for key, field in section.fields %}
-                            <dt class="webform-field-title">{{ field.label }}</dt>
-                            <dd class="webform-field-wrapper">{{ field.value }}</dd>
+                          {% for key3, field in section.fields %}
+                            {% if field.ID != 'applicantType' %}
+                              <dt class="webform-field-title">{{ field.label }}</dt>
+                              <dd class="webform-field-wrapper">{{ field.value }}</dd>
+                            {% endif %}
                           {% endfor %}
                         </dl>
                       </div>


### PR DESCRIPTION
# [AU-1606](https://helsinkisolutionoffice.atlassian.net/browse/AU-1606)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Hakijan tyyppi was visible on print page, not anymore.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1606-nuorproj-hakemuksentyyppi`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill out a form
* [ ] Save as draft or send
* [ ] on the /katso page, click on the print button
* [ ] see that "hakijan tyyppi" is not visible on the printout
* [ ] Check that code follows our standards


[AU-1606]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ