### PR TITLE
AU-1707: yleisavustuksiin toiminnan kuvaus

### DIFF
--- a/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -161,6 +161,7 @@ elements: |
     '#title': 'Description of activities'
   business_purpose:
     '#title': 'Description of activities'
+    '#counter_maximum_message': '%d/500 characters remaining'
     '#help': 'The information is retrieved from the personal information section'
   community_practices_business:
     '#title': 'Is the entity is engaged in business?'

--- a/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -133,6 +133,7 @@ elements: |
   business_purpose:
     '#title': 'Description of activities'
     '#help': 'The information is retrieved from the personal information section'
+    '#counter_maximum_message': '%d/500 characters remaining'
   community_practices_business:
     '#title': 'Is the entity engaged in business?'
     '#options':

--- a/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
@@ -164,6 +164,7 @@ elements: |
   business_purpose:
     '#title': 'Description of activities'
     '#help': 'The description of activities is maintained in your data.'
+    '#counter_maximum_message': '%d/500 characters remaining'
   community_practices_business:
     '#title': 'Is the entity engaged in business?'
     '#options':

--- a/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -131,9 +131,10 @@ elements: |
     '#title': 'Description of activities'
   business_purpose:
     '#title': 'Description of activities'
-    '#help': '<div class="ewa-rteLine">If you want to add, remove or change the description of activities, save the application as a draft and go to your data to maintain the description of activities.</div>'
+    '#counter_maximum_message': '%d/500 characters remaining'
+    '#help': 'If you want to add, remove or change the description of activities, save the application as a draft and go to your data to maintain the description of activities.'
   business_purpose_info:
-    '#markup': '<div class="ewa-rteLine">The description of activities is maintained in your data.</div>'
+    '#markup': 'The description of activities is maintained in your data.'
   community_practices_business:
     '#title': 'Is the entity engaged in business?'
     '#options':

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -179,6 +179,7 @@ elements: |
   business_purpose:
     '#title': Verksamhetsbeskrivning
     '#help': 'Informationen h&auml;mtas fr&aring;n avsnittet med personuppgifter'
+    '#counter_maximum_message': '%d/500 tecken kvar'
   community_practices_business:
     '#title': 'Bedriver samfundet affärsverksamhet'
     '#options':

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -136,6 +136,7 @@ elements: |
   business_purpose:
     '#title': 'Beskrivning av verksamheten'
     '#help': 'Informationen h&auml;mtas fr&aring;n avsnittet med personuppgifter'
+    '#counter_maximum_message': '%d/500 tecken kvar'
   community_practices_business:
     '#title': 'Bedriver samfundet affärsverksamhet'
     '#options':

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -166,6 +166,7 @@ elements: |
   business_purpose:
     '#title': 'Beskrivning av verksamheten'
     '#help': 'Informationen h&auml;mtas fr&aring;n avsnittet med personuppgifter'
+    '#counter_maximum_message': '%d/500 tecken kvar'
   community_practices_business:
     '#title': 'Bedriver samfundet affärsverksamhet'
     '#options':

--- a/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -133,9 +133,10 @@ elements: |
     '#title': Verksamhetsbeskrivning
   business_purpose:
     '#title': 'Beskrivning av verksamheten'
-    '#help': '<div class="ewa-rteLine">Om du vill l&auml;gga till, ta bort eller &auml;ndra verksamhetsbeskrivningen, spara ans&ouml;kan som ett utkast och g&aring; till dina uppgifter f&ouml;r att redigera verksamhetsbeskrivningen.</div>'
+    '#counter_maximum_message': '%d/500 tecken kvar'
+    '#help': 'Om du vill l&auml;gga till, ta bort eller &auml;ndra verksamhetsbeskrivningen, spara ans&ouml;kan som ett utkast och g&aring; till dina uppgifter f&ouml;r att redigera verksamhetsbeskrivningen.'
   business_purpose_info:
-    '#markup': '<div class="ewa-rteLine">Verksamhetsbeskrivningen redigeras i dina uppgifter.</div>'
+    '#markup': 'Verksamhetsbeskrivningen redigeras i dina uppgifter.'
   community_practices_business:
     '#title': 'Bedriver samfundet affärsverksamhet'
     '#options':

--- a/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -510,6 +510,10 @@ elements: |-
         '#type': textarea
         '#title': 'Toiminnan kuvaus'
         '#help': 'Tieto haetaan omat tiedot -osiosta'
+        '#maxlength': 500
+        '#counter_type': character
+        '#counter_maximum': 500
+        '#counter_maximum_message': '%d/500 merkkiä jäljellä'
       community_practices_business:
         '#type': radios
         '#title': 'Harjoittaako yhteisö liiketoimintaa'

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -451,6 +451,10 @@ elements: |-
         '#type': textarea
         '#title': 'Toiminnan kuvaus'
         '#help': 'Tieto haetaan omat tiedot -osiosta'
+        '#maxlength': 500
+        '#counter_type': character
+        '#counter_maximum': 500
+        '#counter_maximum_message': '%d/500 merkkiä jäljellä'
       community_practices_business:
         '#type': radios
         '#title': 'Harjoittaako yhteisö liiketoimintaa'

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -539,6 +539,10 @@ elements: |-
         '#type': textarea
         '#title': 'Toiminnan kuvaus'
         '#help': 'Tieto haetaan omat tiedot -osiosta'
+        '#maxlength': 500
+        '#counter_type': character
+        '#counter_maximum': 500
+        '#counter_maximum_message': '%d/500 merkkiä jäljellä'
       community_practices_business:
         '#type': radios
         '#title': 'Harjoittaako yhteisö liiketoimintaa'

--- a/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -454,10 +454,14 @@ elements: |-
       business_purpose:
         '#type': textarea
         '#title': 'Toiminnan kuvaus'
-        '#help': '<div class="ewa-rteLine">Jos haluat lis&auml;t&auml;, poistaa tai muuttaa toiminnan kuvausta tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n toiminnan kuvausta omiin tietoihin.</div>'
+        '#maxlength': 500
+        '#counter_type': character
+        '#counter_maximum': 500
+        '#counter_maximum_message': '%d/500 merkkiä jäljellä'
+        '#help': 'Jos haluat lis&auml;t&auml;, poistaa tai muuttaa toiminnan kuvausta tallenna hakemus luonnokseksi ja siirry yll&auml;pit&auml;m&auml;&auml;n toiminnan kuvausta omiin tietoihin.'
       business_purpose_info:
         '#type': webform_markup
-        '#markup': '<div class="ewa-rteLine">Toiminnan kuvausta yll&auml;pidet&auml;&auml;n omissa tiedoissa.</div>'
+        '#markup': 'Toiminnan kuvausta yll&auml;pidet&auml;&auml;n omissa tiedoissa.'
       community_practices_business:
         '#type': radios
         '#title': 'Harjoittaako yhteisö liiketoimintaa'


### PR DESCRIPTION
# [AU-1707](https://helsinkisolutionoffice.atlassian.net/browse/AU-1707)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add counter and character limit to yleisavustushakemus business purposes

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1707-yleisavustus-toiminnan-kuvaus`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [KH Yleisavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/yleisavustushakemus), page 3, see that there is a counter in toiminnan tarkoitus.
* [ ] check it in Swedish
* [ ] And in English
* [ ] Go to [KASKO Yleisavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kasvatus_ja_koulutus_yleisavustu) page 3 and see there is a counter in toiminnan tarkoitus
* [ ] check that it is there in Swedish
* [ ] and English
* [ ] Go to the [asukasosallisuus yleis](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_yleis_ja_toimin) and check there is a counter on page 3 in toiminnan tarkoitus
* [ ] see that it is there in Swedish too
* [ ] And in English
* [ ] Go to the [Ympäristö yleishakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/ymparistopalvelut_yleisavustus) page 3, and see there is a counter in toiminnan tarkoitus
* [ ] and in Swedish too
* [ ] and as well in English
* [ ] Check that code follows our standards


[AU-1707]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ