### PR TITLE
AU-1620: Add DbLog override class and service

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -63,6 +63,7 @@ module:
   grants_club_section: 0
   grants_front_banner: 0
   grants_industries: 0
+  grants_logger: 0
   grants_mandate: 0
   grants_metadata: 0
   grants_oma_asiointi: 0

--- a/public/modules/custom/grants_logger/grants_logger.info.yml
+++ b/public/modules/custom/grants_logger/grants_logger.info.yml
@@ -1,0 +1,8 @@
+name: 'Grants Logger'
+type: module
+description: 'Grants logger override.'
+package: 'helfi'
+core_version_requirement: ^8.8 || ^9
+dependencies:
+  - 'dblog'
+  - helfi_helsinki_profiili

--- a/public/modules/custom/grants_logger/grants_logger.services.yml
+++ b/public/modules/custom/grants_logger/grants_logger.services.yml
@@ -1,0 +1,6 @@
+services:
+  logger.dblog:
+    class: Drupal\grants_logger\Logger\GrantsLogger
+    arguments: ['@database', '@logger.log_message_parser', '@helfi_helsinki_profiili.userdata']
+    tags:
+      - { name: logger }

--- a/public/modules/custom/grants_logger/src/Logger/GrantsLogger.php
+++ b/public/modules/custom/grants_logger/src/Logger/GrantsLogger.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\grants_logger\Logger;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Logger\LogMessageParserInterface;
+use Drupal\dblog\Logger\DbLog;
+use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
+
+/**
+ * Override DbLog to include custom data.
+ */
+class GrantsLogger extends DbLog {
+
+
+  /**
+   * The helfi_helsinki_profiili.userdata service.
+   *
+   * @var \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData
+   */
+  protected HelsinkiProfiiliUserData $helfiHelsinkiProfiiliUserdata;
+
+  /**
+   * The database connection object.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * The message's placeholders parser.
+   *
+   * @var \Drupal\Core\Logger\LogMessageParserInterface
+   */
+  protected $parser;
+
+  /**
+   * Constructs a GrantsLogger object.
+   *
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection object.
+   * @param \Drupal\Core\Logger\LogMessageParserInterface $parser
+   *   The parser to use when extracting message variables.
+   * @param \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData $helfiHelsinkiProfiiliUserdata
+   *   The helfi_helsinki_profiili.userdata service.
+   */
+  public function __construct(Connection $connection, LogMessageParserInterface $parser, HelsinkiProfiiliUserData $helfiHelsinkiProfiiliUserdata) {
+    $this->connection = $connection;
+    $this->parser = $parser;
+    $this->helfiHelsinkiProfiiliUserdata = $helfiHelsinkiProfiiliUserdata;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($level, $message, array $context = []) {
+
+    $userData = $this->helfiHelsinkiProfiiliUserdata->getUserProfileData();
+    if ($userData) {
+      $message = $message . (' (HP UID: @helfi_hp_uid)');
+      $context['@helfi_hp_uid'] = $userData['myProfile']['id'];
+    }
+
+    parent::log($level, $message, $context);
+  }
+
+}

--- a/public/modules/custom/grants_logger/src/Logger/GrantsLogger.php
+++ b/public/modules/custom/grants_logger/src/Logger/GrantsLogger.php
@@ -55,10 +55,12 @@ class GrantsLogger extends DbLog {
    */
   public function log($level, $message, array $context = []) {
 
-    $userData = $this->helfiHelsinkiProfiiliUserdata->getUserData();
-    if ($userData) {
-      $message = $message . (' (HP UUID: @helfi_hp_uid)');
-      $context['@helfi_hp_uid'] = $userData["sub"];
+    if ($this->helfiHelsinkiProfiiliUserdata->isAuthenticatedExternally()) {
+      $userData = $this->helfiHelsinkiProfiiliUserdata->getUserData();
+      if ($userData) {
+        $message = $message . (' (HP UUID: @helfi_hp_uid)');
+        $context['@helfi_hp_uid'] = $userData["sub"];
+      }
     }
 
     parent::log($level, $message, $context);

--- a/public/modules/custom/grants_logger/src/Logger/GrantsLogger.php
+++ b/public/modules/custom/grants_logger/src/Logger/GrantsLogger.php
@@ -55,10 +55,10 @@ class GrantsLogger extends DbLog {
    */
   public function log($level, $message, array $context = []) {
 
-    $userData = $this->helfiHelsinkiProfiiliUserdata->getUserProfileData();
+    $userData = $this->helfiHelsinkiProfiiliUserdata->getUserData();
     if ($userData) {
-      $message = $message . (' (HP UID: @helfi_hp_uid)');
-      $context['@helfi_hp_uid'] = $userData['myProfile']['id'];
+      $message = $message . (' (HP UUID: @helfi_hp_uid)');
+      $context['@helfi_hp_uid'] = $userData["sub"];
     }
 
     parent::log($level, $message, $context);


### PR DESCRIPTION
# [AU-1620](https://helsinkisolutionoffice.atlassian.net/browse/AU-1620)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add overriden dblog class / service to include helsinki profiili ID to log messages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1620-hpuid-to-logs`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as end user and browse the site. Check recent log messages and make sure that log messages that are generated by user with a Helsinki Profiili will include it's ID to the end of the log message. (Admin users will log messages without as they don't have HP.)



[AU-1620]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ