### PR TITLE
fix: AU-1299 verify form names

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -158,7 +158,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\LiikuntaSuunnistusDefinition
         definitionId: grants_metadata_liikuntasuunnistus
       labels:
-        fi: 'Liikunta, Suunnistuskartta-avustushakemus'
+        fi: 'Liikunta, suunnistuskartta-avustushakemus'
         en: 'Sports, grant application for orienteering maps'
         sv: 'Idrott, ansökan om bidrag för orienteringskarta'
     60:
@@ -188,7 +188,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\KansliatyoDefinition
         definitionId: grants_metadata_kansliatyo
       labels:
-        fi: 'Asukasosallisuus: yleis- ja toiminta-avustushakemus'
+        fi: 'Asukasosallisuus, yleis- ja toiminta-avustushakemus'
         en: 'Citizen Participation, general and operational grant application'
         sv: 'Invånardelaktighet, ansökan om allmänna och verksamhetsbidrag'
     61:

--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -88,7 +88,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\NuorisoToimintaEnnakkoDefinition
         definitionId: grants_metadata_nuortoimennakko
       labels:
-        fi: 'Nuorisotoiminta, toiminta- ja palkkausavustus ennakkohakemus'
+        fi: 'Nuorisotoimi, toiminta- ja palkkausavustusennakkohakemus'
         en: 'Youth service, operations and employment grant advance application'
         sv: 'Ungdomstjänst, förskottsansökan om verksamhets- och anställningsbidrag'
     56:
@@ -138,7 +138,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\NuorisoLomaDefinition
         definitionId: grants_metadata_nuorisoloma
       labels:
-        fi: 'Nuorisotoiminta, loma-aikojen leiriavustushakemus'
+        fi: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
         en: 'Holiday camp grants for youth activities'
         sv: 'Ungdomsverksamhet, lägerunderstöd under skollovstider'
     64:

--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -149,8 +149,8 @@ third_party_options:
         definitionId: grants_metadata_asukaspien
       labels:
         fi: 'Asukasosallisuus, pienavustushakemus'
-        en: 'EN Asukasosallisuus, pienavustushakemus'
-        sv: 'SV Asukasosallisuus, pienavustushakemus'
+        en: 'Citizen Participation, small grant application'
+        sv: 'Invånardelaktighet, ansökan om små bidrag'
     58:
       id: LIIKUNTASUUNNISTUS
       code: LIIKUNTASUUNNISTUS
@@ -189,8 +189,8 @@ third_party_options:
         definitionId: grants_metadata_kansliatyo
       labels:
         fi: 'Asukasosallisuus: yleis- ja toiminta-avustushakemus'
-        en: 'EN Asukasosallisuus: yleis- ja toiminta-avustushakemus'
-        sv: 'SV Asukasosallisuus: yleis- ja toiminta-avustushakemus'
+        en: 'Citizen Participation, general and operational grant application'
+        sv: 'Invånardelaktighet, ansökan om allmänna och verksamhetsbidrag'
     61:
       id: YMPARISTOYLEIS
       code: YMPARISTOYLEIS

--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -198,7 +198,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\YmparistoYleisDefinition
         definitionId: grants_metadata_ymparisto_yleis
       labels:
-        fi: 'Ympäristöpalvelut: Yleisavustushakemus'
+        fi: 'Ympäristöpalvelut, yleisavustushakemus'
         en: 'Environmental services, general grant application'
         sv: 'Miljötjänster, allmän bidragsansökan'
   application_statuses:

--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -128,7 +128,7 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\KaskoIltapaivaLisaDefinition
         definitionId: grants_metadata_kaskoiplisa
       labels:
-        fi: 'Kasvatus ja koulutus, Iltapäivätoiminnan harkinnanvarainen lisäavustushakemus'
+        fi: 'Kasvatus ja koulutus, iltapäivätoiminnan harkinnanvarainen lisäavustushakemus'
         en: 'Education, supplementary discretionary grant application for afternoon activities'
         sv: 'Fostran och utbildning, ansökan om extra bidrag enligt behovsprövning för eftermiddagsverksamhet'
     65:

--- a/conf/cmi/language/en/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/language/en/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -1,3 +1,4 @@
+title: 'Citizen Participation, small grant application'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'

--- a/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -1,3 +1,4 @@
+title: 'Citizen Participation, general and operational grant application'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'

--- a/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_tapahtuma.yml
@@ -1,4 +1,4 @@
-title: 'Sports: Event grant application'
+title: 'Sports, grant application for events'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'

--- a/conf/cmi/language/fi/grants_metadata.settings.yml
+++ b/conf/cmi/language/fi/grants_metadata.settings.yml
@@ -28,9 +28,9 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\KaskoYleisavustusDefinition
         definitionId: grants_metadata_kaskoyleis
       labels:
-        fi: 'Kasvatus ja koulutus: yleisavustushakemus'
-        en: 'EN Kasvatus ja koulutus: yleisavustushakemus'
-        sv: 'SV Kasvatus ja koulutus: yleisavustushakemus'
+        fi: 'Kasvatus ja koulutus, yleisavustushakemus'
+        en: 'Education, general grant application'
+        sv: 'Fostran och utbildning, allmän bidragsansökan'
   application_statuses:
     DRAFT: DRAFT
     SENT: SENT

--- a/conf/cmi/language/fi/grants_metadata.settings.yml
+++ b/conf/cmi/language/fi/grants_metadata.settings.yml
@@ -18,9 +18,9 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\YleisavustusHakemusDefinition
         definitionId: grants_metadata_yleisavustushakemus
       labels:
-        fi: 'Kaupunginhallituksen yleisavustushakemus'
+        fi: 'Kaupunginhallitus, yleisavustushakemus'
         en: 'City Board, general grant application'
-        sv: 'Ansökan om stadsstyrelsens allmänna understöd'
+        sv: 'Stadsstyrelsen, allmän bidragsansökan'
     51:
       id: KASKOYLEIS
       code: KASKOYLEIS

--- a/conf/cmi/language/sv/grants_metadata.settings.yml
+++ b/conf/cmi/language/sv/grants_metadata.settings.yml
@@ -28,9 +28,9 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\KaskoYleisavustusDefinition
         definitionId: grants_metadata_kaskoyleis
       labels:
-        fi: 'Kasvatus ja koulutus: yleisavustushakemus'
-        en: 'EN Kasvatus ja koulutus: yleisavustushakemus'
-        sv: 'SV Kasvatus ja koulutus: yleisavustushakemus'
+        fi: 'Kasvatus ja koulutus, yleisavustushakemus'
+        en: 'Education, general grant application'
+        sv: 'Fostran och utbildning, allmän bidragsansökan'
   application_statuses:
     DRAFT: DRAFT
     SENT: SENT

--- a/conf/cmi/language/sv/grants_metadata.settings.yml
+++ b/conf/cmi/language/sv/grants_metadata.settings.yml
@@ -18,9 +18,9 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\YleisavustusHakemusDefinition
         definitionId: grants_metadata_yleisavustushakemus
       labels:
-        fi: 'Kaupunginhallituksen yleisavustushakemus'
+        fi: 'Kaupunginhallitus, yleisavustushakemus'
         en: 'City Board, general grant application'
-        sv: 'Ansökan om stadsstyrelsens allmänna understöd'
+        sv: 'Stadsstyrelsen, allmän bidragsansökan'
     51:
       id: KASKOYLEIS
       code: KASKOYLEIS

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -220,3 +220,4 @@ settings:
   wizard_next_button_label: 'Nästa >'
   preview_label: '5. Bekräfta, förhandsgranska och skicka'
   preview_title: 'Bekräfta, förhandsgranska och skicka'
+title: 'Invånardelaktighet, ansökan om små bidrag'

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -1,3 +1,4 @@
+title: 'Invånardelaktighet, ansökan om allmänna och verksamhetsbidrag'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -1,5 +1,4 @@
 title: 'Fostran och utbildning, allmän bidragsansökan'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Sökandens uppgifter'

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -1,5 +1,4 @@
 title: 'Understöd för konst och kultur: Projektstöd'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Sökandens uppgifter'

--- a/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
@@ -1,5 +1,4 @@
 title: 'Idrott,  bidrag för anstalter och stiftelser'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Sökandens uppgifter'

--- a/conf/cmi/language/sv/webform.webform.liikunta_suunnistuskartta_avustu.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_suunnistuskartta_avustu.yml
@@ -1,5 +1,4 @@
 title: 'Idrott, ansökan om bidrag för orienteringskarta'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'

--- a/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
@@ -1,4 +1,4 @@
-title: 'Idrott: Ansökan om evenemangsunderstöd'
+title: 'Idrott, ansökan om evenemangsbidrag'
 elements: |
   applicant_type:
     '#title': 'Sökande typ'

--- a/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -1,5 +1,4 @@
 title: 'Idrott, ansökan om bidrag för verksamhet och lokaler'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Sökandens uppgifter'

--- a/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
@@ -1,5 +1,4 @@
 title: 'Idrott, allmän bidragsansökan'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Sökandens uppgifter'

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -1,5 +1,4 @@
 title: 'Utvecklingsstöd för kultur'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Sökandens uppgifter'

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -1,5 +1,4 @@
 title: 'Stadsstyrelsen, allmän bidragsansökan'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Sökandens uppgifter'

--- a/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -31,7 +31,7 @@ uid: 1
 template: false
 archive: false
 id: asukasosallisuus_yleis_ja_toimin
-title: 'Asukasosallisuus: yleis- ja toiminta-avustushakemus'
+title: 'Asukasosallisuus, yleis- ja toiminta-avustushakemus'
 description: ASUKASYLEISTOIM
 category: ''
 elements: |-

--- a/conf/cmi/webform.webform.kasko_ip_lisa.yml
+++ b/conf/cmi/webform.webform.kasko_ip_lisa.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: kasko_ip_lisa
-title: 'Kasvatus ja koulutus: Iltapäivätoiminnan harkinnanvarainen lisäavustushakemus'
+title: 'Kasvatus ja koulutus, iltapäivätoiminnan harkinnanvarainen lisäavustushakemus'
 description: KASKOIPLISA
 category: ''
 elements: |-

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -35,8 +35,8 @@ uid: 1
 template: false
 archive: false
 id: kasvatus_ja_koulutus_yleisavustu
-title: 'Kasvatus ja koulutus: yleisavustuslomake'
-description: 'KASKO yleisavustus'
+title: 'Kasvatus ja koulutus, yleisavustushakemus'
+description: 'KASKOYLEIS'
 category: ''
 elements: |-
   applicant_type:

--- a/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -32,7 +32,7 @@ template: false
 archive: false
 id: kaupunginkanslia_tyollisyysavust
 title: 'Kaupunginkanslia, työllisyysavustushakemus'
-description: 'Kaupunginkanslia: Ty&ouml;llisyysavustushakemus'
+description: 'KANSLIATYO'
 category: ''
 elements: |-
   applicant_type:

--- a/conf/cmi/webform.webform.liikunta_suunnistuskartta_avustu.yml
+++ b/conf/cmi/webform.webform.liikunta_suunnistuskartta_avustu.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: liikunta_suunnistuskartta_avustu
-title: 'Liikunta, Suunnistuskartta-avustushakemus'
+title: 'Liikunta, suunnistuskartta-avustushakemus'
 description: LIIKUNTASUUNNISTUS
 category: ''
 elements: |-

--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: liikunta_tapahtuma
-title: 'Liikunta: Tapahtuma-avustushakemus'
+title: 'Liikunta, tapahtuma-avustushakemus'
 description: LIIKUNTATAPAHTUMA
 category: ''
 elements: |-

--- a/conf/cmi/webform.webform.nuorlomaleir.yml
+++ b/conf/cmi/webform.webform.nuorlomaleir.yml
@@ -31,7 +31,7 @@ uid: 1
 template: false
 archive: false
 id: nuorlomaleir
-title: 'Nuorisotoiminta, loma-aikojen leiriavustushakemus'
+title: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
 description: NUORLOMALEIR
 category: ''
 elements: |-

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -31,8 +31,8 @@ uid: 1
 template: false
 archive: false
 id: yleisavustushakemus
-title: 'Kaupunginhallituksen yleisavustushakemus'
-description: MVP-lomake
+title: 'Kaupunginhallitus, yleisavustushakemus'
+description: ECONOMICGRANTAPPLICATION
 category: ''
 elements: |-
   applicant_type:

--- a/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -36,7 +36,7 @@ uid: 1
 template: false
 archive: false
 id: ymparistopalvelut_yleisavustus
-title: 'Ympäristöpalvelut: Yleisavustushakemus'
+title: 'Ympäristöpalvelut, yleisavustushakemus'
 description: YMPARISTOYLEIS
 category: ''
 elements: |-

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
@@ -32,7 +32,7 @@ uid: 1
 template: false
 archive: false
 id: kuva_projekti
-title: 'Taide ja kulttuuri: projektiavustus'
+title: 'Taide- ja kulttuuriavustukset: projektiavustukset'
 description: KUVAPROJ
 category: ''
 elements: |-

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kuva_toiminta.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kuva_toiminta.yml
@@ -31,7 +31,7 @@ uid: 1
 template: false
 archive: false
 id: kuva_toiminta
-title: 'Taide- ja kulttuuriavustukset, toiminta-avustus'
+title: 'Taide- ja kulttuuriavustukset: toiminta-avustukset'
 description: KUVATOIM
 category: ''
 elements: |-

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -31,7 +31,7 @@ uid: 1
 template: false
 archive: false
 id: nuorisopalvelut_toiminta_ja_palk
-title: 'Nuorisotoiminta, toiminta- ja palkkausavustus ennakkohakemus'
+title: 'Nuorisotoimi, toiminta- ja palkkausavustusennakkohakemus'
 description: NUORTOIMPALKENNAKKO
 category: ''
 elements: |-

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: nuorlomaleir
-title: 'Nuorisotoiminta, loma-aikojen leiriavustushakemus'
+title: 'Nuorisotoimi, loma-aikojen leiriavustushakemus'
 description: NUORLOMALEIR
 category: ''
 elements: |-

--- a/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: taide_ja_kulttuuriavustukset_tai
-title: 'Taide- ja kulttuuriavustukset, taiteen perusopetus'
+title: 'Taiteen perusopetuksen avustukset'
 description: KUVAPERUS
 category: ''
 elements: |-

--- a/public/modules/custom/grants_metadata/tests/modules/grants_metadata_test_webforms/config/install/webform.webform.kuva_projekti.yml
+++ b/public/modules/custom/grants_metadata/tests/modules/grants_metadata_test_webforms/config/install/webform.webform.kuva_projekti.yml
@@ -29,7 +29,7 @@ uid: 1
 template: false
 archive: false
 id: kuva_projekti
-title: 'Taide ja kulttuuri: projektiavustus'
+title: 'Taide- ja kulttuuriavustukset: projektiavustukset'
 description: KUVAPROJ
 category: ''
 elements: |-


### PR DESCRIPTION
# [AU-1299](https://helsinkisolutionoffice.atlassian.net/browse/AU-1299)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Made sure that the form titles match the excel

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1299-form-names`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that all the forms have titles that match the excel
* [ ] Check that code follows our standards


[AU-1299]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ