### PR TITLE
fix: AU-1648 disable toiminnasta vastaava if empty

### DIFF
--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -35,15 +35,22 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
    */
   public static function getCompositeElements(array $element): array {
     $is_required = FALSE;
+    $is_disabled = FALSE;
+    $description = null;
     $tOpts = ['context' => 'grants_handler'];
 
     if (\Drupal::currentUser()->isAuthenticated()) {
       /** @var \Drupal\grants_profile\GrantsProfileService $grantsProfileService */
       $grantsProfileService = \Drupal::service('grants_profile.service');
+      $selectedCompany = $grantsProfileService->getSelectedRoleData();
+      $profileData = $grantsProfileService->getGrantsProfileContent($selectedCompany ?? '');
 
       $profileType = $grantsProfileService->getApplicantType();
-
       $is_required = ($profileType === 'unregistered_community');
+      if ($profileType === 'registered_community' && count($profileData['officials']) == 0) {
+        $is_disabled = TRUE;
+        $description = t('You do not have any community officials saved in your profile, so you cannot add any to the application.', [], $tOpts);
+      }
     }
     $elements = [];
 
@@ -53,6 +60,8 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
       '#required' => $is_required,
       '#after_build' => [[get_called_class(), 'buildOfficialOptions']],
       '#options' => [],
+      '#description' => $description,
+      '#disabled' => $is_disabled,
       '#attributes' => [
         'class' => [
           'community-officials-select',

--- a/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CommunityOfficialsComposite.php
@@ -47,7 +47,7 @@ class CommunityOfficialsComposite extends WebformCompositeBase {
 
       $profileType = $grantsProfileService->getApplicantType();
       $is_required = ($profileType === 'unregistered_community');
-      if ($profileType === 'registered_community' && count($profileData['officials']) == 0) {
+      if (isset($profileData['officials']) && $profileType === 'registered_community' && count($profileData['officials']) == 0) {
         $is_disabled = TRUE;
         $description = t('You do not have any community officials saved in your profile, so you cannot add any to the application.', [], $tOpts);
       }

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -65,6 +65,10 @@ msgid 'Subvention amount'
 msgstr 'Avustussumma'
 
 msgctxt "grants_handler"
+msgid 'You do not have any community officials saved in your profile, so you cannot add any to the application.'
+msgstr 'Profiiliisi ei ole tallennettu yhtään yhteisöstä vastaavaa henkilöä, joten et voi lisätä niitä hakemukselle.'
+
+msgctxt "grants_handler"
 msgid 'Select address'
 msgstr 'Valitse osoite'
 

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -65,6 +65,10 @@ msgid "Subvention amount"
 msgstr "Bidragsbelopp"
 
 msgctxt "grants_handler"
+msgid 'You do not have any community officials saved in your profile, so you cannot add any to the application.'
+msgstr 'Du har inga motsvarande personer sparade i din profil, så du kan inte lägga till några i programmet.'
+
+msgctxt "grants_handler"
 msgid "Select address"
 msgstr "Välj adress"
 


### PR DESCRIPTION
# [AU-1648](https://helsinkisolutionoffice.atlassian.net/browse/AU-1648)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Toiminnasta vastaava henkilö select is now disabled if there are no toiminnasta vastaava henkilö in profile of a registered community.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1648-disable-toiminnasta-vastaava-if-empty`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to form in Finnish as a registered community when you have a toiminnasta vastaava henkilö set in your profile and see the select works fine
* [ ] Remove your toiminnasta vastaavat henkilöt from profile, return to form and see that the field is disabled and there is a finnish description explaining why below it.
* [ ] Switch language to Swedish and repeat steps above.
* [ ] Save form and see that things work when the field is disabled.
* [ ] Switch role to unregistered community and see that the toiminnasta vastaavat henkilöt field works like regularly.
* [ ] Check that code follows our standards