### PR TITLE
fix: AU-1636: Profile page errors

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -712,7 +712,7 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
     }
 
     if ($newItem == 'bankAccountWrapper') {
-      $nextDelta = count($bankAccountValues);
+      $nextDelta = isset($delta) ? $delta + 1 : 0;
 
       $form['bankAccountWrapper'][$nextDelta]['bank'] = [
         '#type' => 'fieldset',

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -633,7 +633,8 @@ class GrantsProfileFormPrivatePerson extends GrantsProfileFormBase {
       }
 
       // Make sure we have proper UUID as address id.
-      if (!$this->grantsProfileService->isValidUuid($bankAccount['bank_account_id'])) {
+      if (!isset($bankAccount['bank_account_id']) ||
+          !$this->grantsProfileService->isValidUuid($bankAccount['bank_account_id'])) {
         $bankAccount['bank_account_id'] = Uuid::uuid4()->toString();
       }
       $nonEditable = FALSE;
@@ -657,7 +658,7 @@ class GrantsProfileFormPrivatePerson extends GrantsProfileFormBase {
         'bankAccount' => [
           '#type' => 'textfield',
           '#title' => $this->t('Finnish bank account number in IBAN format', [], $tOpts),
-          '#default_value' => $bankAccount['bankAccount'],
+          '#default_value' => $bankAccount['bankAccount'] ?? '',
           '#readonly' => $nonEditable,
           '#attributes' => $attributes,
         ],
@@ -711,8 +712,9 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
     }
 
     if ($newItem == 'bankAccountWrapper') {
+      $nextDelta = count($bankAccountValues);
 
-      $form['bankAccountWrapper'][$delta + 1]['bank'] = [
+      $form['bankAccountWrapper'][$nextDelta]['bank'] = [
         '#type' => 'fieldset',
         '#title' => $this->t('Personal bank account', [], $tOpts),
         'bankAccount' => [
@@ -753,7 +755,7 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
           '#icon_left' => 'trash',
           '#value' => $this
             ->t('Delete', [], $tOpts),
-          '#name' => 'bankAccountWrapper--' . ($delta + 1),
+          '#name' => 'bankAccountWrapper--' . ($nextDelta),
           '#submit' => [
             '::removeOne',
           ],

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -777,10 +777,11 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
 
     $officialValues = $formState->getValue('officialWrapper') ?? $officials;
     unset($officialValues['actions']);
+
     foreach ($officialValues as $delta => $official) {
 
       // Make sure we have proper UUID as address id.
-      if (!$this->grantsProfileService->isValidUuid($official['official_id'])) {
+      if (!isset($official['official_id']) || !$this->grantsProfileService->isValidUuid($official['official_id'])) {
         $official['official_id'] = Uuid::uuid4()->toString();
       }
 
@@ -791,29 +792,29 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Name', [], $tOpts),
-          '#default_value' => $official['name'],
+          '#default_value' => $official['name'] ?? '',
         ],
         'role' => [
           '#type' => 'select',
           '#options' => $roles,
           '#title' => $this->t('Role', [], $tOpts),
-          '#default_value' => $official['role'],
+          '#default_value' => $official['role'] ?? 0,
         ],
         'email' => [
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Email address', [], $tOpts),
-          '#default_value' => $official['email'],
+          '#default_value' => $official['email'] ?? '',
         ],
         'phone' => [
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Telephone', [], $tOpts),
-          '#default_value' => $official['phone'],
+          '#default_value' => $official['phone'] ?? '',
         ],
         'official_id' => [
           '#type' => 'hidden',
-          '#default_value' => $official['official_id'],
+          '#default_value' => $official['official_id'] ?? '',
         ],
         'deleteButton' => [
           '#type' => 'submit',
@@ -833,8 +834,9 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
     }
 
     if ($newItem == 'officialWrapper') {
+      $nextDelta = count($officialValues);
 
-      $form['officialWrapper'][$delta + 1]['official'] = [
+      $form['officialWrapper'][$nextDelta]['official'] = [
         '#type' => 'fieldset',
         '#title' => $this->t('Community official', [], $tOpts),
         'name' => [
@@ -866,7 +868,7 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
           '#icon_left' => 'trash',
           '#value' => $this
             ->t('Delete', [], $tOpts),
-          '#name' => 'officialWrapper--' . $delta,
+          '#name' => 'officialWrapper--' . $nextDelta,
           '#submit' => [
             '::removeOne',
           ],
@@ -945,7 +947,8 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
       }
 
       // Make sure we have proper UUID as address id.
-      if (!$this->grantsProfileService->isValidUuid($bankAccount['bank_account_id'])) {
+      if (!isset($bankAccount['bank_account_id']) ||
+          !$this->grantsProfileService->isValidUuid($bankAccount['bank_account_id'])) {
         $bankAccount['bank_account_id'] = Uuid::uuid4()->toString();
       }
 
@@ -971,7 +974,7 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Finnish bank account number in IBAN format', [], $tOpts),
-          '#default_value' => $bankAccount['bankAccount'],
+          '#default_value' => $bankAccount['bankAccount'] ?? '',
           '#readonly' => $nonEditable,
           '#attributes' => $attributes,
         ],
@@ -1025,8 +1028,9 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
     }
 
     if ($newItem == 'bankAccountWrapper') {
+      $nextDelta = count($bankAccountValues);
 
-      $form['bankAccountWrapper'][$delta + 1]['bank'] = [
+      $form['bankAccountWrapper'][$nextDelta]['bank'] = [
         '#type' => 'fieldset',
         '#title' => $this->t('Community bank account', [], $tOpts),
         'bankAccount' => [
@@ -1068,7 +1072,7 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
           '#icon_left' => 'trash',
           '#value' => $this
             ->t('Delete', [], $tOpts),
-          '#name' => 'bankAccountWrapper--' . ($delta + 1),
+          '#name' => 'bankAccountWrapper--' . ($nextDelta),
           '#submit' => [
             '::removeOne',
           ],

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -834,7 +834,7 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
     }
 
     if ($newItem == 'officialWrapper') {
-      $nextDelta = count($officialValues);
+      $nextDelta = isset($delta) ? $delta + 1 : 0;
 
       $form['officialWrapper'][$nextDelta]['official'] = [
         '#type' => 'fieldset',
@@ -1028,7 +1028,7 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
     }
 
     if ($newItem == 'bankAccountWrapper') {
-      $nextDelta = count($bankAccountValues);
+      $nextDelta = isset($delta) ? $delta + 1 : 0;
 
       $form['bankAccountWrapper'][$nextDelta]['bank'] = [
         '#type' => 'fieldset',

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -734,7 +734,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Name', [], $tOpts),
-          '#default_value' => $official['name'],
+          '#default_value' => $official['name'] ?? '',
         ],
         'role' => [
           '#type' => 'select',
@@ -746,7 +746,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Email address', [], $tOpts),
-          '#default_value' => $official['email'],
+          '#default_value' => $official['email'] ?? '',
         ],
         'phone' => [
           '#type' => 'textfield',
@@ -756,7 +756,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
         ],
         'official_id' => [
           '#type' => 'hidden',
-          '#default_value' => $official['official_id'],
+          '#default_value' => $official['official_id'] ?? '',
         ],
         'deleteButton' => [
           '#type' => 'submit',
@@ -776,8 +776,9 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
     }
 
     if ($newItem == 'officialWrapper') {
+      $nextDelta = count($officialValues);
 
-      $form['officialWrapper'][$delta + 1]['official'] = [
+      $form['officialWrapper'][$nextDelta]['official'] = [
         '#type' => 'fieldset',
         '#title' => $this->t('Community official', [], $tOpts),
         'name' => [
@@ -809,7 +810,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
           '#icon_left' => 'trash',
           '#value' => $this
             ->t('Delete', [], $tOpts),
-          '#name' => 'officialWrapper--' . $delta,
+          '#name' => 'officialWrapper--' . $nextDelta,
           '#submit' => [
             '::removeOne',
           ],
@@ -887,7 +888,8 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
       }
 
       // Make sure we have proper UUID as address id.
-      if (!$this->isValidUuid($bankAccount['bank_account_id'])) {
+      if (!isset($bankAccount['bank_account_id']) ||
+          !$this->isValidUuid($bankAccount['bank_account_id'])) {
         $bankAccount['bank_account_id'] = Uuid::uuid4()->toString();
       }
       $nonEditable = FALSE;
@@ -911,7 +913,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
           '#type' => 'textfield',
           '#required' => TRUE,
           '#title' => $this->t('Finnish bank account number in IBAN format', [], $tOpts),
-          '#default_value' => $bankAccount['bankAccount'],
+          '#default_value' => $bankAccount['bankAccount'] ?? '',
           '#readonly' => $nonEditable,
           '#attributes' => $attributes,
         ],
@@ -978,8 +980,9 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
     }
 
     if ($newItem == 'bankAccountWrapper') {
+      $nextDelta = count($bankAccountValues);
 
-      $form['bankAccountWrapper'][$delta + 1]['bank'] = [
+      $form['bankAccountWrapper'][$nextDelta]['bank'] = [
         '#type' => 'fieldset',
         '#description_display' => 'before',
         '#description' => $this->t('You can only fill in your own bank account information.', [], $tOpts),
@@ -1035,7 +1038,7 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
           '#type' => 'submit',
           '#icon_left' => 'trash',
           '#value' => $this->t('Delete', [], $tOpts),
-          '#name' => 'bankAccountWrapper--' . ($delta + 1),
+          '#name' => 'bankAccountWrapper--' . ($nextDelta),
           '#submit' => [
             '::removeOne',
           ],

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -776,7 +776,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
     }
 
     if ($newItem == 'officialWrapper') {
-      $nextDelta = count($officialValues);
+      $nextDelta = isset($delta) ? $delta + 1 : 0;
 
       $form['officialWrapper'][$nextDelta]['official'] = [
         '#type' => 'fieldset',
@@ -980,7 +980,7 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
     }
 
     if ($newItem == 'bankAccountWrapper') {
-      $nextDelta = count($bankAccountValues);
+      $nextDelta = isset($delta) ? $delta + 1 : 0;
 
       $form['bankAccountWrapper'][$nextDelta]['bank'] = [
         '#type' => 'fieldset',


### PR DESCRIPTION
# [AU-1636](https://helsinkisolutionoffice.atlassian.net/browse/AU-1636)

## What was done
This pull request implements changes to the user profile forms. Previously, warnings were being thrown in situations where the forms tried to access either array indexes or variables that did not exist. These issues have been fixed.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout fix/AU-1636-profile-page-fix`
  * `make fresh`
  * `make drush-cr`

## How to test
- Login with a test user and test the profile form with all three user roles (registered, unregistered and private). Experiment with adding and deleting Addresses, Persons responsible for operations, and Bank account details. Check the Drupal logs and make sure that no warnings are thrown during your testing.
- Review the code.

[AU-1636]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ