### PR TITLE
fix: AU-1623: Decode profile content

### DIFF
--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -1098,10 +1098,10 @@ class GrantsProfileService {
    * recursively.
    *
    * @param AtvDocument $profileDocument
-   *   An ATV document that we want to decode.
+   *   An ATV document whose content that we want to decode.
    *
    * @return AtvDocument
-   *   The decoded document.
+   *   An ATV document whose content has been decoded.
    */
   private function decodeProfileContent(AtvDocument $profileDocument): AtvDocument {
     $profileDocumentContent = $profileDocument->getContent();

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -1098,7 +1098,7 @@ class GrantsProfileService {
    * recursively.
    *
    * @param \Drupal\helfi_atv\AtvDocument $profileDocument
-   *   An ATV document whose content that we want to decode.
+   *   An ATV document whose content we want to decode.
    *
    * @return \Drupal\helfi_atv\AtvDocument
    *   An ATV document whose content has been decoded.

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\grants_profile;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Logger\LoggerChannel;
 use Drupal\Core\Logger\LoggerChannelFactory;
@@ -773,6 +774,7 @@ class GrantsProfileService {
       $profileDocument = $this->getGrantsProfileFromAtv($profileIdentifier, $refetch);
 
       if ($profileDocument) {
+        $profileDocument = $this->decodeProfileContent($profileDocument);
         $this->setToCache($profileIdentifier['identifier'], $profileDocument);
         return $profileDocument;
       }
@@ -1086,6 +1088,50 @@ class GrantsProfileService {
    */
   public function getUuid(): string {
     return Uuid::uuid4()->toString();
+  }
+
+  /**
+   * The decodeProfileContent method.
+   *
+   * This method calls decodeProfileContentRecursive
+   * in order to handle decoding of the profile document
+   * recursively.
+   *
+   * @param AtvDocument $profileDocument
+   *   An ATV document that we want to decode.
+   *
+   * @return AtvDocument
+   *   The decoded document.
+   */
+  private function decodeProfileContent(AtvDocument $profileDocument): AtvDocument {
+    $profileDocumentContent = $profileDocument->getContent();
+    $profileDocumentContent = $this->decodeProfileContentRecursive($profileDocumentContent);
+    $profileDocument->setContent($profileDocumentContent);
+    return $profileDocument;
+  }
+
+  /**
+   * The decodeProfileContentRecursive method,
+   *
+   * This method recursively walks through an associative array
+   * and decodes all the string values in it. The method is used by
+   * decodeProfileContent() to decode the profile content from ATV.
+   *
+   * @param array $profileDocumentContent
+   *   An array of profile document content.
+   * @return array
+   *   A decoded array of profile document content.
+   */
+  private function decodeProfileContentRecursive(array $profileDocumentContent): array {
+    foreach ($profileDocumentContent as &$item) {
+      if (is_array($item)) {
+        $item = $this->decodeProfileContentRecursive($item);
+      }
+      if (is_string($item)) {
+        $item = Html::decodeEntities(strip_tags($item));
+      }
+    }
+    return $profileDocumentContent;
   }
 
 }

--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -1097,10 +1097,10 @@ class GrantsProfileService {
    * in order to handle decoding of the profile document
    * recursively.
    *
-   * @param AtvDocument $profileDocument
+   * @param \Drupal\helfi_atv\AtvDocument $profileDocument
    *   An ATV document whose content that we want to decode.
    *
-   * @return AtvDocument
+   * @return \Drupal\helfi_atv\AtvDocument
    *   An ATV document whose content has been decoded.
    */
   private function decodeProfileContent(AtvDocument $profileDocument): AtvDocument {
@@ -1111,7 +1111,7 @@ class GrantsProfileService {
   }
 
   /**
-   * The decodeProfileContentRecursive method,
+   * The decodeProfileContentRecursive method.
    *
    * This method recursively walks through an associative array
    * and decodes all the string values in it. The method is used by
@@ -1119,6 +1119,7 @@ class GrantsProfileService {
    *
    * @param array $profileDocumentContent
    *   An array of profile document content.
+   *
    * @return array
    *   A decoded array of profile document content.
    */


### PR DESCRIPTION
# [AU-1623](https://helsinkisolutionoffice.atlassian.net/browse/AU-1623)

## What was done

This pull request adds a few decoding methods to the `GrantsProfileService.php` service class. The methods are used to decode various fields on a users profile.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-1623-profile-name-fix`
  * `make fresh`
  * `make drush-cr`

## How to test
- [ ] Login with a test user and edit the user profile with all three roles (registered, unregistered and private). Attempt to fill in various characters that are going to be encoded (such as <, > and &) into the company name, address and additional information fields. After the profile has been saved, the characters should be displayed normally on the user profile and not in an encoded format.
- [ ] Review the code.
- [ ] Check that nothing else breaks.


[AU-1623]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ