### PR TITLE
fix: AU-xxx: Fix PHP warning notices

### DIFF
--- a/public/modules/custom/grants_handler/src/Processor/NumberProcessor.php
+++ b/public/modules/custom/grants_handler/src/Processor/NumberProcessor.php
@@ -13,7 +13,7 @@ class NumberProcessor {
    * Process number fields to allow . or , and convert them for validators.
    */
   public static function process(&$element, FormStateInterface $form_state, &$complete_form) {
-    $valueFromElement = $element['#value'] ?? NULL;
+    $valueFromElement = $element['#value'] ?? '';
     $value = trim($valueFromElement);
 
     if (empty($value)) {

--- a/public/modules/custom/grants_handler/src/Processor/NumberProcessor.php
+++ b/public/modules/custom/grants_handler/src/Processor/NumberProcessor.php
@@ -13,10 +13,11 @@ class NumberProcessor {
    * Process number fields to allow . or , and convert them for validators.
    */
   public static function process(&$element, FormStateInterface $form_state, &$complete_form) {
-    $value = trim($element['#value']);
+    $valueFromElement = $element['#value'] ?? NULL;
+    $value = trim($valueFromElement);
 
     if (empty($value)) {
-      $element;
+      return $element;
     }
 
     // Count the number of dots and commas.


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix PHP warning notices caused by NumberProcessor class on some webforms

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-xxx-fix-php-notices`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] [Kasvatus ja koulutus: toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-toiminta-av)
* [ ] You should not see php warnings about #value field

