### PR TITLE
feat: AU-1727: add text when you cant send messages

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -42,6 +42,7 @@ function grants_handler_theme(): array {
         'messages' => NULL,
         'message_form' => NULL,
         'submission' => NULL,
+        'isDraft' => NULL,
       ],
     ],
 
@@ -1039,6 +1040,16 @@ function grants_handler_preprocess_webform_submission_messages(&$variables) {
     '#items' => $messages,
     '#style' => 'default',
   ];
+
+  $variables['isDraft'] = FALSE;
+
+  $fdkf = $submissionData;
+
+  if ($submissionData['status'] == 'DRAFT') {
+    $variables['isDraft'] = TRUE;
+  }
+
+  $fdkf2 = $submissionData;
 
   // If submission is ok for messaging.
   if (ApplicationHandler::isSubmissionMessageable($submission, NULL)) {

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1043,13 +1043,9 @@ function grants_handler_preprocess_webform_submission_messages(&$variables) {
 
   $variables['isDraft'] = FALSE;
 
-  $fdkf = $submissionData;
-
   if ($submissionData['status'] == 'DRAFT') {
     $variables['isDraft'] = TRUE;
   }
-
-  $fdkf2 = $submissionData;
 
   // If submission is ok for messaging.
   if (ApplicationHandler::isSubmissionMessageable($submission, NULL)) {

--- a/public/modules/custom/grants_handler/templates/webform-submission-messages.html.twig
+++ b/public/modules/custom/grants_handler/templates/webform-submission-messages.html.twig
@@ -27,6 +27,9 @@
       <h4>{{ 'Sent messages'|t({}, {'context': 'grants_handler'})}}</h4>
       <hr/>
       <div{{ attributes.addClass(classes) }}>
+        {% if isDraft %}
+          <p>{{ 'You cannot send messages to an incomplete application.'|t({}, {'context': 'grants_handler'}) }}</p>
+        {% endif %}
         {{ messages }}
       </div>
       <div{{ attributes.addClass(classes) }}>

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -573,3 +573,7 @@ msgstr "Omat hakemukset"
 msgctxt "grants_handler"
 msgid "Applications Helsinki"
 msgstr "Hakemuksen käsittelijä"
+
+msgctxt "grants_handler"
+msgid "You cannot send messages to an incomplete application."
+msgstr "Keskeneräiseen hakemukseen ei voi lähettää viestejä."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -573,3 +573,7 @@ msgstr "Mina ansökningar"
 msgctxt "grants_handler"
 msgid "Applications Helsinki"
 msgstr "Applikationshanterare"
+
+msgctxt "grants_handler"
+msgid "You cannot send messages to an incomplete application."
+msgstr "Du kan inte skicka meddelanden till en pågående ansökan"


### PR DESCRIPTION
# [AU-1727](https://helsinkisolutionoffice.atlassian.net/browse/AU-1727)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Drafts were showing empty messages-box which can be confusing
* Added text to clarify

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1727-messages`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any draft application you have
* [ ] Check that you see this text

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/4620df5d-cc6d-4921-b79d-39c050a487bf)

* [ ] Go to any sent application you have
* [ ] Check that you don't see the text
* [ ] Repeat in every language

[AU-1727]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ