### PR TITLE
AU-1703: Change size field to allow decimals and fix data types

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -338,3 +338,8 @@ overridden_configuration:
         applicationOpen: '2022-10-03T11:08:26'
         applicationClose: '2029-07-30T11:19:00'
         disableCopying: 0
+  - 58:
+      grants_metadata:
+        applicationOpen: '2022-10-03T11:08:26'
+        applicationClose: '2029-07-30T11:19:00'
+        disableCopying: 0

--- a/public/modules/custom/grants_orienteering_map/src/Element/OrienteeringMapComposite.php
+++ b/public/modules/custom/grants_orienteering_map/src/Element/OrienteeringMapComposite.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\grants_orienteering_map\Element;
 
+use Drupal\grants_handler\Processor\NumberProcessor;
 use Drupal\webform\Element\WebformCompositeBase;
 
 /**
@@ -42,22 +43,34 @@ class OrienteeringMapComposite extends WebformCompositeBase {
     $elements['size'] = [
       '#type' => 'number',
       '#title' => t('Size in km2', [], $tOpts),
-      '#step' => 1,
+      '#process' => [
+        [NumberProcessor::class, 'process'],
+      ],
     ];
 
     $elements['voluntaryHours'] = [
       '#type' => 'number',
       '#title' => t('Informal voluntary work in hours', [], $tOpts),
+      '#step' => 1,
+      '#process' => [
+        [NumberProcessor::class, 'process'],
+      ],
     ];
 
     $elements['cost'] = [
       '#type' => 'number',
       '#title' => t('Costs in euros', [], $tOpts),
+      '#process' => [
+        [NumberProcessor::class, 'process'],
+      ],
     ];
 
     $elements['otherCompensations'] = [
       '#type' => 'number',
       '#title' => t('Grants received from others in euros', [], $tOpts),
+      '#process' => [
+        [NumberProcessor::class, 'process'],
+      ],
     ];
 
     return $elements;

--- a/public/modules/custom/grants_orienteering_map/src/TypedData/Definition/OrienteeringMapDefinition.php
+++ b/public/modules/custom/grants_orienteering_map/src/TypedData/Definition/OrienteeringMapDefinition.php
@@ -19,35 +19,26 @@ class OrienteeringMapDefinition extends ComplexDataDefinitionBase {
       $info = &$this->propertyDefinitions;
 
       $info['mapName'] = DataDefinition::create('string')
-        ->setLabel('Sijainnin nimi')
         ->setSetting('jsonPath', [
           'mapName',
         ]);
 
-      $info['size'] = DataDefinition::create('string')
-        ->setLabel('Sijainnin nimi')
+      $info['size'] = DataDefinition::create('float')
         ->setSetting('jsonPath', [
           'size',
         ])
-        ->setSetting('typeOverride', [
-          'dataType' => 'string',
-          'jsonType' => 'double',
-        ]);
-
-      $info['voluntaryHours'] = DataDefinition::create('string')
-        ->setLabel('Sijainnin nimi')
-        ->setSetting('jsonPath', [
-          'voluntaryHours',
+        ->setSetting('valueCallback', [
+          '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
+          'convertToFloat',
         ])
         ->setSetting('typeOverride', [
           'dataType' => 'string',
           'jsonType' => 'double',
         ]);
 
-      $info['cost'] = DataDefinition::create('integer')
-        ->setLabel('Sijainnin nimi')
+      $info['voluntaryHours'] = DataDefinition::create('integer')
         ->setSetting('jsonPath', [
-          'cost',
+          'voluntaryHours',
         ])
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
@@ -58,10 +49,26 @@ class OrienteeringMapDefinition extends ComplexDataDefinitionBase {
           'jsonType' => 'int',
         ]);
 
-      $info['otherCompensations'] = DataDefinition::create('string')
-        ->setLabel('Sijainnin nimi')
+      $info['cost'] = DataDefinition::create('float')
+        ->setSetting('jsonPath', [
+          'cost',
+        ])
+        ->setSetting('valueCallback', [
+          '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
+          'convertToFloat',
+        ])
+        ->setSetting('typeOverride', [
+          'dataType' => 'string',
+          'jsonType' => 'double',
+        ]);
+
+      $info['otherCompensations'] = DataDefinition::create('float')
         ->setSetting('jsonPath', [
           'otherCompensations',
+        ])
+        ->setSetting('valueCallback', [
+          '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
+          'convertToFloat',
         ])
         ->setSetting('typeOverride', [
           'dataType' => 'string',


### PR DESCRIPTION
# [AU-1703](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done

* Fixed orienteering map component to allow decimals on the size field.
* Fixed data types

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1703-fix-orienteering-application`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] [Open a new Liikunta, suunnistuskartta-avustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/liikunta-suunnistuskartta-avustu)
* [ ] Fill the application and make sure you can enter decimals on the orienteering map fields (Except name & voluntaryHours)
* [ ] **OBS**: Integration is doing some math based on the orienteering map values and if you enter low cost and high other compensations, sending will fail -> Maybe we need to do something later or maybe avus2/integration resolve the negative compensation value.



[AU-1703]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ