### PR TITLE
fix: AU-1647 add missing counter to kuva projekti

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -278,7 +278,7 @@ elements: |
   muu_huomioitava_panostus_osio:
     '#markup': '<h4>Other notable input</h4>'
   muu_huomioitava_panostus:
-    '#counter_maximum_message': '%d/2500 characters remaining'
+    '#counter_maximum_message': '%d/1000 characters remaining'
     '#title': 'Does the implementation of the activity include any other contribution of monetary value or barter that is not reflected in the budget?'
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and attachments'

--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -278,6 +278,7 @@ elements: |
   muu_huomioitava_panostus_osio:
     '#markup': '<h4>Other notable input</h4>'
   muu_huomioitava_panostus:
+    '#counter_maximum_message': '%d/2500 characters remaining'
     '#title': 'Does the implementation of the activity include any other contribution of monetary value or barter that is not reflected in the budget?'
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and attachments'

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -281,7 +281,7 @@ elements: |
   muu_huomioitava_panostus_osio:
     '#markup': '<h4>Övrig betydande insats</h4>'
   muu_huomioitava_panostus:
-    '#counter_maximum_message': '%d/2500 tecken kvar'
+    '#counter_maximum_message': '%d/1000 tecken kvar'
     '#title': 'Inkluderar genomförandet av verksamheten något annat bidrag av monetärt värde eller byteshandel som inte återspeglas i budgeten?'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -281,6 +281,7 @@ elements: |
   muu_huomioitava_panostus_osio:
     '#markup': '<h4>Övrig betydande insats</h4>'
   muu_huomioitava_panostus:
+    '#counter_maximum_message': '%d/2500 tecken kvar'
     '#title': 'Inkluderar genomförandet av verksamheten något annat bidrag av monetärt värde eller byteshandel som inte återspeglas i budgeten?'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -969,6 +969,9 @@ elements: |-
         '#markup': '<h4>Muu huomioitava panostus</h4>'
       muu_huomioitava_panostus:
         '#type': textarea
+        '#counter_type': character
+        '#counter_maximum': 2500
+        '#counter_maximum_message': '%d/2500 merkkiä jäljellä'
         '#attributes':
           class:
             - webform--large

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -970,8 +970,9 @@ elements: |-
       muu_huomioitava_panostus:
         '#type': textarea
         '#counter_type': character
-        '#counter_maximum': 2500
-        '#counter_maximum_message': '%d/2500 merkkiä jäljellä'
+        '#counter_maximum': 1000
+        '#maxlength': 1000
+        '#counter_maximum_message': '%d/1000 merkkiä jäljellä'
         '#attributes':
           class:
             - webform--large


### PR DESCRIPTION
# [AU-1647](https://helsinkisolutionoffice.atlassian.net/browse/AU-1647)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* A field in KUVA: Projekti was missing a counter.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1647-counter`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to Kulttuuri: Projektiavustus, page 6
* [ ] See that there is a 1000 character counter in the "Sisältyykö toiminnan toteuttamiseen jotain muuta rahanarvoista panosta tai vaihtokauppaa, joka ei käy ilmi budjetista?" field in Finnish
* [ ] ... in Swedish
* [ ] ... and in English
* [ ] Check that code follows our standards


[AU-1647]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ