### PR TITLE
AU-1695: Change EN empty_string setting to -

### DIFF
--- a/conf/cmi/language/en/webform.settings.yml
+++ b/conf/cmi/language/en/webform.settings.yml
@@ -43,7 +43,7 @@ settings:
     wide:
       title: Wide
 element:
-  empty_message: '{Empty}'
+  empty_message: '-'
   default_more_title: More
   default_section_title_tag: h2
 file:


### PR DESCRIPTION
# [AU-1695](https://helsinkisolutionoffice.atlassian.net/browse/AU-1695)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Previews are showing empty fields as `{Empty}` when browsing on EN side.
* Changed the empty string to be `-`.
## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1695-empty-string-change`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Start a new application
* [ ] Go straight to the preview page and check that empty fields has `-` instead of `{Empty}` for empty fields.




[AU-1695]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ