### PR TITLE
feat: AU-1649: Check copyable budget fields from definition class.

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1283,10 +1283,8 @@ class ApplicationHandler {
     if (isset($submissionData["community_address"]["community_country"]) && !empty($submissionData["community_address"]["community_country"])) {
       $submissionData["community_country"] = $submissionData["community_address"]["community_country"];
     }
-    // Budget data defined e.g. in
-    // grants_metadata/src/TypedData/Definition/LiikuntaTapahtumaDefinition.
-    // or grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.
 
+    // Copy budget component fields into budgetInfo.
     if ($copy && isset($budgetInfoKeys)) {
       foreach ($budgetInfoKeys as $budgetKey) {
         if (isset($submissionData[$budgetKey])) {
@@ -2152,7 +2150,8 @@ class ApplicationHandler {
         $budgetInfoKeys = array_keys($budgetInfoDefinition->getPropertyDefinitions()) ?? [];
         return $budgetInfoKeys;
       }
-    } catch (\Exception $e) {
+    }
+    catch (\Exception $e) {
       return [];
     }
 

--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1215,6 +1215,7 @@ class ApplicationHandler {
     else {
       $copy = TRUE;
       $submissionData = self::clearDataForCopying($submissionData);
+      $budgetInfoKeys = $this->getBudgetInfoKeysForCopying($submissionData);
     }
 
     // Set.
@@ -1285,26 +1286,13 @@ class ApplicationHandler {
     // Budget data defined e.g. in
     // grants_metadata/src/TypedData/Definition/LiikuntaTapahtumaDefinition.
     // or grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.
-    if (isset($submissionData['budget_other_income'])) {
-      $submissionData['budgetInfo']['budget_other_income'] = $submissionData['budget_other_income'];
-    }
-    if (isset($submissionData['budget_other_cost'])) {
-      $submissionData['budgetInfo']['budget_other_cost'] = $submissionData['budget_other_cost'];
-    }
-    if (isset($submissionData['budget_static_income'])) {
-      $submissionData['budgetInfo']['budget_static_income'] = $submissionData['budget_static_income'];
-    }
-    if (isset($submissionData['budget_static_cost'])) {
-      $submissionData['budgetInfo']['budget_static_cost'] = $submissionData['budget_static_cost'];
-    }
-    if (isset($submissionData['menot_yhteensa'])) {
-      $submissionData['budgetInfo']['menot_yhteensa'] = $submissionData['menot_yhteensa'];
-    }
-    if (isset($submissionData['suunnitellut_menot'])) {
-      $submissionData['budgetInfo']['suunnitellut_menot'] = $submissionData['suunnitellut_menot'];
-    }
-    if (isset($submissionData['toteutuneet_tulot_data'])) {
-      $submissionData['budgetInfo']['toteutuneet_tulot_data'] = $submissionData['toteutuneet_tulot_data'];
+
+    if ($copy && isset($budgetInfoKeys)) {
+      foreach ($budgetInfoKeys as $budgetKey) {
+        if (isset($submissionData[$budgetKey])) {
+          $submissionData['budgetInfo'][$budgetKey] = $submissionData[$budgetKey];
+        }
+      }
     }
 
     try {
@@ -2140,6 +2128,35 @@ class ApplicationHandler {
       'PROD',
     ];
     return in_array($appEnv, $proenvs);
+  }
+
+  /**
+   * Get budgetInfo keys, that should be copied.
+   *
+   * @param array $submissionData
+   *   Submission data.
+   *
+   * @return array
+   *   Array containing the the keys to be copied.
+   */
+  private function getBudgetInfoKeysForCopying($submissionData) {
+    try {
+      $typeData = $this->webformToTypedData($submissionData);
+      /** @var \Drupal\Core\TypedData\ComplexDataDefinitionBase */
+      $dataDefinition = $typeData->getDataDefinition();
+      $propertyDefinitions = $dataDefinition->getPropertyDefinitions();
+
+      /** @var \Drupal\grants_budget_components\TypedData\Definition\GrantsBudgetInfoDefinition */
+      $budgetInfoDefinition = $propertyDefinitions['budgetInfo'] ?? NULL;
+      if ($budgetInfoDefinition) {
+        $budgetInfoKeys = array_keys($budgetInfoDefinition->getPropertyDefinitions()) ?? [];
+        return $budgetInfoKeys;
+      }
+    } catch (\Exception $e) {
+      return [];
+    }
+
+    return [];
   }
 
 }


### PR DESCRIPTION
# [AU-1649](https://helsinkisolutionoffice.atlassian.net/browse/AU-1649)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1649-budgetinfo-copy`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fully fill and send applications with a budget components.
* [ ] Copy the sent application and check that all budget components are being copied correctly



[AU-1649]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ