### PR TITLE
fix: AU-1753: Translate private profile display page headers to Finnish

### DIFF
--- a/public/modules/custom/grants_profile/templates/own-profile-private-person.html.twig
+++ b/public/modules/custom/grants_profile/templates/own-profile-private-person.html.twig
@@ -6,7 +6,7 @@
     <h3 class="info-grants">{{ "Own contact information"|t({}, {'context': 'Yksityishenkilön asiointi'}) }}</h3>
     <div class="grants-profile--extrainfo">
       <dl class="webform-section-grid-wrapper">
-        <dt class="webform-section-title" id="addresses">{{ 'Address'|t({}, {'context': 'grants_profile'}) }}</dt>
+        <dt class="webform-section-title" id="addresses">{{ 'Address' }}</dt>
         <div class="webform-section-wrapper grants-profile--officials">
           {% for address in profile.addresses %}
             <dd class="grants-profile--officials-item">
@@ -16,7 +16,7 @@
           {% endfor %}
         </div>
 
-        <dt class="webform-section-title" id="phone-number">{{ 'Phone number'|t({}, {'context': 'grants_profile'}) }}</dt>
+        <dt class="webform-section-title" id="phone-number">{{ 'Phone number' }}</dt>
         <div class="webform-section-wrapper grants-profile--officials">
           <dd class="grants-profile--officials-item">
             {{ profile.phone_number }}

--- a/public/modules/custom/grants_profile/templates/own-profile-private-person.html.twig
+++ b/public/modules/custom/grants_profile/templates/own-profile-private-person.html.twig
@@ -6,7 +6,7 @@
     <h3 class="info-grants">{{ "Own contact information"|t({}, {'context': 'Yksityishenkilön asiointi'}) }}</h3>
     <div class="grants-profile--extrainfo">
       <dl class="webform-section-grid-wrapper">
-        <dt class="webform-section-title" id="addresses">{{ 'Address' }}</dt>
+        <dt class="webform-section-title" id="addresses">{{ 'Address'|t }}</dt>
         <div class="webform-section-wrapper grants-profile--officials">
           {% for address in profile.addresses %}
             <dd class="grants-profile--officials-item">
@@ -16,7 +16,7 @@
           {% endfor %}
         </div>
 
-        <dt class="webform-section-title" id="phone-number">{{ 'Phone number' }}</dt>
+        <dt class="webform-section-title" id="phone-number">{{ 'Phone number'|t }}</dt>
         <div class="webform-section-wrapper grants-profile--officials">
           <dd class="grants-profile--officials-item">
             {{ profile.phone_number }}


### PR DESCRIPTION
# [AU-1753](https://helsinkisolutionoffice.atlassian.net/browse/AU-1753)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove contexts from where contexts are not required.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1753-private-form`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to profile page as private person in Finnish and Swedish. See that there are no english there
* [ ] Check that code follows our standards

[AU-1753]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ