### PR TITLE
fix: AU-1706: Allow multiple subventions on Työllisyysavustus

### DIFF
--- a/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -226,7 +226,6 @@ elements: |-
         '#subventionType':
           1: '1'
           17: '17'
-        '#onlyOneSubventionPerApplication': 1
         '#required': true
         '#multiple__header': true
         '#multiple__empty_items': 0
@@ -243,9 +242,6 @@ elements: |-
         '#subvention_type_id__access': false
         '#subvention_type__title': Avustuslaji
         '#subvention_amount__title': 'Avustuksen summa'
-      markup_01:
-        '#type': webform_markup
-        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
     kayttotarkoitus:
       '#type': webform_section
       '#title': Käyttötarkoitus


### PR DESCRIPTION
# [AU-1706](https://helsinkisolutionoffice.atlassian.net/browse/AU-1706)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Työllisyysavustus can have multiple subvention types

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1706-työllisyysavustus-multiple-subventions`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Työllisyysavustus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kaupunginkanslia_tyollisyysavust)
* [ ] See that on page 2, you can add multiple values to the subvention types table and there is no markup about only one subvention per application
* [ ] Check that code follows our standards


[AU-1706]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ