### PR TITLE
fix: AU-1651: Missing translation for Applications Helsinki

### DIFF
--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -574,3 +574,7 @@ msgstr "Vain yksi tiedosto.<br>Rajoitus: 20 MB.<br>Sallitut tiedostotyypit: doc,
 msgctxt "grants_handler"
 msgid "My applications"
 msgstr "Omat hakemukset"
+
+msgctxt "grants_handler"
+msgid "Applications Helsinki"
+msgstr "Hakemuksen käsittelijä"

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -574,3 +574,7 @@ msgstr "Bara en fil.<br>Limitation: 20 MB.<br>Tillåtna filtyper: doc, docx, gif
 msgctxt "grants_handler"
 msgid "My applications"
 msgstr "Mina ansökningar"
+
+msgctxt "grants_handler"
+msgid "Applications Helsinki"
+msgstr "Applikationshanterare"


### PR DESCRIPTION
# [AU-1651](https://helsinkisolutionoffice.atlassian.net/browse/AU-1651)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add missing translation

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1651-check-sender-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

[AU-1651]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ