### PR TITLE
fix: AU-1676: move translation of My applications from oma asiointi to handler (oma asiointi requires handler)

### DIFF
--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -554,3 +554,7 @@ msgstr "Tämän avustuksen hakuaika on päättynyt."
 msgctxt "grants_handler"
 msgid "You can no longer submit an application because the application period for this grant has closed."
 msgstr "Et voi enää lähettää hakemusta, sillä avustuksen hakuaika on päättynyt."
+
+msgctxt "grants_handler"
+msgid "My applications"
+msgstr "Omat hakemukset"

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -554,3 +554,7 @@ msgstr "Ansökningstiden för detta bidrag har löpt ut."
 msgctxt "grants_handler"
 msgid "You can no longer submit an application because the application period for this grant has closed."
 msgstr "Du kan inte längre skicka in denna ansökan eftersom att ansökningstiden har löpt ut."
+
+msgctxt "grants_handler"
+msgid "My applications"
+msgstr "Mina ansökningar"

--- a/public/modules/custom/grants_oma_asiointi/src/Controller/ApplicationsListController.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Controller/ApplicationsListController.php
@@ -179,7 +179,7 @@ class ApplicationsListController extends ControllerBase {
       '#theme' => 'application_list',
       '#items' => $applications,
       '#type' => 'all',
-      '#header' => $this->t('My applications', [], ['context' => 'grants_oma_asiointi']),
+      '#header' => $this->t('My applications', [], ['context' => 'grants_handler']),
       '#id' => 'applications__list',
       '#attached' => [
         'library' => [

--- a/public/modules/custom/grants_oma_asiointi/translations/fi.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/fi.po
@@ -25,10 +25,6 @@ msgid "Sent applications"
 msgstr "Lähetetyt hakemukset"
 
 msgctxt "grants_oma_asiointi"
-msgid "My applications"
-msgstr "Omat hakemukset"
-
-msgctxt "grants_oma_asiointi"
 msgid "My data"
 msgstr "Omat tiedot"
 

--- a/public/modules/custom/grants_oma_asiointi/translations/sv.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/sv.po
@@ -25,10 +25,6 @@ msgid "Sent applications"
 msgstr "Skickade ansökningar"
 
 msgctxt "grants_oma_asiointi"
-msgid "My applications"
-msgstr "Mina ansökningar"
-
-msgctxt "grants_oma_asiointi"
 msgid "My data"
 msgstr "Mina uppgifter"
 


### PR DESCRIPTION
# [AU-1676](https://helsinkisolutionoffice.atlassian.net/browse/AU-1676)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Translation of "My applications" was in oma asiointi module, but used in grants_handler as well, moved the translation upwards in food chain to handler module that is a requirement for oma asiointi

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-My-applications-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill an application. On the thank you page, see that the "My applications" button is translated to Finnish
* [ ] check for Swedish as well. 
* [ ] Check that code follows our standards


[AU-1676]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ