### PR TITLE
fix: AU-1633: Remove markup from below subvention type

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
@@ -54,8 +54,6 @@ elements: |
     '#title': 'Types of grant'
   subventions:
     '#title': Grants
-  markup_01:
-    '#markup': 'Only apply for one grant type at a time with each application.'
   osallistujat:
     '#title': Participants
   markup_02:

--- a/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
@@ -65,8 +65,6 @@ elements: |
     '#title': Understödsformer
   subventions:
     '#title': Understöd
-  markup_01:
-    '#markup': 'S&ouml;k alltid endast en typ av bidrag &aring;t g&aring;ngen med en ans&ouml;kan.'
   osallistujat:
     '#title': Deltagare
   markup_02:

--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -210,9 +210,6 @@ elements: |-
         '#subvention_type_id__access': false
         '#subvention_type__title': Avustuslaji
         '#subvention_amount__title': 'Avustuksen summa'
-      markup_01:
-        '#type': webform_markup
-        '#markup': 'Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.'
     tapahtuman_tiedot:
       '#type': webform_section
       '#title': 'Tapahtuman tiedot'


### PR DESCRIPTION
# [AU-1633](https://helsinkisolutionoffice.atlassian.net/browse/AU-1633)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove Markup from Liikunnan tapahtuma-avustus

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1633-extra-text-on-liikunnan`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to Liikunnan tapahtuma-avustus
* [ ] see that the offending text is no-longer there
* [ ] check swedish
* [ ] check english
* [ ] Check that code follows our standards
