### PR TITLE
fix: AU-1693: Add application number to DRAFTs in List

### DIFF
--- a/public/modules/custom/grants_handler/templates/application-list-item.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list-item.html.twig
@@ -46,6 +46,10 @@
           {{ applicationSubmittedSortable }}
         </div>
       </div>
+      <div class="application-list__item--number">
+        <h4>{{ "Application number"|t({}, {'context': 'grants_handler'})}}</h4>
+        {{ applicationNumber }}
+      </div>
       {% if (errorType == 'NOT_OPEN') %}
         <div class="hds-notification hds-notification--error">
           <div class="hds-notification__content">


### PR DESCRIPTION
# [AU-1693](https://helsinkisolutionoffice.atlassian.net/browse/AU-1693)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add Application Number to Drafts in application list on profile page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1693-draft-id-to-list`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to the Omat hakemukset ja viestintä page on profiili
* [ ] See that the Application list has application numbers in the draft cards
* [ ] See that this works on mobile as well
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR has been visually reviewed by a designer (Heikki)

[AU-1693]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ