### PR TITLE
fix: AU-1666: Add webformDataExtracter to KuvaProjektiDefinition

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -578,6 +578,10 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
           'method' => 'processPremises',
           'webform' => TRUE,
         ])
+        ->setSetting('webformDataExtracter', [
+          'service' => 'grants_premises.service',
+          'method' => 'extractToWebformData',
+        ])
         ->setSetting('fieldsForApplication', [
           'premiseName',
           'isOwnedByCity',


### PR DESCRIPTION
# [AU-1666](https://helsinkisolutionoffice.atlassian.net/browse/AU-1666)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

KuvaProjektiDefinition class was missing a webformDataExtractor for the premises field, this caused information to be displayed as "true/false" strings to the end user.

Added the missing setting, to fix this problem

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1666-kuva-premise-missing-webform-extractor`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] [Open a new KUVA Projektiavustus application](https://hel-fi-drupal-grant-applications.docker.so/fi/form/taide-ja-kulttuuriavustukset-tai)
* [ ] Select page 4 and add a new element to "Muut tilat" field.
* [ ] Add required info to this element.
* [ ] Save document as draft
* [ ] Check the preview view and make sure that "Kyseessä on kaupungin omistama tila" shows Kyllä / EI - Yes / No instead of "true" or "false"




[AU-1666]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ