### PR TITLE
Feature/au 1729 suunnistus required field

### DIFF
--- a/public/modules/custom/grants_orienteering_map/src/Element/OrienteeringMapComposite.php
+++ b/public/modules/custom/grants_orienteering_map/src/Element/OrienteeringMapComposite.php
@@ -37,6 +37,7 @@ class OrienteeringMapComposite extends WebformCompositeBase {
     $elements['mapName'] = [
       '#type' => 'textarea',
       '#title' => t('Map name, location and map type', [], $tOpts),
+      '#required' => TRUE,
     ];
 
     $elements['size'] = [

--- a/public/modules/custom/grants_orienteering_map/src/Element/OrienteeringMapComposite.php
+++ b/public/modules/custom/grants_orienteering_map/src/Element/OrienteeringMapComposite.php
@@ -38,6 +38,10 @@ class OrienteeringMapComposite extends WebformCompositeBase {
       '#type' => 'textarea',
       '#title' => t('Map name, location and map type', [], $tOpts),
       '#required' => TRUE,
+      '#counter_type' => 'character',
+      '#maxlength' => 5000,
+      '#counter_maximum' => 5000,
+      '#counter_maximum_message' => t('%d/5000 characters left', [], $tOpts),
     ];
 
     $elements['size'] = [

--- a/public/modules/custom/grants_orienteering_map/translations/fi.po
+++ b/public/modules/custom/grants_orienteering_map/translations/fi.po
@@ -31,3 +31,7 @@ msgstr "Kustannukset euroa"
 msgctxt "grants_orienteering_map"
 msgid "Grants received from others in euros"
 msgstr "Muilta saadut avustukset euroa"
+
+msgctxt "grants_orienteering_map"
+msgid "%d/5000 characters left"
+msgstr "%d/5000 merkkiä jäljellä"

--- a/public/modules/custom/grants_orienteering_map/translations/sv.po
+++ b/public/modules/custom/grants_orienteering_map/translations/sv.po
@@ -31,3 +31,7 @@ msgstr "Kostnader, euro"
 msgctxt "grants_orienteering_map"
 msgid "Grants received from others in euros"
 msgstr "Understöd från tredje part, euro"
+
+msgctxt "grants_orienteering_map"
+msgid "%d/5000 characters left"
+msgstr "%d/5000 tecken kvar"


### PR DESCRIPTION
# [AU-1729](https://helsinkisolutionoffice.atlassian.net/browse/AU-1729)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Suunnistuskartta field is required

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1729-suunnistus-required-field`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as admin and make [suunnistusavustus available](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/liikunta_suunnistuskartta_avustu/settings) to be tested if not already.
* [ ] Log in as actual user
* [ ] Go to [Suunnistushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/liikunta_suunnistuskartta_avustu) Page 2
* [ ] See that the Kartan nimi, sijainti ja karttatyyppi is required
* [ ] See that there is a counter for max 5000 characters underneath
* [ ] Check that it is there in Swedish and English
* [ ] Check that code follows our standards


[AU-1729]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ