### PR TITLE
fix: AU-1670 add submission time to form status bar

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1210,9 +1210,18 @@ function grants_handler_preprocess_webform_submission_form(&$variables) {
     '#langcode' => $language,
     '#applicationID' => $submissionData["application_number"],
   ];
-  $date = $submissionData["form_timestamp_submitted"] ?: 'now';
-  $dt = new DateTime($date, new DateTimeZone('Europe/Helsinki'));
-  $variables['date'] = $dt->format('d.m.Y H:i');
+
+  if (isset($submissionData["form_timestamp"])) {
+    $date = $submissionData["form_timestamp"];
+    $dt = new DateTime($date, new DateTimeZone('Europe/Helsinki'));
+    $variables['date'] = $dt->format('d.m.Y H:i');
+  }
+
+  if (isset($submissionData["form_timestamp_submitted"])) {
+    $subDate = $submissionData["form_timestamp_submitted"];
+    $sdt = new DateTime($subDate, new DateTimeZone('Europe/Helsinki'));
+    $variables['subDate'] = $sdt->format('d.m.Y H:i');
+  }
 
   if ($route = $request->attributes->get(RouteObjectInterface::ROUTE_OBJECT)) {
     $title = \Drupal::service('title_resolver')->getTitle($request, $route);

--- a/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-form.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-form.html.twig
@@ -19,14 +19,26 @@
       {{ statusTag }}
       </div>
     </div>
-    <div class="application-list__status__item">
-      <div class="application-list__status__label">
-        {{ "Saved"|t }}
+    {% if date != '' %}
+      <div class="application-list__status__item">
+        <div class="application-list__status__label">
+          {{ "Saved time"|t }}
+        </div>
+        <div class="application-list__status__value">
+          <div>{{ date }}</div>
+        </div>
       </div>
-      <div class="application-list__status__value">
-        <div>{{ date }}</div>
+    {% endif %}
+    {% if subDate != '' %}
+      <div class="application-list__status__item">
+        <div class="application-list__status__label">
+          {{ "Sent time"|t }}
+        </div>
+        <div class="application-list__status__value">
+          <div>{{ subDate }}</div>
+        </div>
       </div>
-    </div>
+    {% endif %}
   </div>
 </div>
 <div class="container">

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -106,3 +106,9 @@ msgstr "Virhe sivulla"
 
 msgid "This value should be a number"
 msgstr "Arvon tulisi olla numero"
+
+msgid "Saved time"
+msgstr "Tallennusaika"
+
+msgid "Sent time"
+msgstr "Lähetysaika"

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -50,3 +50,9 @@ msgstr "Sammanfattning om din ansökan och handläggningsdetaljer."
 
 msgid "Print filled form"
 msgstr "Skriva ut den ifyllda ansökan"
+
+msgid "Saved time"
+msgstr "Inspelningstid"
+
+msgid "Sent time"
+msgstr "Sändningstid"


### PR DESCRIPTION
# [AU-1670](https://helsinkisolutionoffice.atlassian.net/browse/AU-1670)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Status bar timestamp now has two timestamps that display correct values

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1670-submission-date-to-statusbar`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Create a new form. See that the timestamp matches current time.
* [ ] Wait a minute or two and navigate to another webform wizard page. See that the timestamp matches the created time above.
* [ ] Save form as a draft and return to editing the form. See that the timestamp matches the time you saved the form at.
* [ ] Wait a minute or two and navigate to another webform wizard page on the form. See that the timestamp matches the saved time from the previous step
* [ ] Send the form and return to editing it. See that there is now a sent timestamp that matches the time you sent the form. And a saved timestamp that also matches the same time.
* [ ] Check that code follows our standards


[AU-1670]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ