### PR TITLE
fix: AU-1684: Sort DRAFT status list

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1814,7 +1814,7 @@ class ApplicationHandler {
     }
     elseif ($sortByStatus === TRUE) {
       $applicationsSorted = [];
-      foreach($applications as $key => $value) {
+      foreach ($applications as $key => $value) {
         krsort($value);
         $applicationsSorted[$key] = $value;
       }

--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1796,7 +1796,7 @@ class ApplicationHandler {
           }
         }
         elseif ($sortByStatus === TRUE) {
-          $applications[$submissionData['status']][] = $submission;
+          $applications[$submissionData['status']][$ts] = $submission;
         }
         else {
           $applications[$ts] = $submission;
@@ -1811,6 +1811,15 @@ class ApplicationHandler {
         'finished' => $finished,
         'unifinished' => $unfinished,
       ];
+    }
+    elseif ($sortByStatus === TRUE) {
+      $applicationsSorted = [];
+      foreach($applications as $key => $value) {
+        krsort($value);
+        $applicationsSorted[$key] = $value;
+      }
+      ksort($applicationsSorted);
+      return $applicationsSorted;
     }
     else {
       ksort($applications);


### PR DESCRIPTION
# [AU-1684](https://helsinkisolutionoffice.atlassian.net/browse/AU-1684)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Sort applications lists that are sorted by status also by date

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1684-draft-order`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in. Save multiple different drafts of your forms
* [ ] Go to omat tiedot and see that the DRAFTS list is sorted by last saved date (newest first)
* [ ] See that the sorting of sent application still works (below the drafts list on the same page)
* [ ] Create an unregistered company
* [ ] Fill out an application (for example kuva project) and save as draft
* [ ] Delete the profile and see that you can do it
* [ ] Create another unregistered company
* [ ] Fill out an application and send it
* [ ] Try to delete the profile and see that you cannot do it (The application list function that was changed is used here)
* [ ] Check that code follows our standards


[AU-1684]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ