### PR TITLE
AU-1662: Insert 0 for all budget fields for ATV

### DIFF
--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -38,11 +38,7 @@ class GrantsBudgetComponentService {
 
       if (!in_array($itemName, self::IGNORED_FIELDS)) {
 
-        $value = GrantsHandler::convertToFloat($item->getValue()) ?? NULL;
-
-        if (!$value) {
-          continue;
-        }
+        $value = GrantsHandler::convertToFloat($item->getValue()) ?? '0';
 
         $items[] = [
           'ID' => $itemName,
@@ -70,16 +66,7 @@ class GrantsBudgetComponentService {
     foreach ($property as $itemIndex => $p) {
       $values = $p->getValue();
 
-      if (!isset($values['value'])) {
-        continue;
-      }
-
-      $value = GrantsHandler::convertToFloat($values['value']) ?? NULL;
-
-      if (!$value) {
-        continue;
-      }
-
+      $value = GrantsHandler::convertToFloat($values['value']) ?? '0';
       $itemValues = [
         'ID' => $property->getName() . '_' . $index,
         'label' => $values['label'] ?? NULL,
@@ -372,7 +359,6 @@ class GrantsBudgetComponentService {
         ],
       ],
     ];
-
     return $retval;
 
   }


### PR DESCRIPTION
# [AU-1662](https://helsinkisolutionoffice.atlassian.net/browse/AU-1662)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Insert 0 for all budget in order for data to appear in print preview.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1662-budget-in-print-review`
  * `make fresh`
* Run `make drush-cr`

## How to test
Start a new application with budget fields.
Save it as draft
Check that all necessary fields appear in print preview.

[AU-1662]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ