### PR TITLE
fix: AU-1711: Liikunta tilankäyttö fixes.

### DIFF
--- a/public/modules/custom/grants_handler/js/compensation-element.js
+++ b/public/modules/custom/grants_handler/js/compensation-element.js
@@ -202,7 +202,11 @@
       return container;
     },
     isEmptyEuroValue: function(stringToCheck) {
-      return stringToCheck === '0.00' || stringToCheck === '0,00' || stringToCheck == null || stringToCheck == '';
+      return stringToCheck === '0.00' ||
+             stringToCheck === '0,00' ||
+             stringToCheck == null ||
+             stringToCheck == '' ||
+             stringToCheck == 0;
     },
     // Event listeners to handle enabling / disabling fields, when answered.
     addEventListenerToRadios: function(buttons, elements, subventionId, inputValue) {

--- a/public/modules/custom/grants_handler/js/compensation-element.js
+++ b/public/modules/custom/grants_handler/js/compensation-element.js
@@ -79,7 +79,7 @@
             const isEmptyEuroValue = Drupal.behaviors.GrantsHandlerCompensationElement.isEmptyEuroValue(cleanValue);
             if (isEmptyEuroValue) {
               Drupal.behaviors.GrantsHandlerCompensationElement.enableAll(elemParents);
-            } else if (!isEmptyEuroValue) {
+            } else {
               Drupal.behaviors.GrantsHandlerCompensationElement.disableOthers(key, elemParents);
             }
           })

--- a/public/modules/custom/grants_handler/js/compensation-element.js
+++ b/public/modules/custom/grants_handler/js/compensation-element.js
@@ -76,9 +76,10 @@
             }
 
             const cleanValue = e.target.value.replace('€', '');
-            if (cleanValue === '0.00' || cleanValue === '0,00' || cleanValue === null || cleanValue === '') {
+            const isEmptyEuroValue = Drupal.behaviors.GrantsHandlerCompensationElement.isEmptyEuroValue(cleanValue);
+            if (isEmptyEuroValue) {
               Drupal.behaviors.GrantsHandlerCompensationElement.enableAll(elemParents);
-            } else if (cleanValue !== '') {
+            } else if (!isEmptyEuroValue) {
               Drupal.behaviors.GrantsHandlerCompensationElement.disableOthers(key, elemParents);
             }
           })
@@ -92,7 +93,8 @@
     allInputsEmpty: function(elements) {
       for (let [key, value] of Object.entries(elements)) {
         const cleanValue = value.input.value.replace('€', '');
-        if (cleanValue === '0.00' || cleanValue === '0,00' || cleanValue === null || cleanValue === '') {
+        const isEmptyEuroValue = Drupal.behaviors.GrantsHandlerCompensationElement.isEmptyEuroValue(cleanValue);
+        if (isEmptyEuroValue) {
           continue;
         } else {
           return false
@@ -127,8 +129,9 @@
     // Disables fields based on submitted data if needed.
     validateElementStates: function(elements) {
       for (let [key, value] of Object.entries(elements)) {
-        const cleanValue = value.input.value;
-        if (cleanValue != false) {
+        const cleanValue = value.input.value.replace('€', '');
+        const isEmptyEuroValue = Drupal.behaviors.GrantsHandlerCompensationElement.isEmptyEuroValue(cleanValue);
+        if (!isEmptyEuroValue) {
           Drupal.behaviors.GrantsHandlerCompensationElement.disableOthers(key, elements);
           break;
         }
@@ -137,12 +140,15 @@
     // Disables fields based on submitted data if needed.
     validateElementStatesLimited: function(limitedKey, elements) {
       for (let [key, value] of Object.entries(elements)) {
-        const cleanValue = value.input.value;
-        if (cleanValue != false && limitedKey == key) {
+        const cleanValue = value.input.value.replace('€', '');
+        const isEmptyEuroValue = Drupal.behaviors.GrantsHandlerCompensationElement.isEmptyEuroValue(cleanValue);
+        // Limited key has value, lock the other fields.
+        if (!isEmptyEuroValue && limitedKey == key) {
           Drupal.behaviors.GrantsHandlerCompensationElement.disableOthers(key, elements);
           break;
         }
-        else if (cleanValue != false && limitedKey != key) {
+        // Other fields have a value, lock the limited field.
+        else if (!isEmptyEuroValue && limitedKey != key) {
           Drupal.behaviors.GrantsHandlerCompensationElement.disabledById(limitedKey, elements);
           break;
         }
@@ -194,6 +200,9 @@
       container.append(label, option1, option2);
 
       return container;
+    },
+    isEmptyEuroValue: function(stringToCheck) {
+      return stringToCheck === '0.00' || stringToCheck === '0,00' || stringToCheck == null || stringToCheck == '';
     },
     // Event listeners to handle enabling / disabling fields, when answered.
     addEventListenerToRadios: function(buttons, elements, subventionId, inputValue) {

--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -159,8 +159,8 @@ class CompensationsComposite extends WebformCompositeBase {
       $premiseSubventionValue = $valueMap['32'] ?? NULL;
       $generalSubventionAmount = $valueMap['1'] ?? NULL;
 
-      $premiseAmountFilled = $premiseSubventionValue !== '0,00e' && !empty($premiseSubventionValue);
-      $generalAmountFilled = $generalSubventionAmount !== '0,00e' && !empty($generalSubventionAmount);
+      $premiseAmountFilled = $premiseSubventionValue !== '0,00€' && !empty($premiseSubventionValue);
+      $generalAmountFilled = $generalSubventionAmount !== '0,00€' && !empty($generalSubventionAmount);
 
       if ($premiseAmountFilled && !$generalAmountFilled) {
         $formState->setErrorByName(

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
@@ -30,12 +30,12 @@ class LiikuntaTilankayttoDefinition extends ComplexDataDefinitionBase {
 
       // Section 2: Avustustiedot.
       $info['hakijan_tyyppi'] = DataDefinition::create('string')
-      ->setLabel('')
-      ->setSetting('jsonPath', [
-        'compensation',
-        'applicantInfoArray',
-        'communityType',
-      ]);
+        ->setLabel('')
+        ->setSetting('jsonPath', [
+          'compensation',
+          'applicantInfoArray',
+          'communityType',
+        ]);
 
       $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
         ->setLabel('compensationArray')

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
@@ -29,6 +29,14 @@ class LiikuntaTilankayttoDefinition extends ComplexDataDefinitionBase {
       }
 
       // Section 2: Avustustiedot.
+      $info['hakijan_tyyppi'] = DataDefinition::create('string')
+      ->setLabel('')
+      ->setSetting('jsonPath', [
+        'compensation',
+        'applicantInfoArray',
+        'communityType',
+      ]);
+
       $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
         ->setLabel('compensationArray')
         ->setSetting('jsonPath', [


### PR DESCRIPTION
# [AU-1711](https://helsinkisolutionoffice.atlassian.net/browse/AU-1711
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix javascript logic with Liikunta tila application, that caused wrong fields to be blocked when there is a value in "Muiden liikuntaa edistävien yhteisöjen avustus".
* Add missing mapping for Hakijan tyyppi
* Validation fix.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1711-liikuntatila-fixes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] [Open a new Liikunta, toiminta- ja tilankäyttöavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/liikunta-toiminta-ja-tilankaytto) 
* [x] Go to page 2 and insert value to "Muiden liikuntaa edistävien yhteisöjen avustus" field.
* [x] Also select value for the "Hakijan tyyppi" field.
* [x] Save document as draft
* [x] Return back to editing mode and make sure that the subvention value is showing up correctly and "Hakijan tyyppi" is mapped back to webform correctly.



[AU-1711]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ