### PR TITLE
fix: AU-1658: remove context from unversal texts in unregistered community info

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
+++ b/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
@@ -233,7 +233,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
 
     $elements['firstname'] = [
       '#type' => 'textfield',
-      '#title' => t('First name', [], $tOpts),
+      '#title' => t('First name'),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["firstName"],
@@ -244,7 +244,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     ];
     $elements['lastname'] = [
       '#type' => 'textfield',
-      '#title' => t('Last name', [], $tOpts),
+      '#title' => t('Last name'),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["lastName"],
@@ -254,7 +254,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     ];
     $elements['socialSecurityNumber'] = [
       '#type' => 'textfield',
-      '#title' => t('Social security number', [], $tOpts),
+      '#title' => t('Social security number'),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["nationalIdentificationNumber"],
@@ -264,7 +264,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     ];
     $elements['email'] = [
       '#type' => 'textfield',
-      '#title' => t('Email', [], $tOpts),
+      '#title' => t('Email'),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $userData["myProfile"]["primaryEmail"]["email"],
@@ -275,7 +275,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
 
     $elements['street'] = [
       '#type' => 'textfield',
-      '#title' => t('Street Address', [], $tOpts),
+      '#title' => t('Street Address'),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $profileContent["addresses"][0]["street"],
@@ -285,7 +285,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     ];
     $elements['city'] = [
       '#type' => 'textfield',
-      '#title' => t('City', [], $tOpts),
+      '#title' => t('City'),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $profileContent["addresses"][0]["city"],
@@ -295,7 +295,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     ];
     $elements['postCode'] = [
       '#type' => 'textfield',
-      '#title' => t('Postal Code', [], $tOpts),
+      '#title' => t('Postal Code'),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $profileContent["addresses"][0]["postCode"],
@@ -305,7 +305,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     ];
     $elements['country'] = [
       '#type' => 'textfield',
-      '#title' => t('Country', [], $tOpts),
+      '#title' => t('Country'),
       '#readonly' => TRUE,
       '#required' => FALSE,
       '#value' => $profileContent["addresses"][0]["country"],

--- a/public/modules/custom/grants_profile/templates/grants-profile--basic-info--private-person.html.twig
+++ b/public/modules/custom/grants_profile/templates/grants-profile--basic-info--private-person.html.twig
@@ -7,11 +7,11 @@
     <hr />
     <dl class="grants-profile--wrapper">
       <div class="grants-profile--wrapper-item">
-        <dt><strong>{{ "First name"|t({}, {'context': 'grants_profile'}) }}</strong></dt>
+        <dt><strong>{{ "First name"|t }}</strong></dt>
         <dd class="grants-profile--item grants-profile-company-name">{{ myProfile.verifiedPersonalInformation.firstName }}</dd>
       </div>
       <div class="grants-profile--wrapper-item">
-        <dt><strong>{{ "Last name"|t({}, {'context': 'grants_profile'}) }}</strong></dt>
+        <dt><strong>{{ "Last name"|t }}</strong></dt>
         <dd class="grants-profile-item">{{ myProfile.verifiedPersonalInformation.lastName }}</dd>
       </div>
       <div class="grants-profile--wrapper-item">
@@ -19,7 +19,7 @@
         <dd class="grants-profile-item">{{ myProfile.verifiedPersonalInformation.nationalIdentificationNumber }}</dd>
       </div>
       <div class="grants-profile--wrapper-item">
-        <dt><strong>{{ "Email"|t({}, {'context': 'grants_profile'}) }}</strong></dt>
+        <dt><strong>{{ "Email"|t }}</strong></dt>
         <dd class="grants-profile-item">{{ myProfile.primaryEmail.email }}</dd>
       </div>
     </dl>


### PR DESCRIPTION
# [AU-1658](https://helsinkisolutionoffice.atlassian.net/browse/AU-1658)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1658-omat-tiedot-translate`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that oma profiili as unregistered community translates to Finnish
* [ ] .. and Swedish
* [ ] Check that on an application, the haetut tiedot block translates to Finnish
* [ ] .. and Swedish
* [ ] Check that code follows our standards

[AU-1658]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ