### PR TITLE
AU-1754: Fix empty date field crashing webform configration saving in some cases

### DIFF
--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -176,16 +176,24 @@ function grants_metadata_set_node_values(Node &$page, mixed $thirdPartySettings)
     $page->set('field_avustuslaji', $terms);
   }
   $applicationOpenStr = strtotime($thirdPartySettings["applicationOpen"]);
-  $applicationOpenDate = DrupalDateTime::createFromFormat('U', $applicationOpenStr, 'Europe/Helsinki');
-  $applicationOpenDateFormat = $applicationOpenDate->format('Y-m-d\TH:i:s');
+  $applicationOpenDate = $applicationOpenStr ?
+    DrupalDateTime::createFromFormat('U', $applicationOpenStr, 'Europe/Helsinki') :
+    NULL;
+
+  $applicationOpenDateFormat = $applicationOpenDate?->format('Y-m-d\TH:i:s');
 
   $applicationCloseStr = strtotime($thirdPartySettings["applicationClose"]);
-  $applicationCloseDate = DrupalDateTime::createFromFormat('U', $applicationCloseStr, 'Europe/Helsinki');
-  $applicationCloseDateFormat = $applicationCloseDate->format('Y-m-d\TH:i:s');
+  $applicationCloseDate = $applicationCloseStr ?
+    DrupalDateTime::createFromFormat('U', $applicationCloseStr, 'Europe/Helsinki') :
+    NULL;
+
+  $applicationCloseDateFormat = $applicationCloseDate?->format('Y-m-d\TH:i:s');
+
+  $bothDatesEmpty = ($applicationCloseDateFormat === NULL) && ($applicationOpenDate === NULL);
 
   // If we have open time, assume that end time is added as well and
-  // use them as is.
-  if (!empty($thirdPartySettings["applicationOpen"])) {
+  // use them as is, but also update values, if both dates are NULL.
+  if (!empty($thirdPartySettings["applicationOpen"]) || $bothDatesEmpty) {
     $page->set('field_application_period',
       [
         'value' => $applicationOpenDateFormat,


### PR DESCRIPTION
# [AU-1754](https://helsinkisolutionoffice.atlassian.net/browse/AU-1754)

## What was done

In some cases saving empty values will cause crash, when we try to sync updated settings to service page. (Due null not being right value to use DateTime with).

Added null checks and allowed updateing applicationPeriod to empty values, if both dates are empty.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1754-empty-date-crash`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

You can validate the crash in Develop:

* [ ] Open https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/kuva_projekti/settings as admin
* [ ] Clear both open & end dates values and save the form configuration
* [ ] You should see a crash / error page

In this branch:

* [ ] Check that the application won't crash, when saving empty values.
* [ ] Check that empty values are updated to service pages that are referencing the updated form.
* [ ] Check that non-empty values are saving correctly.



[AU-1754]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ