### PR TITLE
fix: AU-871: Bank account deletion logging

### DIFF
--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -152,8 +152,8 @@ class AtvSchema {
         $newValues['attachmentName'] = $attachment['fileName'];
       }
 
-      // @todo Do away with hard coded field name for muu liite.
-      if ($fieldName === 'muu_liite') {
+      // Attachments under "muu_liite" and "bank_account_confirmation" all go under "$other_attachments".
+      if ($fieldName === 'muu_liite' || $fieldName === 'bank_account_confirmation') {
         $other_attachments[$key] = $newValues;
         unset($typedDataValues["attachments"][$key]);
       }


### PR DESCRIPTION
# [AU-871](https://helsinkisolutionoffice.atlassian.net/browse/AU-871)
## What was done

This pull request implements the following fixes regarding application bank account confirmation files:

1. When a bank account is deleted or changed in a grants application form, the confirmation file attached to said bank account is deleted simultaneously. This deletion event is now correctly logged in ATV as in the picture below.
<img width="1099" alt="Screenshot 2023-09-19 at 15 55 51" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/1f828634-88ba-4e6d-96d5-9220db5019a2">

2.  The bank account confirmation file should now be correctly displayed under the `Muu liite` section in each application (previously the file was not displayed there at all).

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-871-bank-account-file-deletion-fix`
  * `make fresh`
  * `make drush-cr`

## How to test
1. Login with a registered community user. Make sure that said user has two bank accounts attached to it.
2. Start filling in an application and change the bank account information a few times while saving it as a draft. Make sure that the change is correctly logged in ATV (as in the picture above).
3. Make sure that the bank account confirmation file is correctly displayed under the `Muu liite` section in each application.

[AU-871]: https://helsinkisolutionoffice.atlassian.net/browse/AU-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ