### PR TITLE
fix: AU-1206: Fix attachment checkbox states when editing draft

### DIFF
--- a/public/modules/custom/grants_handler/js/webform-additions.js
+++ b/public/modules/custom/grants_handler/js/webform-additions.js
@@ -3,7 +3,6 @@
     attach: function (context, settings) {
 
       const formData = drupalSettings.grants_handler.formData
-      const selectedCompany = drupalSettings.grants_handler.selectedCompany
       const submissionId = drupalSettings.grants_handler.submissionId
       const lockedStatus = drupalSettings.grants_handler.formLocked;
 

--- a/public/modules/custom/grants_handler/js/webform-additions.js
+++ b/public/modules/custom/grants_handler/js/webform-additions.js
@@ -91,6 +91,7 @@
         const box2 = $(parent).find('[data-webform-composite-attachment-isDeliveredLater]');
         const attachment = $(this).find('input');
         const attachmentValue = $(attachment).val();
+        const checkBoxesAreEqual = box1.prop('checked') === box2.prop('checked');
 
         // Notice that we might have attachmentName field instead of managedFile
         // (If you need to change logic here).
@@ -98,9 +99,15 @@
           box1.prop('disabled', true)
           box2.prop('disabled', true)
         }
-        else if (attachment) {
+        else if (attachment && checkBoxesAreEqual) {
           box1.prop('disabled', false)
           box2.prop('disabled', false)
+        }
+        else if (!checkBoxesAreEqual) {
+          // If we are returning to edit a draft, make sure
+          // we disable the other box.
+          box1.prop('disabled', box2.prop('checked') === true)
+          box2.prop('disabled', box1.prop('checked') === true)
         }
       });
 


### PR DESCRIPTION


# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done

Extend JavaScript logic a bit, to handle checkbox state when returning to edit attachments. Previously if 1 of the check boxes were checked and user returned to attachment section, the non-selected box didn't get disabled upon page load.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1206-attachment-checkbox-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any webform that has attachments with delivered later / included in other field selections. [Like KASKO Yleis](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-yleisavustu)
* [ ] Select some of the delivered later / in other file check boxes and save as draft
* [ ] Return to edit mode and make sure the selection stays and that the other field is disabled
* [ ] Jump between the form sections and check that everything is good.

