### PR TITLE
fix: AU-1625, AU-1626: edit unregistered community profile texts

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -606,7 +606,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
         '#type' => 'fieldset',
         '#description_display' => 'before',
         '#description' => $this->t('The address must be your official address. One address is mandatory information in your personal information and on the application.', [], $tOpts),
-        '#title' => $this->t('Community address', [], $tOpts),
+        '#title' => $this->t('Community or group address', [], $tOpts),
       ];
       $form['addressWrapper'][$delta]['address']['street'] = [
         '#type' => 'textfield',
@@ -645,7 +645,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
       $form['addressWrapper'][] = [
         'address' => [
           '#type' => 'fieldset',
-          '#title' => $this->t('Community address', [], $tOpts),
+          '#title' => $this->t('Community or group address', [], $tOpts),
           '#help_display' => 'before',
           '#description' => $this->t('The address must be your official address. One address is mandatory information in your personal information and on the application.', [], $tOpts),
           'street' => [
@@ -729,7 +729,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
 
       $form['officialWrapper'][$delta]['official'] = [
         '#type' => 'fieldset',
-        '#title' => $this->t('Community official', [], $tOpts),
+        '#title' => $this->t('Community or group official', [], $tOpts),
         'name' => [
           '#type' => 'textfield',
           '#required' => TRUE,
@@ -903,7 +903,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
       $confFilename = $bankAccount['confirmationFileName'] ?? $bankAccount['confirmationFile'];
       $form['bankAccountWrapper'][$delta]['bank'] = [
         '#type' => 'fieldset',
-        '#title' => $this->t('Community bank account', [], $tOpts),
+        '#title' => $this->t('Community or group bank account', [], $tOpts),
         '#description_display' => 'before',
         '#description' => $this->t('You can only fill in your own bank account information.', [], $tOpts),
         'bankAccount' => [

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -134,13 +134,14 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
     ];
     $form['companyNameWrapper'] = [
       '#type' => 'webform_section',
-      '#title' => $this->t('Community name', [], $tOpts),
+      '#title' => $this->t('Name of the community or group', [], $tOpts),
     ];
     $form['companyNameWrapper']['companyName'] = [
       '#type' => 'textfield',
       '#required' => TRUE,
-      '#title' => $this->t('Community name', [], $tOpts),
+      '#title' => $this->t('Name of the community or group', [], $tOpts),
       '#default_value' => $grantsProfileContent['companyName'],
+      '#help' => $this->t("The name of the community or group will be visible in the applications, decisions, and other similar contexts as the applicant's name. If the community's or group's name includes names of individual persons, they may be published as part of the name also on the internet.", [], $tOpts),
     ];
 
     $form['newItem'] = [

--- a/public/modules/custom/grants_profile/templates/own-profile-form-unregistered-community.html.twig
+++ b/public/modules/custom/grants_profile/templates/own-profile-form-unregistered-community.html.twig
@@ -1,10 +1,12 @@
 
 <div class="container">
-  <h2>{{ "Association information"|t({}, {'context': 'grants_profile'}) }}</h2>
-  <p class="grants-profile--infotext">{{ "To apply for grants, the community data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."|t({}, {'context': 'grants_profile'}) }}</p>
+  <h2>{{ "Community or group information"|t({}, {'context': 'grants_profile'}) }}</h2>
+  <p class="grants-profile--infotext">{{ "To apply for grants, the community or group data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."|t({}, {'context': 'grants_profile'}) }}</p>
+  <p class="grants-profile--infotext">{{ "When you form a community or group, you will be responsible for the possible grant awarded to the community or group, and reporting on the use of the grant. If the grant is awarded, it will be paid to your account. A group can be youth activity group or an artistic working group, for example."|t({}, {'context': 'grants_profile'}) }}</p>
+  <p class="grants-profile--infotext">{{ "With the grants for culture a notification of a grant paid to the bank account of a private person will be submitted to the Tax Administration in the recipient's name. This means that a person receiving the grant on behalf of a working group must themself ensure that the details of the entire group are forwarded to the Tax Administration as necessary."|t({}, {'context': 'grants_profile'}) }}</p>
   <div class="grants-profile">
     {{ basic_info }}
-    <h3 class="info-grants">{{ "Add association information"|t({}, {'context': 'grants_profile'}) }}</h3>
+    <h3 class="info-grants">{{ "Add community or group information"|t({}, {'context': 'grants_profile'}) }}</h3>
     <div class="grants-profile--extrainfo">
       {{ form }}
     </div>

--- a/public/modules/custom/grants_profile/templates/own-profile-unregistered-community.html.twig
+++ b/public/modules/custom/grants_profile/templates/own-profile-unregistered-community.html.twig
@@ -1,12 +1,14 @@
 <div class="container">
-  <h2>{{ "Association information"|t({}, {'context': 'grants_profile'}) }}</h2>
-  <p class="grants-profile--infotext">{{ "To apply for grants, the community data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."|t({}, {'context': 'grants_profile'}) }}</p>
+  <h2>{{ "Community or group information"|t({}, {'context': 'grants_profile'}) }}</h2>
+  <p class="grants-profile--infotext">{{ "To apply for grants, the community or group data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."|t({}, {'context': 'grants_profile'}) }}</p>
+  <p class="grants-profile--infotext">{{ "When you form a community or group, you will be responsible for the possible grant awarded to the community or group, and reporting on the use of the grant. If the grant is awarded, it will be paid to your account. A group can be youth activity group or an artistic working group, for example."|t({}, {'context': 'grants_profile'}) }}</p>
+  <p class="grants-profile--infotext">{{ "With the grants for culture a notification of a grant paid to the bank account of a private person will be submitted to the Tax Administration in the recipient's name. This means that a person receiving the grant on behalf of a working group must themself ensure that the details of the entire group are forwarded to the Tax Administration as necessary."|t({}, {'context': 'grants_profile'}) }}</p>
   <div class="grants-profile">
     {{ basic_info }}
-    <h3 class="info-grants">{{ "Association information in Grants"|t({}, {'context': 'grants_profile'}) }}</h3>
+    <h3 class="info-grants">{{ "Community or group information in Grants"|t({}, {'context': 'grants_profile'}) }}</h3>
     <div class="grants-profile--extrainfo">
       <dl class="webform-section-grid-wrapper">
-        <dt class="webform-section-title" id="yhteison-nimi">{{ "Name of association"|t({}, {'context': 'grants_profile'}) }}</dt>
+        <dt class="webform-section-title" id="yhteison-nimi">{{ "Name of the community or group"|t({}, {'context': 'grants_profile'}) }}</dt>
         <dd class="webform-section-wrapper">
           {{ profile.companyName }}
         </dd>

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -57,8 +57,16 @@ msgid "Show my profile"
 msgstr "Näytä oma profiili"
 
 msgctxt "grants_profile"
-msgid "To apply for grants, the community data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."
-msgstr "Avustusten hakeminen edellyttää yhteisön tietojen täydentämistä. Tehdessäsi avustushakemuksia antamasi tiedot täytetään niihin automaattisesti."
+msgid "To apply for grants, the community or group data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."
+msgstr "Avustusten hakeminen edellyttää yhteisön tai ryhmän tietojen täydentämistä. Tehdessäsi avustushakemuksia antamasi tiedot täytetään niihin automaattisesti."
+
+msgctxt "grants_profile"
+msgid "When you form a community or group, you will be responsible for the possible grant awarded to the community or group, and reporting on the use of the grant. If the grant is awarded, it will be paid to your account. A group can be youth activity group or an artistic working group, for example."
+msgstr "Kun perustat yhteisön tai ryhmän, vastaat sille mahdollisesti myönnettävästä avustuksesta ja avustuksen käytön selvittämisestä. Jos avustusta myönnetään, maksetaan se sinun tilillesi.  Ryhmä voi olla esimerkiksi nuorten toimintaryhmä tai taiteellinen työryhmä."
+
+msgctxt "grants_profile"
+msgid "With the grants for culture a notification of a grant paid to the bank account of a private person will be submitted to the Tax Administration in the recipient's name. This means that a person receiving the grant on behalf of a working group must themself ensure that the details of the entire group are forwarded to the Tax Administration as necessary."
+msgstr "Kulttuurin avustuksissa tehdään kaikista yksityishenkilöiden tileille maksettavista avustuksista apurahailmoitus verottajalle hänen nimissään. Yhteisön puolesta avustuksen vastaanottaneen tulee siis tarvittaessa itse huolehtia yhteisön tai ryhmän tietojen selvittämisestä verottajalle."
 
 msgctxt "grants_profile"
 msgid "Add association information"
@@ -71,6 +79,14 @@ msgstr "Yhteisön viralliset tiedot"
 msgctxt "grants_profile"
 msgid "Name of association"
 msgstr "Yhteisön nimi"
+
+msgctxt "grants_profile"
+msgid "Name of the community or group"
+msgstr "Yhteisön tai ryhmän nimi"
+
+msgctxt "grants_profile"
+msgid "The name of the community or group will be visible in the applications, decisions, and other similar contexts as the applicant's name. If the community's or group's name includes names of individual persons, they may be published as part of the name also on the internet."
+msgstr "Yhteisön tai ryhmän nimi näkyy avustushakemuksissa, päätöksissä ja muissa vastaavissa yhteyksissä hakijan nimenä. Jos yhteisön tai ryhmän nimeen on sisällytetty yksityishenkilöiden nimiä, voidaan nekin julkaista osana nimeä myös internetissä."
 
 msgctxt "grants_profile"
 msgid "Name"

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -50,8 +50,16 @@ msgid "Association information"
 msgstr "Yhteisön tiedot"
 
 msgctxt "grants_profile"
+msgid "Community or group information"
+msgstr "Yhteisön tai ryhmän tiedot"
+
+msgctxt "grants_profile"
 msgid "Association information in Grants"
 msgstr "Yhteisön tiedot avustusasioinnissa"
+
+msgctxt "grants_profile"
+msgid "Community or group information in Grants"
+msgstr "Yhteisön tai ryhmän tiedot avustusasioinnissa"
 
 msgid "Show my profile"
 msgstr "Näytä oma profiili"
@@ -71,6 +79,10 @@ msgstr "Kulttuurin avustuksissa tehdään kaikista yksityishenkilöiden tileille
 msgctxt "grants_profile"
 msgid "Add association information"
 msgstr "Lisää yhteisön tiedot"
+
+msgctxt "grants_profile"
+msgid "Add community or group information"
+msgstr "Lisää yhteisön tai ryhmän tiedot"
 
 msgctxt "grants_profile"
 msgid "Basic details"
@@ -336,6 +348,10 @@ msgid "Community address"
 msgstr "Yhteisön osoite"
 
 msgctxt "grants_profile"
+msgid "Community or group address"
+msgstr "Yhteisön tai ryhmän osoite"
+
+msgctxt "grants_profile"
 msgid "Add address"
 msgstr "Lisää osoite"
 
@@ -344,12 +360,24 @@ msgid "Community official"
 msgstr "Yhteisön vastuuhenkilö"
 
 msgctxt "grants_profile"
+msgid "Community or group official"
+msgstr "Yhteisön tai ryhmän vastuuhenkilö"
+
+msgctxt "grants_profile"
+msgid "Community or group official"
+msgstr "Yhteisön tai ryhmän vastuuhenkilö"
+
+msgctxt "grants_profile"
 msgid "Add official"
 msgstr "Lisää vastuuhenkilö"
 
 msgctxt "grants_profile"
 msgid "Community bank account"
 msgstr "Yhteisön pankkitili"
+
+msgctxt "grants_profile"
+msgid "Community or group bank account"
+msgstr "Yhteisön tai ryhmän pankkitili"
 
 msgctxt "grants_profile"
 msgid "Add bank account"

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -50,6 +50,14 @@ msgid "Association information"
 msgstr "Uppgifter om gemenskapen"
 
 msgctxt "grants_profile"
+msgid "Community or group information"
+msgstr "Uppgifter om gemenskapen eller gruppen"
+
+msgctxt "grants_profile"
+msgid "Community or group information in Grants"
+msgstr "Uppgifter om gemenskapen eller gruppen i understöd"
+
+msgctxt "grants_profile"
 msgid "Association information in Grants"
 msgstr "Uppgifter om gemenskapen i understöd"
 
@@ -73,6 +81,10 @@ msgid "Add association information"
 msgstr "Lägg till föreningsinformation"
 
 msgctxt "grants_profile"
+msgid "Add community or group information"
+msgstr "Lägg till uppgifter om gemenskapen eller gruppen"
+
+msgctxt "grants_profile"
 msgid "Basic details"
 msgstr "Grundläggande information"
 
@@ -82,7 +94,7 @@ msgstr "Sammanslutningens namn"
 
 msgctxt "grants_profile"
 msgid "Name of the community or group"
-msgstr "Gruppens namn"
+msgstr "Gemenskapens eller gruppens namn"
 
 msgctxt "grants_profile"
 msgid "The name of the community or group will be visible in the applications, decisions, and other similar contexts as the applicant's name. If the community's or group's name includes names of individual persons, they may be published as part of the name also on the internet."
@@ -336,6 +348,10 @@ msgid "Community address"
 msgstr "Gemenskapsadress"
 
 msgctxt "grants_profile"
+msgid "Community or group address"
+msgstr "Gemenskaps- eller gruppadress"
+
+msgctxt "grants_profile"
 msgid "Add address"
 msgstr "Lägg till adress"
 
@@ -344,12 +360,20 @@ msgid "Community official"
 msgstr "Gemenskapstjänsteman"
 
 msgctxt "grants_profile"
+msgid "Community or group official"
+msgstr "Gemenskaps- eller grupptjänsteman"
+
+msgctxt "grants_profile"
 msgid "Add official"
 msgstr "Lägg till tjänsteman"
 
 msgctxt "grants_profile"
 msgid "Community bank account"
 msgstr "Gemenskapens bankkonto"
+
+msgctxt "grants_profile"
+msgid "Community or group bank account"
+msgstr "Gemenskapens eller gruppens bankkonto"
 
 msgctxt "grants_profile"
 msgid "Add bank account"

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -57,8 +57,16 @@ msgid "Show my profile"
 msgstr "Visa min profil"
 
 msgctxt "grants_profile"
-msgid "To apply for grants, the community data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."
-msgstr "För att kunna ansöka om understöd krävs att gemenskapens uppgifter kompletteras. De uppgifter du lämnar fylls automatiskt i när du ansöker om understöd."
+msgid "To apply for grants, the community or group data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."
+msgstr "För att kunna ansöka om understöd krävs att gemenskapens eller gruppens uppgifter kompletteras. De uppgifter du lämnar fylls automatiskt i när du ansöker om understöd."
+
+msgctxt "grants_profile"
+msgid "When you form a community or group, you will be responsible for the possible grant awarded to the community or group, and reporting on the use of the grant. If the grant is awarded, it will be paid to your account. A group can be youth activity group or an artistic working group, for example."
+msgstr "När du grundar en grupp eller gemenskap ansvarar du för det eventuella understöd som gruppen beviljas och även för redovisningen av understödet. Om understöd beviljas utbetalas det till ditt bankkonto.  En grupp kan vara till exempel en konstnärlig arbetsgrupp eller en verksamhetsgrupp för ungdomar."
+
+msgctxt "grants_profile"
+msgid "With the grants for culture a notification of a grant paid to the bank account of a private person will be submitted to the Tax Administration in the recipient's name. This means that a person receiving the grant on behalf of a working group must themself ensure that the details of the entire group are forwarded to the Tax Administration as necessary."
+msgstr "Vid understöd för kultur gör Helsingfors stad en stipendieanmälan till skattemyndigheten om understöd som betalas till en privatpersons konto i personens namn, varvid den som tar emot understödet på arbetsgruppens vägnar vid behov själv ska se till att uppgifterna om gruppen utreds för skattemyndigheten."
 
 msgctxt "grants_profile"
 msgid "Add association information"
@@ -71,6 +79,14 @@ msgstr "Grundläggande information"
 msgctxt "grants_profile"
 msgid "Name of association"
 msgstr "Sammanslutningens namn"
+
+msgctxt "grants_profile"
+msgid "Name of the community or group"
+msgstr "Gruppens namn"
+
+msgctxt "grants_profile"
+msgid "The name of the community or group will be visible in the applications, decisions, and other similar contexts as the applicant's name. If the community's or group's name includes names of individual persons, they may be published as part of the name also on the internet."
+msgstr "Gruppens namn blir namnet på den sökande i ansökningsblanketten, i besluten om understöd och i andra motsvarande sammanhang. Om namn på enskilda personer ingår som delar av gruppens namn kan det hända att de även syns i samband med publicering på internet."
 
 msgctxt "grants_profile"
 msgid "Name"


### PR DESCRIPTION
# [AU-1625](https://helsinkisolutionoffice.atlassian.net/browse/AU-1625), [AU-1626](https://helsinkisolutionoffice.atlassian.net/browse/AU-1626)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add help-text to community name field
* Add info text under title
* Change community -> community or group

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1625-ohjeteksti`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that texts are correct

[UHF-1625]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UHF-1626]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-1625]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1626]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ