### PR TITLE
fix: AU-1775: Fix incorrect mapping in NuorisoToimintaDefinition

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoToimintaDefinition.php
@@ -285,6 +285,7 @@ class NuorisoToimintaDefinition extends ComplexDataDefinitionBase {
         ->setLabel('Lisätiedot')
         ->setSetting('jsonPath', [
           'compensation',
+          'rentsInfo',
           'rentsSummaryArray',
           'rentsInformation',
         ]);


### PR DESCRIPTION
# [AU-1775](https://helsinkisolutionoffice.atlassian.net/browse/AU-1775)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->
* Additional information field was disappearing after sending through integration due wrong mapping. Fixed this.

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1775-fix-nuor-field-mapping`
  * `make fresh`
* Run `make drush-cr`

## How to test


* [ ] Open a new [Nuorisotoiminta, toiminta- ja palkkausavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka)
* [ ] Fill at least all the required fields and Haen vuokra-avustusta + Avustuslajit to unlock 4 & 5 pages (We need to send this through integration)
* [ ] on page 5, make sure you add some data to "Lisätiedot" field
* [ ] Send the application through integration, after the status has been changed to received, check that the data you put into LIsätiedot field is still present



[AU-1775]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ