### PR TITLE
AU-1765: Add node caching for anon page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2023.21.1
+- ce3eb676 AU-1765: PHPCS for the anon block fix
+- 84f11913 AU-1765: Make sure we have address info for private person.
+- 199e8646 AU-1765: Update cache method from stackoverflow
+- 1f9d36be AU-1765: Add node caching for anon page.
+
 ## 2023.21
 - 9fe2611f Update nuoriso ennakko form times.
 - a49e5cf2 feat: AU-1675: Ajaxify message read functionality (#836)

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/City-of-Helsinki/drupal-helfi-platform",
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "version": "2023.21",
+    "version": "2023.21.1",
     "require": {
         "ext-json": "*",
         "composer/installers": "^1.9",

--- a/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
+++ b/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
@@ -55,7 +55,7 @@ class ApplicantInfoService {
 
     $applicantType = '';
 
-    foreach ($property as $itemIndex => $p) {
+    foreach ($property as $p) {
       $pDef = $p->getDataDefinition();
       $pJsonPath = $pDef->getSetting('jsonPath');
       $defaultValue = $pDef->getSetting('defaultValue');
@@ -203,6 +203,9 @@ class ApplicantInfoService {
       }
     }
     if ($applicantType == 'private_person') {
+
+      unset($retval["compensation"]["currentAddressInfoArray"]);
+      self::removeItemById($retval, 'email');
       self::removeItemById($retval, 'companyNumber');
       self::removeItemById($retval, 'communityOfficialName');
       self::removeItemById($retval, 'communityOfficialNameShort');
@@ -210,6 +213,87 @@ class ApplicantInfoService {
       self::removeItemById($retval, 'foundingYear');
       self::removeItemById($retval, 'home');
       self::removeItemById($retval, 'homePage');
+
+      /*
+       * We need to bring address details from applicant info details, since
+       * address information needs to be automatically filled.
+       *
+       * These also do not need to be parsed the other way, since these details
+       * are inside the applicant info component
+       */
+
+      $roleId = $this->grantsProfileService->getSelectedRoleData();
+      $profile = $this->grantsProfileService->getGrantsProfileContent($roleId);
+
+      if ($profile) {
+        $addressPath = [
+          'compensation',
+          'currentAddressInfoArray',
+        ];
+
+        $addressElement = [
+          [
+            'ID' => 'street',
+            'value' => $profile["addresses"][0]["street"],
+            'valueType' => 'string',
+            'label' => 'Katuosoite',
+          ],
+          [
+            'ID' => 'city',
+            'value' => $profile["addresses"][0]["city"],
+            'valueType' => 'string',
+            'label' => 'Postitoimipaikka',
+          ],
+          [
+            'ID' => 'postCode',
+            'value' => $profile["addresses"][0]["postCode"],
+            'valueType' => 'string',
+            'label' => 'Postinumero',
+          ],
+          [
+            'ID' => 'country',
+            'value' => $profile["addresses"][0]["country"],
+            'valueType' => 'string',
+            'label' => 'Postinumero',
+          ],
+          // Add contact person from user data.
+          [
+            'ID' => 'contactPerson',
+            'value' => $roleId["name"] ?? '',
+            'valueType' => 'string',
+            'label' => 'Yhteyshenkilö',
+          ],
+          // Add phone from user data.
+          [
+            'ID' => 'phoneNumber',
+            'value' => $profile["phone_number"] ?? '',
+            'valueType' => 'string',
+            'label' => 'Puhelinnumero',
+          ],
+        ];
+
+        foreach ($addressElement as $ae) {
+          self::setNestedValue($retval, $addressPath, $ae);
+        }
+
+        /*
+         * Set email from user details. This must be set,
+         * or applications do not work
+         */
+        self::setNestedValue(
+          $retval,
+          [
+            'compensation',
+            'applicantInfoArray',
+          ],
+          [
+            'ID' => 'email',
+            'value' => $profile["email"],
+            'valueType' => 'string',
+            'label' => 'Sähköpostiosoite',
+          ]);
+      }
+
     }
 
     if (is_array($retval["compensation"]["applicantInfoArray"])) {

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -212,9 +212,12 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
   /**
    * {@inheritdoc}
    */
-  public function getCacheTags(): array {
-    $node = \Drupal::routeMatch()->getParameter('node');
-    return Cache::mergeTags(parent::getCacheTags(), $node->getCacheTags());
+  public function getCacheContexts(): array {
+    //if you depends on \Drupal::routeMatch()
+    //you must set context of this block with 'route' context tag.
+    //Every new route this block will rebuild
+    return Cache::mergeContexts(parent::getCacheContexts(), array('route'));
   }
+
 
 }

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -213,11 +213,10 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
    * {@inheritdoc}
    */
   public function getCacheContexts(): array {
-    //if you depends on \Drupal::routeMatch()
-    //you must set context of this block with 'route' context tag.
-    //Every new route this block will rebuild
-    return Cache::mergeContexts(parent::getCacheContexts(), array('route'));
+    // If you depends on \Drupal::routeMatch()
+    // you must set context of this block with 'route' context tag.
+    // Every new route this block will rebuild.
+    return Cache::mergeContexts(parent::getCacheContexts(), ['route']);
   }
-
 
 }

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -4,6 +4,7 @@ namespace Drupal\grants_handler\Plugin\Block;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -206,6 +207,14 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
     ];
 
     return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags(): array {
+    $node = \Drupal::routeMatch()->getParameter('node');
+    return Cache::mergeTags(parent::getCacheTags(), $node->getCacheTags());
   }
 
 }


### PR DESCRIPTION
# [AU-1765](https://helsinkisolutionoffice.atlassian.net/browse/AU-1765)
<!-- What problem does this solve? -->

Preview links are apparently cached, and this tries to tie them to node savings.

## What was done
<!-- Describe what was done -->

* Add node trigger for caching preview block.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout hotfix/AU-1765-preview-link-caching`
  * `make fresh`
* Run `make drush-cr`



[AU-1765]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ