### PR TITLE
fix: AU-1694: Do not escape json for ATV

### DIFF
--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -431,7 +431,7 @@ class GrantsBudgetComponentService {
         'label' => $label,
       ];
 
-      $value['meta'] = json_encode(AtvSchema::getMetaData($page, $section, $element));
+      $value['meta'] = json_encode(AtvSchema::getMetaData($page, $section, $element), JSON_UNESCAPED_UNICODE);
 
     }
 

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -556,7 +556,7 @@ class AtvSchema {
               ];
               $elementWeight++;
               $metaData = self::getMetaData($page, $section, $element);
-              $structureArray["compensation"][$propertyArrayKey][$propertyKey]['meta'] = json_encode($metaData);
+              $structureArray["compensation"][$propertyArrayKey][$propertyKey]['meta'] = json_encode($metaData, JSON_UNESCAPED_UNICODE);
             }
           }
           $documentStructure = array_merge_recursive(
@@ -681,7 +681,7 @@ class AtvSchema {
               'value' => $itemValue,
               'valueType' => $itemTypes['jsonType'],
               'label' => $label,
-              'meta' => json_encode($metaData),
+              'meta' => json_encode($metaData, JSON_UNESCAPED_UNICODE),
             ];
             $documentStructure[$jsonPath[0]][$jsonPath[1]][$jsonPath[2]][$jsonPath[3]][] = $valueArray;
             $addedElements[$numberOfItems][] = $elementName;
@@ -747,7 +747,7 @@ class AtvSchema {
                         'value' => $itemValue,
                         'valueType' => $itemTypes['jsonType'],
                         'label' => $label,
-                        'meta' => json_encode($metaData),
+                        'meta' => json_encode($metaData, JSON_UNESCAPED_UNICODE),
                       ];
                       $fieldValues[] = $valueArray;
                     }
@@ -764,7 +764,7 @@ class AtvSchema {
               'value' => $itemValue,
               'valueType' => $itemTypes['jsonType'],
               'label' => $label,
-              'meta' => json_encode($metaData),
+              'meta' => json_encode($metaData, JSON_UNESCAPED_UNICODE),
             ];
             $documentStructure[$jsonPath[0]][$jsonPath[1]][$jsonPath[2]][] = $valueArray;
             $addedElements[$numberOfItems][] = $elementName;
@@ -835,7 +835,7 @@ class AtvSchema {
                         'value' => $itemValue,
                         'valueType' => $itemTypes['jsonType'],
                         'label' => $label,
-                        'meta' => json_encode($metaData),
+                        'meta' => json_encode($metaData, JSON_UNESCAPED_UNICODE),
                       ];
                       $fieldValues[] = $valueArray;
                     }
@@ -852,7 +852,7 @@ class AtvSchema {
               'value' => $itemValue,
               'valueType' => $itemTypes['jsonType'],
               'label' => $label,
-              'meta' => json_encode($metaData),
+              'meta' => json_encode($metaData, JSON_UNESCAPED_UNICODE),
             ];
             if ($schema['type'] == 'number') {
               if ($itemValue == NULL) {
@@ -931,7 +931,7 @@ class AtvSchema {
                       'value' => $itemValue,
                       'valueType' => $itemTypes['jsonType'],
                       'label' => $label,
-                      'meta' => json_encode($metaData),
+                      'meta' => json_encode($metaData, JSON_UNESCAPED_UNICODE),
                     ];
                     $fieldValues[] = $valueArray;
                   }
@@ -946,7 +946,7 @@ class AtvSchema {
               'value' => $itemValue,
               'valueType' => $itemTypes['jsonType'],
               'label' => $label,
-              'meta' => json_encode($metaData),
+              'meta' => json_encode($metaData, JSON_UNESCAPED_UNICODE),
             ];
             if ($schema['type'] == 'string') {
               $documentStructure[$jsonPath[$baseIndex - 1]][$elementName] = $itemValue;

--- a/public/modules/custom/grants_place_of_operation/src/PlaceOfOperationService.php
+++ b/public/modules/custom/grants_place_of_operation/src/PlaceOfOperationService.php
@@ -62,7 +62,7 @@ class PlaceOfOperationService {
         $elementMeta = self::getMeta($itemDefinition);
         $completeMeta = json_encode(AtvSchema::getMetaData(
           $pageMeta, $sectionMeta, $elementMeta,
-        ));
+        ), JSON_UNESCAPED_UNICODE);
 
         // Process boolean values separately.
         if ($itemName == 'free') {

--- a/public/modules/custom/grants_premises/src/GrantsPremisesService.php
+++ b/public/modules/custom/grants_premises/src/GrantsPremisesService.php
@@ -64,7 +64,7 @@ class GrantsPremisesService {
         $elementMeta = self::getMeta($itemDefinition);
         $completeMeta = json_encode(AtvSchema::getMetaData(
           $pageMeta, $sectionMeta, $elementMeta,
-        ));
+        ), JSON_UNESCAPED_UNICODE);
 
         // Process boolean values separately.
         if (


### PR DESCRIPTION
# [AU-1694](https://helsinkisolutionoffice.atlassian.net/browse/AU-1694)
<!-- What problem does this solve? -->

Ei lähetellä epävalidia JSONia ympäriinsä

## What was done
<!-- Describe what was done -->

Laita json_encode-funktiolle sopiva flägi. Ääkköset pysyvät ääkkösinä eikä erityisiä enkoodauksia tarvita. 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1694-invalid-json`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Tällä ei ole suoraa vaikutusta Drupalin toimintaan. PHP on käsitellyt aiemmin itse luomansa JSONin kitinöittä.

JSONia voi tarkastella ATVSchemassa, tulostusvaiheessa tai vaikkapa suoraan ATV:ssä.


[AU-1694]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ