### PR TITLE
fix: AU-1701: move preview link to the blue box

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -213,6 +213,7 @@ function grants_handler_theme(): array {
     'grants_service_page_block' => [
       'render element' => 'build',
       'variables' => [
+        'webformLink' => NULL,
         'link' => NULL,
         'text' => NULL,
         'auth' => NULL,

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -181,11 +181,27 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
       $text = $this->t('You do not have the necessary authorizations to make an application. Log in to grants service.', [], $tOpts);
     }
 
+    $node = \Drupal::routeMatch()->getParameter('node');
+    $webformArray = $node->get('field_webform')->getValue();
+
+    if ($webformArray) {
+      $webformName = $webformArray[0]['target_id'];
+
+      $webformLink = Url::fromRoute('grants_webform_print.print_webform',
+        [
+          'webform' => $webformName,
+        ]);
+    }
+    else {
+      $webformLink = NULL;
+    }
+
     $build['content'] = [
       '#theme' => 'grants_service_page_block',
       '#applicantType' => $isCorrectApplicantType,
       '#link' => $link,
       '#text' => $text,
+      '#webformLink' => $webformLink,
       '#auth' => 'anon',
     ];
 

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
@@ -116,11 +116,27 @@ class ServicePageAuthBlock extends BlockBase implements ContainerFactoryPluginIn
 
     $text = $this->t('Please familiarize yourself with the instructions on this page before proceeding to the application.', [], $tOpts);
 
+    $node = \Drupal::routeMatch()->getParameter('node');
+    $webformArray = $node->get('field_webform')->getValue();
+
+    if ($webformArray) {
+      $webformName = $webformArray[0]['target_id'];
+
+      $webformLink = Url::fromRoute('grants_webform_print.print_webform',
+        [
+          'webform' => $webformName,
+        ]);
+    }
+    else {
+      $webformLink = NULL;
+    }
+
     $build['content'] = [
       '#theme' => 'grants_service_page_block',
       '#link' => $link,
       '#text' => $text,
       '#auth' => 'auth',
+      '#webformLink' => $webformLink,
     ];
 
     $build['#cache']['contexts'] = [

--- a/public/modules/custom/grants_handler/templates/grants-service-page-block.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-service-page-block.html.twig
@@ -11,4 +11,10 @@
 <h3><span class="hel-icon hel-icon--{{ icon }}-circle hel-icon--size-s" aria-hidden="true"></span> {{ title }}</h3>
 <p>{{ text }}</p>
 {{ link }}
+{% if webformLink %}
+    <a href="{{ webformLink }}" class="hds-button hds-button--supplementary">
+      <span class="hds-button__label">{{ "Preview the application"|t({}, {'context': 'grants_preview_link'}) }}</span>
+      <span aria-hidden="true" class="hds-icon hds-icon--arrow-right"></span>
+    </a>
+{% endif %}
 </div>

--- a/public/modules/custom/grants_preview_link/grants_preview_link.module
+++ b/public/modules/custom/grants_preview_link/grants_preview_link.module
@@ -16,7 +16,6 @@ function grants_preview_link_theme() {
   return [
     'grants_preview_link' => [
       'variables' => [
-        'webformLink' => NULL,
         'allowanceLink' => NULL,
       ],
     ],

--- a/public/modules/custom/grants_preview_link/src/Plugin/Block/GrantsPreviewLinkBlock.php
+++ b/public/modules/custom/grants_preview_link/src/Plugin/Block/GrantsPreviewLinkBlock.php
@@ -23,28 +23,12 @@ class GrantsPreviewLinkBlock extends BlockBase {
    */
   public function build() {
 
-    $node = \Drupal::routeMatch()->getParameter('node');
-    $webformArray = $node->get('field_webform')->getValue();
-
-    if ($webformArray) {
-      $webformName = $webformArray[0]['target_id'];
-
-      $link = Url::fromRoute('grants_webform_print.print_webform',
-      [
-        'webform' => $webformName,
-      ]);
-    }
-    else {
-      $link = NULL;
-    }
-
     $allowanceOptions = ['absolute' => TRUE];
     $allowanceUrl = Url::fromRoute('entity.node.canonical', ['node' => 43], $allowanceOptions);
     $allowanceUrl = $allowanceUrl->toString();
 
     $build = [
       '#theme' => 'grants_preview_link',
-      '#webformLink' => $link,
       '#allowanceLink' => $allowanceUrl,
     ];
     return $build;

--- a/public/modules/custom/grants_preview_link/templates/grants-preview-link.html.twig
+++ b/public/modules/custom/grants_preview_link/templates/grants-preview-link.html.twig
@@ -2,10 +2,12 @@
   <div class="sidebar-text sidebar-text--full has-title">
     <h2 class="sidebar-text__title">{{ 'Important links'|t({}, {'context': 'grants_preview_link'}) }}</h2>
     <div class="sidebar-text__text-content">
-      <p><a href="{{ allowanceLink }}">{{ "Allowance terms"|t({}, {'context': 'grants_preview_link'}) }}</a></p>
-      {% if webformLink %}
-        <p><a href="{{ webformLink }}">{{ "Preview the application"|t({}, {'context': 'grants_preview_link'}) }}</a></p>
-      {% endif %}
+      <p>
+        <a href="{{ allowanceLink }}" class="hds-button hds-button--supplementary">
+          <span class="hds-button__label">{{ "Allowance terms"|t({}, {'context': 'grants_preview_link'}) }}</span>
+          <span aria-hidden="true" class="hds-icon hds-icon--arrow-right"></span>
+        </a>
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# [AU-1701](https://helsinkisolutionoffice.atlassian.net/browse/AU-1701)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved the preview link from the link list to the new application box in the left panel of TPR page.
 
## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1701-preview-link-to-blue-box`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to a [TPR page](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/liikunnan-avustukset/avustus-liikunnan-vuoden-2023-jaljella-olevasta).
* [ ] See that the preview link works in the "new application" block.
* [ ] Check that code follows our standards

[AU-1701]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ