### PR TITLE
fix: AU-XX: remove context from javascript prompts

### DIFF
--- a/public/modules/custom/grants_handler/js/webform.form.unsaved.js
+++ b/public/modules/custom/grants_handler/js/webform.form.unsaved.js
@@ -58,7 +58,7 @@
           // For reset button we must confirm unsaved changes before the
           // before unload event handler.
           if ($(this).hasClass('webform-button--reset') && unsaved) {
-            if (!window.confirm(Drupal.t('Changes you made may not be saved.', {}, {context: "grants_handler"}) + '\n\n' + Drupal.t('Press OK to leave this page or Cancel to stay.', {}, {context: "grants_handler"}))) {
+            if (!window.confirm(Drupal.t('Changes you made may not be saved.') + '\n\n' + Drupal.t('Press OK to leave this page or Cancel to stay.'))) {
               return false;
             }
           }
@@ -96,11 +96,11 @@
         `<div></div>`,
       ).appendTo('body');
       Drupal.dialog($previewDialog, {
-        title: Drupal.t('Are you sure you want to leave? Leave without saving.', {}, {context: "grants_handler"}),
+        title: Drupal.t('Are you sure you want to leave? Leave without saving.'),
         width: '33%',
         buttons: [
           {
-            text: Drupal.t('Leave the application', {}, {context: "grants_handler"}),
+            text: Drupal.t('Leave the application'),
             click() {
               unsaved = false;
               $(this).dialog('close');
@@ -109,7 +109,7 @@
             },
           },
           {
-            text: Drupal.t('Back to application', {}, {context: "grants_handler"}),
+            text: Drupal.t('Back to application'),
             buttonType: 'secondary',
             click() {
               $(this).dialog('close');
@@ -155,7 +155,7 @@
       if (typeof href !== 'undefined' && !(href.match(/^#/) || href.trim() === '')) {
         if ($(window).triggerHandler('beforeunload')) {
 
-          if (!window.confirm(Drupal.t('Changes you made may not be saved.', {}, {context: "grants_handler"}) + '\n\n' + Drupal.t('Press OK to leave this page or Cancel to stay.', {}, {context: "grants_handler"}))) {
+          if (!window.confirm(Drupal.t('Changes you made may not be saved.') + '\n\n' + Drupal.t('Press OK to leave this page or Cancel to stay.'))) {
             return false;
           }
         }

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -519,15 +519,12 @@ msgctxt "grants_handler"
 msgid "Your request was not fulfilled due to network error."
 msgstr "Pyyntösi keskeytyi verkkovirheen takia."
 
-msgctxt "grants_handler"
 msgid "Are you sure you want to leave? Leave without saving."
 msgstr "Oletko varma että haluat keskeyttää lomakkeen täyttämisen? Poistu tallentamatta."
 
-msgctxt "grants_handler"
 msgid "Leave the application"
 msgstr "Poistu hakemukselta"
 
-msgctxt "grants_handler"
 msgid "Back to application"
 msgstr "Takaisin hakemukselle"
 
@@ -535,11 +532,9 @@ msgctxt "grants_handler"
 msgid "View application"
 msgstr "Katsele hakemusta"
 
-msgctxt "grants_handler"
 msgid "Changes you made may not be saved."
 msgstr "Tekemiäsi muutoksia ei ole tallennettu."
 
-msgctxt "grants_handler"
 msgid "Press OK to leave this page or Cancel to stay."
 msgstr "Paina OK poistuaksesi sivulta tai Peruuta jatkaaksesi."
 

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -519,15 +519,12 @@ msgctxt "grants_handler"
 msgid "Your request was not fulfilled due to network error."
 msgstr "Din begäran uppfylldes inte på grund av nätverksfel."
 
-msgctxt "grants_handler"
 msgid "Are you sure you want to leave? Leave without saving."
 msgstr "Är du säker att du vill stänga blanketten? Avsluta utan att spara."
 
-msgctxt "grants_handler"
 msgid "Leave the application"
 msgstr "Avsluta från ansökningshandling"
 
-msgctxt "grants_handler"
 msgid "Back to application"
 msgstr "Tillbaka till ansökningshandling"
 
@@ -535,11 +532,9 @@ msgctxt "grants_handler"
 msgid "View application"
 msgstr "Visa ansökning"
 
-msgctxt "grants_handler"
 msgid "Changes you made may not be saved."
 msgstr "Ändringar du gjort kanske inte sparas."
 
-msgctxt "grants_handler"
 msgid "Press OK to leave this page or Cancel to stay."
 msgstr "Tryck på OK för att lämna den här sidan eller Avbryt för att stanna."
 


### PR DESCRIPTION
# AU-XX
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* The modals when exiting form did not translate when context was set, removed context to get translations.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-fix-exit-form-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [an application in Finnish](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti)
* [ ] Refresh your browser with cache clear (shift-ctrl-r on windows chrome) to get latest javascript.
* [ ] Navigate to page 2 with the page wizard.
* [ ] Click on Swedish. See that the modal that telling that you're leaving is in Finnish. Say that you want to navigate away.
* [ ] in the Swedish version, navigate to page 2 with the page wizard
* [ ] Click on English. See that the modal that is telling you you're leaving is in Swedish. Navigate away.
* [ ] Repeat in English.
* [ ] Check that code follows our standards