### PR TITLE
fix: AU-1702: Liikunta laitos: Allow multiple subventions

### DIFF
--- a/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
@@ -233,7 +233,6 @@ elements: |-
           5: '5'
           8: '8'
           9: '9'
-        '#onlyOneSubventionPerApplication': 1
         '#required': true
         '#multiple__header': true
         '#multiple__empty_items': 0


### PR DESCRIPTION
# [AU-1702](https://helsinkisolutionoffice.atlassian.net/browse/AU-1702)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Limit was configured by a mistake to Liikunta laitos webform, removed this.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1702-fix-subvention-limit`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] [Open a new Liikunta, laitos- ja säätiöavustukset](https://hel-fi-drupal-grant-applications.docker.so/fi/form/liikunta-laitosavustushakemus)
* [ ] Go to page 2 and check that you can input values to multiple subvention types



[AU-1702]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ