### PR TITLE
fix: AU-1714: Add info on the role of the user to asiointirooli-block

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.module
+++ b/public/modules/custom/grants_oma_asiointi/grants_oma_asiointi.module
@@ -41,9 +41,8 @@ function grants_oma_asiointi_theme() {
   $theme['grants_oma_asiointi_asiointirooli_block'] = [
     'render element' => 'build',
     'variables' => [
-      'companyName' => NULL,
       'switchRole' => NULL,
-      'logOut' => NULL,
+      'currentRole' => NULL,
       'asiointiLink' => NULL,
     ],
   ];

--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
@@ -83,10 +83,13 @@ class AsiointirooliBlock extends BlockBase implements ContainerFactoryPluginInte
   public function build() {
 
     $companyName = NULL;
+    $currentRole = NULL;
 
     $selectedCompany = $this->grantsProfileService->getSelectedRoleData();
+
     if ($selectedCompany) {
       $companyName = $selectedCompany['name'];
+      $currentRole = $selectedCompany['type'];
     }
 
     $switchRole = Link::createFromRoute($this->t('Switch role', [], [
@@ -109,9 +112,8 @@ class AsiointirooliBlock extends BlockBase implements ContainerFactoryPluginInte
 
     $build = [
       '#theme' => 'grants_oma_asiointi_asiointirooli_block',
-      '#companyName' => $companyName,
       '#switchRole' => $switchRole,
-      '#logOut' => $logOut,
+      '#currentRole' => $currentRole,
       '#asiointiLink' => $asiointiLink,
     ];
 

--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
@@ -5,7 +5,6 @@ namespace Drupal\grants_oma_asiointi\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Url;
 use Drupal\grants_profile\GrantsProfileService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
@@ -103,13 +103,6 @@ class AsiointirooliBlock extends BlockBase implements ContainerFactoryPluginInte
 
     $asiointiLink = Link::createFromRoute($companyName, 'grants_profile.show');
 
-    $logOut = Link::fromTextAndUrl(t('Log out'), Url::fromUri('base:user/logout',
-    [
-      'attributes' => [
-        'class' => ['link--stop-mandate'],
-      ],
-    ]));
-
     $build = [
       '#theme' => 'grants_oma_asiointi_asiointirooli_block',
       '#switchRole' => $switchRole,

--- a/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-asiointirooli-block.html.twig
+++ b/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-asiointirooli-block.html.twig
@@ -1,8 +1,5 @@
-{% set name = companyName ? companyName : 'Private person'|t({}, {'context': 'Asiointirooli block'}) %}
-{% set link = switchRole %}
-
-<div class="asiointirooli-block">
+<div class="asiointirooli-block asiointirooli-block-{{ currentRole }}">
   <div class="container">
-    <span class="asiointirooli--rooli">{{ "Role"|t({}, {'context': 'Asiointirooli block'}) }}: {{ asiointiLink }}</span> {{ link }}
+    <span class="asiointirooli--rooli">{{ "Role"|t({}, {'context': 'Asiointirooli block'}) }}: {{ asiointiLink }}</span> {{ switchRole }}
   </div>
 </div>


### PR DESCRIPTION
# [AU-1714](https://helsinkisolutionoffice.atlassian.net/browse/AU-1714)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed unused variables from asiointirooli-block
* Add class that indicates current role to asiointirooli-block

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1714-asiointirooli-class`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the asiointirooli block (The black line on top of the header) works
* [ ] Check that the classes asiointirooli-block-registered_community, asiointirooli-block-unregistered_community and asiointirooli-block-private_person are passed to the block and are such that they are useful for the tests
* [ ] Check that code follows our standards


[AU-1714]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ