### PR TITLE
hotfix: AU-xxx: Remove #form_state statement to possibly fix ajax errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 2023.19.1
+86fbdb5e fix: Bring Save time fixes from separate PR to get them in this hotfix
+b0c08aa1 fix: AU-xxx: Remove #form_state statement to possibly fix ajax errors
+75afb4ea fix: Hotfix AU-1656
+0ac47cd9 fix: AU-1656: Add new productin applications to ignore
+5d97e568 fix: AU-1656: Fix missing referenced item error
+
 ## 2023.19
 - e148d9be config: Automatic update (#623)
 - 1fbe4684 feat: AU-1313: KUVA Tila senior mappings & premise cost component (#685)

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1209,9 +1209,17 @@ function grants_handler_preprocess_webform_submission_form(&$variables) {
     '#langcode' => $language,
     '#applicationID' => $submissionData["application_number"],
   ];
-  $date = $submissionData["form_timestamp_submitted"] ?: 'now';
-  $dt = new DateTime($date, new DateTimeZone('Europe/Helsinki'));
-  $variables['date'] = $dt->format('d.m.Y H:i');
+  if (isset($submissionData["form_timestamp"])) {
+    $date = $submissionData["form_timestamp"];
+    $dt = new DateTime($date, new DateTimeZone('Europe/Helsinki'));
+    $variables['date'] = $dt->format('d.m.Y H:i');
+  }
+
+  if (isset($submissionData["form_timestamp_submitted"])) {
+    $subDate = $submissionData["form_timestamp_submitted"];
+    $sdt = new DateTime($subDate, new DateTimeZone('Europe/Helsinki'));
+    $variables['subDate'] = $sdt->format('d.m.Y H:i');
+  }
 
   if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
     $title = \Drupal::service('title_resolver')->getTitle($request, $route);

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -556,7 +556,6 @@ class GrantsHandler extends WebformHandlerBase {
     $this->alterFormNavigation($form, $form_state, $webform_submission);
 
     $form['#webform_submission'] = $webform_submission;
-    $form['#form_state'] = $form_state;
 
     $this->setFromThirdPartySettings($webform_submission->getWebform());
 

--- a/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-form.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-form.html.twig
@@ -19,14 +19,26 @@
       {{ statusTag }}
       </div>
     </div>
-    <div class="application-list__status__item">
-      <div class="application-list__status__label">
-        {{ "Saved"|t }}
+    {% if date != '' %}
+      <div class="application-list__status__item">
+        <div class="application-list__status__label">
+          {{ "Saved time"|t }}
+        </div>
+        <div class="application-list__status__value">
+          <div>{{ date }}</div>
+        </div>
       </div>
-      <div class="application-list__status__value">
-        <div>{{ date }}</div>
+    {% endif %}
+    {% if subDate != '' %}
+      <div class="application-list__status__item">
+        <div class="application-list__status__label">
+          {{ "Sent time"|t }}
+        </div>
+        <div class="application-list__status__value">
+          <div>{{ subDate }}</div>
+        </div>
       </div>
-    </div>
+    {% endif %}
   </div>
 </div>
 <div class="container">

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -106,3 +106,9 @@ msgstr "Virhe sivulla"
 
 msgid "This value should be a number"
 msgstr "Arvon tulisi olla numero"
+
+msgid "Saved time"
+msgstr "Tallennusaika"
+
+msgid "Sent time"
+msgstr "Lähetysaika"

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -50,3 +50,9 @@ msgstr "Sammanfattning om din ansökan och handläggningsdetaljer."
 
 msgid "Print filled form"
 msgstr "Skriva ut den ifyllda ansökan"
+
+msgid "Saved time"
+msgstr "Inspelningstid"
+
+msgid "Sent time"
+msgstr "Sändningstid"


### PR DESCRIPTION
# [AU-1657](https://helsinkisolutionoffice.atlassian.net/browse/AU-1657)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout hotfix/ajax_formstate_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Test to spam ajax functions and the form




[AU-1657]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ