### PR TITLE
fix: AU-1652 add context to translation of "Select"

### DIFF
--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -65,6 +65,10 @@ msgid 'Subvention amount'
 msgstr 'Avustussumma'
 
 msgctxt "grants_handler"
+msgid 'Select'
+msgstr 'Valitse'
+
+msgctxt "grants_handler"
 msgid 'Select address'
 msgstr 'Valitse osoite'
 

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -65,6 +65,10 @@ msgid "Subvention amount"
 msgstr "Bidragsbelopp"
 
 msgctxt "grants_handler"
+msgid "Select"
+msgstr "Välj"
+
+msgctxt "grants_handler"
 msgid "Select address"
 msgstr "Välj adress"
 


### PR DESCRIPTION
# [AU-1652 ](https://helsinkisolutionoffice.atlassian.net/browse/AU-1652 )
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Select in grants handler is now translated
## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1652-toiminnasta-vastaava-select`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to a form in Finnish that requires a registered community
* [ ] See that the text "Select" is translated in toiminnasta vastaavat henkilöt
* [ ] Switch to Swedish
* [ ] repeat. 
* [ ] Check that code follows our standards
