### PR TITLE
feat: AU-1780: add text in message field to closed and cancelled applications

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -43,6 +43,7 @@ function grants_handler_theme(): array {
         'message_form' => NULL,
         'submission' => NULL,
         'isDraft' => NULL,
+        'hideMessageText' => NULL,
       ],
     ],
 
@@ -1042,9 +1043,20 @@ function grants_handler_preprocess_webform_submission_messages(&$variables) {
   ];
 
   $variables['isDraft'] = FALSE;
+  $variables['hideMessageText'] = FALSE;
 
   if ($submissionData['status'] == 'DRAFT') {
     $variables['isDraft'] = TRUE;
+  }
+
+  if ($submissionData['status'] == 'DRAFT') {
+    $variables['isDraft'] = TRUE;
+  }
+
+  $statuses = ['DELETED', 'CANCELED', 'CANCELLED', 'CLOSED'];
+
+  if (in_array($submissionData['status'], $statuses)) {
+    $variables['hideMessageText'] = TRUE;
   }
 
   // If submission is ok for messaging.

--- a/public/modules/custom/grants_handler/templates/webform-submission-messages.html.twig
+++ b/public/modules/custom/grants_handler/templates/webform-submission-messages.html.twig
@@ -22,13 +22,18 @@
 
 <div class="webform-submission-messages__wrapper">
     <h3>{{ 'Messages'|t({}, {'context': 'grants_handler'})}}</h3>
-    <p>{{ 'You can send a message to the handler of the application or provide a missing attachment'|t({}, {'context': 'grants_handler'})}}</p>
+    {% if not hideMessageText and not isDraft %}
+      <p>{{ 'You can send a message to the handler of the application or provide a missing attachment'|t({}, {'context': 'grants_handler'})}}</p>
+    {% endif %}
     <div class="webform-submission-messages">
       <h4>{{ 'Sent messages'|t({}, {'context': 'grants_handler'})}}</h4>
       <hr/>
       <div{{ attributes.addClass(classes) }}>
         {% if isDraft %}
           <p>{{ 'You cannot send messages to an incomplete application.'|t({}, {'context': 'grants_handler'}) }}</p>
+        {% endif %}
+        {% if hideMessageText %}
+          <p>{{ 'Messages cannot be sent to a resolved application.'|t({}, {'context': 'grants_handler'}) }}</p>
         {% endif %}
         {{ messages }}
       </div>

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -577,3 +577,7 @@ msgstr "Hakemuksen käsittelijä"
 msgctxt "grants_handler"
 msgid "You cannot send messages to an incomplete application."
 msgstr "Keskeneräiseen hakemukseen ei voi lähettää viestejä."
+
+msgctxt "grants_handler"
+msgid "Messages cannot be sent to a resolved application."
+msgstr "Ratkaistuun hakemukseen ei voi lähettää viestejä."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -577,3 +577,7 @@ msgstr "Applikationshanterare"
 msgctxt "grants_handler"
 msgid "You cannot send messages to an incomplete application."
 msgstr "Du kan inte skicka meddelanden till en pågående ansökan"
+
+msgctxt "grants_handler"
+msgid "Messages cannot be sent to a resolved application."
+msgstr "Du kan inte skicka meddelanden till ett löst ansökan."


### PR DESCRIPTION
# [AU-1780](https://helsinkisolutionoffice.atlassian.net/browse/AU-1780)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added text to message field so it wouldn't be so confusing

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1780-message-text`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Oma asiointi](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi)
* [ ] Ask one of your applications to be cancelled from Avus2, if you dont have one already
* [ ] Open one draft, one sent and one cancelled application
* [ ] Check that you see text "You can send a message to the handler of the application or provide a missing attachment" only in sent application where the message box is open
* [ ] Check that you see text corresponding to status when message box is not open, and text above is not there

[AU-1780]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ