### PR TITLE
test: AU-1671: Allow multiple sessions in non-production environments

### DIFF
--- a/public/sites/default/development.settings.php
+++ b/public/sites/default/development.settings.php
@@ -1,3 +1,5 @@
 <?php
 
 $config['grants_mandate.settings']['extra_access_roles'] = ['NIMKO'];
+// Allow multiple sessions for smoother test process.
+$config['session_limit.settings']['session_limit_roles']['helsinkiprofiili'] = 5;

--- a/public/sites/default/staging.settings.php
+++ b/public/sites/default/staging.settings.php
@@ -1,2 +1,4 @@
 <?php
 $config['grants_mandate.settings']['extra_access_roles'] = ['NIMKO'];
+// Allow multiple sessions for smoother test process.
+$config['session_limit.settings']['session_limit_roles']['helsinkiprofiili'] = 5;

--- a/public/sites/default/testing.settings.php
+++ b/public/sites/default/testing.settings.php
@@ -1,2 +1,4 @@
 <?php
 $config['grants_mandate.settings']['extra_access_roles'] = ['NIMKO'];
+// Allow multiple sessions for smoother test process.
+$config['session_limit.settings']['session_limit_roles']['helsinkiprofiili'] = 5;


### PR DESCRIPTION
This is for testing purposes

# [AU-1671](https://helsinkisolutionoffice.atlassian.net/browse/AU-1671)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

No need to do local install.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Current behaviour:
Login with tunnistamo
Take another browser or private window
Login again with tunnistamo with same user
First session is killed and message is shown

Insert the code `$config['session_limit.settings']['session_limit_roles']['helsinkiprofiili'] = 5;` in your `local.settings.php`

Login with tunnistamo
Take another browser or private window
Login again with tunnistamo
Now first session stays alive



[AU-1671]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ