### PR TITLE
fix: AU-1078: Postal code validation

### DIFF
--- a/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
@@ -3,7 +3,7 @@
 namespace Drupal\grants_place_of_operation\Element;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCodeValidator;
 use Drupal\webform\Element\WebformCompositeBase;
 
 /**
@@ -71,7 +71,7 @@ class PlaceOfOperationComposite extends WebformCompositeBase {
       '#type' => 'textfield',
       '#title' => t('Post Code', [], $tOpts),
       '#maxlength' => 8,
-      '#pattern' => ValidPostalCode::$postalCodePattern,
+      '#pattern' => ValidPostalCodeValidator::$postalCodePattern,
       '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
       '#suffix' => '</div>',
       '#wrapper_attributes' => [

--- a/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
@@ -3,6 +3,7 @@
 namespace Drupal\grants_place_of_operation\Element;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
 use Drupal\webform\Element\WebformCompositeBase;
 
 /**
@@ -70,7 +71,7 @@ class PlaceOfOperationComposite extends WebformCompositeBase {
       '#type' => 'textfield',
       '#title' => t('Post Code', [], $tOpts),
       '#maxlength' => 8,
-      '#pattern' => '^(FI-)?[0-9]{5}$',
+      '#pattern' => ValidPostalCode::$postalCodePattern,
       '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
       '#suffix' => '</div>',
       '#wrapper_attributes' => [

--- a/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
@@ -4,7 +4,7 @@ namespace Drupal\grants_premises\Element;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCodeValidator;
 use Drupal\webform\Element\WebformCompositeBase;
 
 /**
@@ -74,7 +74,7 @@ class PremisesComposite extends WebformCompositeBase {
       '#title' => t('Post Code', [], $tOpts),
       '#size' => 10,
       '#maxlength' => 8,
-      '#pattern' => ValidPostalCode::$postalCodePattern,
+      '#pattern' => ValidPostalCodeValidator::$postalCodePattern,
       '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
       '#required' => TRUE,
     ];

--- a/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
@@ -4,6 +4,7 @@ namespace Drupal\grants_premises\Element;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
 use Drupal\webform\Element\WebformCompositeBase;
 
 /**
@@ -73,7 +74,7 @@ class PremisesComposite extends WebformCompositeBase {
       '#title' => t('Post Code', [], $tOpts),
       '#size' => 10,
       '#maxlength' => 8,
-      '#pattern' => '^(FI-)?[0-9]{5}$',
+      '#pattern' => ValidPostalCode::$postalCodePattern,
       '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
       '#required' => TRUE,
     ];

--- a/public/modules/custom/grants_profile/grants_profile.libraries.yml
+++ b/public/modules/custom/grants_profile/grants_profile.libraries.yml
@@ -4,3 +4,9 @@ profile_dialog:
     js/profile_dialog.js: {}
   depencies:
     - core/jquery
+
+pattern_error:
+  js:
+    js/pattern_error.js: { }
+  dependencies:
+    - core/drupal

--- a/public/modules/custom/grants_profile/js/pattern_error.js
+++ b/public/modules/custom/grants_profile/js/pattern_error.js
@@ -1,0 +1,30 @@
+(function (Drupal) {
+
+  'use strict';
+
+  /**
+   * The patternError behavior.
+   *
+   * This behavior adds custom error messages to inputs
+   * that have defined a data-pattern-error error message.
+   */
+  Drupal.behaviors.patternError = {
+    attach: function(context, settings) {
+
+      const inputsWithCustomErrors = document.querySelectorAll('[data-pattern-error]');
+
+      inputsWithCustomErrors.forEach(input => {
+        const errorMessage = input.getAttribute('data-pattern-error');
+
+        input.addEventListener('invalid', function(event) {
+          event.target.setCustomValidity(errorMessage);
+        });
+
+        input.addEventListener('input', function(event) {
+          event.target.setCustomValidity('');
+        });
+      });
+
+    }
+  };
+})(Drupal);

--- a/public/modules/custom/grants_profile/js/pattern_error.js
+++ b/public/modules/custom/grants_profile/js/pattern_error.js
@@ -5,8 +5,10 @@
   /**
    * The patternError behavior.
    *
-   * This behavior adds custom error messages to inputs
+   * This behavior adds a custom error messages to inputs
    * that have defined a data-pattern-error error message.
+   * The message is displayed by the browser if an inputs #pattern
+   * fails to validate.
    */
   Drupal.behaviors.patternError = {
     attach: function(context, settings) {

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
@@ -280,6 +280,9 @@ abstract class GrantsProfileFormBase extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $tOpts = ['context' => 'grants_profile'];
 
+    // Attach pattern error library.
+    $form['#attached']['library'][] = 'grants_profile/pattern_error';
+
     $form['actions'] = [
       '#type' => 'actions',
     ];

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -6,7 +6,7 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\grants_profile\GrantsProfileService;
-use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCodeValidator;
 use Drupal\grants_profile\TypedData\Definition\GrantsProfileRegisteredCommunityDefinition;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvFailedToConnectException;
@@ -658,7 +658,7 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
         '#required' => TRUE,
         '#title' => $this->t('Postal code', [], $tOpts),
         '#default_value' => $address['postCode'],
-        '#pattern' => ValidPostalCode::$postalCodePattern,
+        '#pattern' => ValidPostalCodeValidator::$postalCodePattern,
         '#maxlength' => 8,
         '#attributes' => [
           'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
@@ -708,7 +708,7 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
             '#type' => 'textfield',
             '#required' => TRUE,
             '#title' => $this->t('Postal code', [], $tOpts),
-            '#pattern' => ValidPostalCode::$postalCodePattern,
+            '#pattern' => ValidPostalCodeValidator::$postalCodePattern,
             '#maxlength' => 8,
             '#attributes' => [
               'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -6,6 +6,7 @@ use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\grants_profile\GrantsProfileService;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
 use Drupal\grants_profile\TypedData\Definition\GrantsProfileRegisteredCommunityDefinition;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvFailedToConnectException;
@@ -657,6 +658,11 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
         '#required' => TRUE,
         '#title' => $this->t('Postal code', [], $tOpts),
         '#default_value' => $address['postCode'],
+        '#pattern' => ValidPostalCode::$postalCodePattern,
+        '#maxlength' => 8,
+        '#attributes' => [
+          'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
+        ],
       ];
       $form['addressWrapper'][$delta]['address']['city'] = [
         '#type' => 'textfield',
@@ -702,6 +708,11 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
             '#type' => 'textfield',
             '#required' => TRUE,
             '#title' => $this->t('Postal code', [], $tOpts),
+            '#pattern' => ValidPostalCode::$postalCodePattern,
+            '#maxlength' => 8,
+            '#attributes' => [
+              'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
+            ],
           ],
           'city' => [
             '#type' => 'textfield',

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -9,6 +9,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\TypedData\TypedDataManager;
 use Drupal\Core\Url;
 use Drupal\grants_profile\GrantsProfileService;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
 use Drupal\grants_profile\TypedData\Definition\GrantsProfileUnregisteredCommunityDefinition;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvFailedToConnectException;
@@ -626,6 +627,11 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
         '#required' => TRUE,
         '#title' => $this->t('Postal code', [], $tOpts),
         '#default_value' => $address['postCode'],
+        '#pattern' => ValidPostalCode::$postalCodePattern,
+        '#maxlength' => 8,
+        '#attributes' => [
+          'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
+        ],
       ];
       $form['addressWrapper'][$delta]['address']['city'] = [
         '#type' => 'textfield',
@@ -664,6 +670,11 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
             '#type' => 'textfield',
             '#required' => TRUE,
             '#title' => $this->t('Postal code', [], $tOpts),
+            '#pattern' => ValidPostalCode::$postalCodePattern,
+            '#maxlength' => 8,
+            '#attributes' => [
+              'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
+            ],
           ],
           'city' => [
             '#type' => 'textfield',

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -9,7 +9,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\TypedData\TypedDataManager;
 use Drupal\Core\Url;
 use Drupal\grants_profile\GrantsProfileService;
-use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCode;
+use Drupal\grants_profile\Plugin\Validation\Constraint\ValidPostalCodeValidator;
 use Drupal\grants_profile\TypedData\Definition\GrantsProfileUnregisteredCommunityDefinition;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvFailedToConnectException;
@@ -627,7 +627,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
         '#required' => TRUE,
         '#title' => $this->t('Postal code', [], $tOpts),
         '#default_value' => $address['postCode'],
-        '#pattern' => ValidPostalCode::$postalCodePattern,
+        '#pattern' => ValidPostalCodeValidator::$postalCodePattern,
         '#maxlength' => 8,
         '#attributes' => [
           'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
@@ -670,7 +670,7 @@ class GrantsProfileFormUnregisteredCommunity extends GrantsProfileFormBase {
             '#type' => 'textfield',
             '#required' => TRUE,
             '#title' => $this->t('Postal code', [], $tOpts),
-            '#pattern' => ValidPostalCode::$postalCodePattern,
+            '#pattern' => ValidPostalCodeValidator::$postalCodePattern,
             '#maxlength' => 8,
             '#attributes' => [
               'data-pattern-error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),

--- a/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCode.php
+++ b/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCode.php
@@ -22,11 +22,4 @@ class ValidPostalCode extends Constraint {
    */
   public string $notValidPostalCode = '%value is not valid Finnish postal code';
 
-  /**
-   * The postal code pattern.
-   *
-   * @var string
-   */
-  public static string $postalCodePattern = '^(FI-)?[0-9]{5}$';
-
 }

--- a/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCode.php
+++ b/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCode.php
@@ -22,4 +22,11 @@ class ValidPostalCode extends Constraint {
    */
   public string $notValidPostalCode = '%value is not valid Finnish postal code';
 
+  /**
+   * The postal code pattern.
+   *
+   * @var string
+   */
+  public static string $postalCodePattern = '^(FI-)?[0-9]{5}$';
+
 }

--- a/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCodeValidator.php
+++ b/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCodeValidator.php
@@ -5,16 +5,22 @@ namespace Drupal\grants_profile\Plugin\Validation\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
- * Validates the ValidIban constraint.
+ * Validates the ValidPostalCode constraint.
  */
 class ValidPostalCodeValidator extends ConstraintValidator {
+
+  /**
+   * The postal code pattern to validate against.
+   *
+   * @var string
+   */
+  public static string $postalCodePattern = '^(FI-)?[0-9]{5}$';
 
   /**
    * {@inheritdoc}
    */
   public function validate($value, $constraint) {
     if ($value !== NULL && !$this->isValidPostalCode($value)) {
-
       $this->context->addViolation($constraint->notValidPostalCode, ['%value' => $value]);
     }
   }
@@ -29,7 +35,7 @@ class ValidPostalCodeValidator extends ConstraintValidator {
    *   Is postal code valid.
    */
   private function isValidPostalCode(?string $value): bool {
-    return (bool) preg_match("/^(FI-)?[0-9]{5}$/", $value);
+    return (bool) preg_match("/" . self::$postalCodePattern . "/", $value);
   }
 
 }

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -571,3 +571,7 @@ msgstr "Muokkaa omaa profiilia"
 
 msgid "Remove Application Profile"
 msgstr "Poista oma profiili"
+
+msgctxt "grants_profile"
+msgid "Use the format FI-XXXXX or enter a five-digit postcode."
+msgstr "Käytä muotoa FI-XXXXX tai syötä postinumero viisinumeroisena."

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -528,3 +528,7 @@ msgstr "Redigera min profil"
 
 msgid "Remove Application Profile"
 msgstr "Radera min profil"
+
+msgctxt "grants_profile"
+msgid "Use the format FI-XXXXX or enter a five-digit postcode."
+msgstr "Använd formen FI-XXXXX eller ange ett femsiffrigt postnummer."


### PR DESCRIPTION
# [AU-1078](https://helsinkisolutionoffice.atlassian.net/browse/AU-1078)

## What was done
This pull request implements "pattern" validation to postal code fields on registered- and unregistered community user profiles. Since the `#pattern_error` attribute is functionality provided by the Webform module and not natively supported by HTML5, a custom `patternError` behavior has been created. The behavior scans for inputs with a `data-pattern-error` attribute, and displays an error message contained in said attribute if the input in question fails to validate against its pattern.

In addition to this, a static `$postalCodePattern` attribute has been added to the `ValidPostalCodeValidator` class. This attribute is now used across all postal code fields when performing the pattern validation.

## How to install

Make sure your instance is up and running on the correct branch.
  * `git checkout feature/AU-1078-postal-code-validation`
  * `make fresh`
  * `make drush-cr`
  * `make shell -> drush locale:check; drush locale:update; drush cr`

## How to test
- Login with a test user and start by testing the unregistered community role. Go to the "[My data](https://hel-fi-drupal-grant-applications.docker.so/oma-asiointi/hakuprofiili/muokkaa)" -page and verify that you are only able to enter valid postal codes (FI-XXXXX OR 12345).

- Do exactly the same test with the registered community role.

- Test that the postal code pattern validation works in the `Place of operation` composite component. The component can be tested with the **Kasvatus ja koulutus: toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille** form.

- Test that the postal code pattern validation works in the `Premises` composite component. The component can be tested with the **Taide- ja kulttuuriavustukset: toiminta-avustukset** form.

[AU-1078]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ