### PR TITLE
feat: AU-1662 Budget components in print preview

### DIFF
--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -299,10 +299,10 @@ class GrantsWebformPrintController extends ControllerBase {
       }
     }
     if ($element['#type'] == 'grants_budget_other_cost' || $element['#type'] == 'grants_budget_other_income') {
-      $explanation = $element['#type'] == 'grants_budget_other_cost' ? 'Cost explanation' : 'Income explanation';
+      $explanation = $element['#type'] == 'grants_budget_other_cost' ? $this->t('Cost explanation', [], ['context' => 'grants_budget_components']) : $this->t('Income explanation', [], ['context' => 'grants_budget_components']);
       $element['#type'] = 'markup';
       $element['#markup'] = '<p><strong>' . $this->getTranslatedTitle($element, $translatedFields) . '</strong><br>';
-      $element['#markup'] .= $this->t($explanation, [], ['context' => 'grants_budget_components']);
+      $element['#markup'] .= $explanation;
       $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
       $element['#markup'] .= $this->t('Amount (€)', [], ['context' => 'grants_budget_components']);
       $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -6,6 +6,8 @@ namespace Drupal\grants_webform_print\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\grants_budget_components\Element\GrantsBudgetCostStatic;
+use Drupal\grants_budget_components\Element\GrantsBudgetIncomeStatic;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\WebformTranslationManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -268,6 +270,32 @@ class GrantsWebformPrintController extends ControllerBase {
           $element['#markup'] .= '▢ ' . $value . '<br>';
         }
         $element['#markup'] .= '<br></p>';
+      }
+    }
+    if ($element['#type'] === 'grants_budget_income_static') {
+      $element['#type'] = 'markup';
+      $element['#markup'] = '';
+      $fields = GrantsBudgetIncomeStatic::getFieldNames();
+      foreach ($fields as $name => $title) {
+        // This is fast and dirty way to filter fields.
+        if (isset($element['#' . $name . '__access']) && $element['#' . $name . '__access'] === FALSE) {
+          continue;
+        }
+        $element['#markup'] .= '<p><strong>' . $title . '</strong><br>';
+        $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
+      }
+    }
+    if ($element['#type'] === 'grants_budget_cost_static') {
+      $element['#type'] = 'markup';
+      $element['#markup'] = '';
+      $fields = GrantsBudgetCostStatic::getFieldNames();
+      foreach ($fields as $name => $title) {
+        // This is fast and dirty way to filter fields.
+        if (isset($element['#' . $name . '__access']) && $element['#' . $name . '__access'] === FALSE) {
+          continue;
+        }
+        $element['#markup'] .= '<p><strong>' . $title . '</strong><br>';
+        $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
       }
     }
 

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -298,6 +298,15 @@ class GrantsWebformPrintController extends ControllerBase {
         $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
       }
     }
+    if ($element['#type'] == 'grants_budget_other_cost' || $element['#type'] == 'grants_budget_other_income') {
+      $explanation = $element['#type'] == 'grants_budget_other_cost' ? 'Cost explanation' : 'Income explanation';
+      $element['#type'] = 'markup';
+      $element['#markup'] = '<p><strong>' . $this->getTranslatedTitle($element, $translatedFields) . '</strong><br>';
+      $element['#markup'] .= $this->t($explanation, [], ['context' => 'grants_budget_components']);
+      $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
+      $element['#markup'] .= $this->t('Amount (€)', [], ['context' => 'grants_budget_components']);
+      $element['#markup'] .= '<div class="hds-text-input__input-wrapper"><div class="hide-input form-text hds-text-input__input webform_large" type="text">&nbsp;</div></div>';
+    }
 
     // Loop translated fields.
     if (!empty($translatedFields[$key])) {


### PR DESCRIPTION
# [AU-1662](https://helsinkisolutionoffice.atlassian.net/browse/AU-1662)
<!-- What problem does this solve? -->

Tyhjän lomakkeen näkymässä budjettikentät eivät näkyneet.

## What was done
<!-- Describe what was done -->

Kovakoodaa kentät GrantsWebformPrintController luokkaan.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1662-preview-fields`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Täältä näkee other income / other cost kentät vierekkäin:
https://hel-fi-drupal-grant-applications.docker.so/fi/tietoja-avustuksista/liikunta_tapahtuma/tulosta

Ja static kentät täältä:
https://hel-fi-drupal-grant-applications.docker.so/fi/tietoja-avustuksista/kuva_projekti/tulosta


[AU-1662]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ