### PR TITLE
fix: AU-1634: Add redirect after failed tunnistamo login

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.routing.yml
+++ b/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.routing.yml
@@ -4,7 +4,7 @@ grants_oma_asiointi.front:
     _title_callback: '\Drupal\grants_oma_asiointi\Controller\GrantsOmaAsiointiController::title'
     _controller: '\Drupal\grants_oma_asiointi\Controller\GrantsOmaAsiointiController::build'
   requirements:
-    _permission: 'access grants_oma_asiointi'
+    _permission: 'access content'
 
 grants_oma_asiointi.applications_list:
   path: '/oma-asiointi/hakemukset'

--- a/public/modules/custom/grants_oma_asiointi/src/Controller/GrantsOmaAsiointiController.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Controller/GrantsOmaAsiointiController.php
@@ -8,12 +8,13 @@ use Drupal\Core\Http\RequestStack;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Logger\LoggerChannel;
 use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Url;
 use Drupal\grants_handler\ApplicationHandler;
 use Drupal\grants_mandate\Controller\GrantsMandateController;
 use Drupal\grants_profile\GrantsProfileService;
 use Drupal\helfi_atv\AtvService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Returns responses for Oma Asiointi routes.
@@ -109,11 +110,13 @@ class GrantsOmaAsiointiController extends ControllerBase implements ContainerInj
    * @return array
    *   Render array
    */
-  public function build(): array {
+  public function build(): array|RedirectResponse {
     $selectedCompany = $this->grantsProfileService->getSelectedRoleData();
 
+    /* If we have no company data, someone is trying to access the oma
+     * asiointi page directly or after failed Tunnistamo login */
     if ($selectedCompany == NULL) {
-      throw new AccessDeniedHttpException('User not authorised');
+      return new RedirectResponse(Url::fromRoute('<front>')->toString());
     }
 
     $grantsProfileDocument = $this->grantsProfileService->getGrantsProfile($selectedCompany);


### PR DESCRIPTION
# [AU-1634](https://helsinkisolutionoffice.atlassian.net/browse/AU-1634)
<!-- What problem does this solve? -->

Tämä PR on draft-tilassa koska asian voi ratkaista sisällönsyötön kautta määrittämällä sisältö 403 virhetilanteille. Keskustellaan asiasta dailyssa ennen kuin mergetään tätä koodia. Katso tiketin kommentit lisätietoja varten.

Virheilmoitus epäonnistuneen tunnistamo-kirjautumisen jälkeen.

## What was done
<!-- Describe what was done -->

Lisää redirect oma asiointi sivulle.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1634-tunnistamo-error-redirect`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Aloita kirjautumis flow, mutta Tunnistamossa paina Return to service nappulaa.
## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1634]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ