### PR TITLE
hotfix: AU-1656: Fix missing reference webform

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -223,6 +223,8 @@ config_import_ignore:
   - 48
   - 56
   - 50
+  - 59
+  - 29
 overridden_configuration:
   - 53:
       grants_metadata:

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -93,6 +93,10 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
 
     $node = \Drupal::routeMatch()->getParameter('node');
 
+    if (!$node) {
+      return AccessResult::forbidden('No referenced item');
+    }
+
     $applicantTypes = $node->get('field_hakijatyyppi')->getValue();
 
     $currentRole = $this->grantsProfileService->getSelectedRoleData();

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -76,6 +76,11 @@ function grants_metadata_node_presave(EntityInterface $entity): void {
 
     /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $referenceItem */
     $referenceItem = $entity->get('field_webform')->first();
+
+    if (!$referenceItem) {
+      return;
+    }
+
     /** @var \Drupal\Core\Entity\Plugin\DataType\EntityReference $entityReference */
     $entityReference = $referenceItem->get('entity');
     /** @var \Drupal\Core\Entity\Plugin\DataType\EntityAdapter $entityAdapter */


### PR DESCRIPTION
# [AU-1656](https://helsinkisolutionoffice.atlassian.net/browse/AU-1656)
<!-- What problem does this solve? -->

Somehow form edits stopped working if there is no refenced webform selected on 2 different places.

## What was done
<!-- Describe what was done -->

* Added checks for existing entity.


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout hotfix/AU-1656-fix-missing-reference-webform`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Try to save SErvice page node without selecting webform
* [ ] No errors should be seen, and node should be saved.



[AU-1656]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ