### PR TITLE
fix: AU-1590: Update application language during save phase

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1385,11 +1385,12 @@ class ApplicationHandler {
         $submittedFormData);
 
     $atvDocument = $this->getAtvDocument($applicationNumber, TRUE);
+    // Set language for the application.
+    $language = $this->languageManager->getCurrentLanguage()->getId();
+    $atvDocument->addMetadata('language', $language);
     try {
-      $atvDocument->addMetadata(
-        'saveid',
-        $this->logSubmissionSaveid(NULL, $applicationNumber)
-      );
+      $saveId = $this->logSubmissionSaveid(NULL, $applicationNumber);
+      $atvDocument->addMetadata('saveid', $saveId);
     }
     catch (\Exception $e) {
     }


### PR DESCRIPTION
# [AU-1590](https://helsinkisolutionoffice.atlassian.net/browse/AU-1590)
<!-- What problem does this solve? -->

Sekakieliset hakemukset tulostusnäkymässä

## What was done
<!-- Describe what was done -->

Tallenna hakemuksen kieli lomaketta tallennettaessa.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1590-application-language`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Aloita lomakkeen täyttäminen yhdellä kielellä ja viimeistele se toisella. Tallennuksen jälkeen koko lomake on tulostusnäkymässä viimeistelykielellä.


[AU-1590]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ