### PR TITLE
fix: AU-1788: Vuokra-avustus fields

### DIFF
--- a/public/modules/custom/grants_premises/src/Element/RentedPremiseComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/RentedPremiseComposite.php
@@ -36,12 +36,14 @@ class RentedPremiseComposite extends WebformCompositeBase {
 
     $elements['premiseAddress'] = [
       '#type' => 'textfield',
-      '#title' => t('Premise Address', [], $tOpts),
+      '#title' => t('Street address', [], $tOpts),
+      '#required' => TRUE,
     ];
 
     $elements['premisePostalCode'] = [
       '#type' => 'textfield',
-      '#title' => t('Post Code', [], $tOpts),
+      '#title' => t('Postal Code', [], $tOpts),
+      '#required' => TRUE,
       '#size' => 10,
       '#maxlength' => 8,
       '#pattern' => '^(FI-)?[0-9]{5}$',
@@ -50,58 +52,48 @@ class RentedPremiseComposite extends WebformCompositeBase {
 
     $elements['premisePostOffice'] = [
       '#type' => 'textfield',
-      '#title' => t('Post office', [], $tOpts),
+      '#required' => TRUE,
+      '#title' => t('City', [], $tOpts),
     ];
 
     $elements['rentSum'] = [
       '#type' => 'number',
-      '#title' => t('Rent sum', [], $tOpts),
-    ];
-
-    $elements['usage'] = [
-      '#type' => 'textfield',
-      '#title' => t('Usage', [], $tOpts),
-    ];
-
-    $elements['daysPerWeek'] = [
-      '#type' => 'number',
-      '#title' => t('Days per week', [], $tOpts),
-    ];
-
-    $elements['hoursPerDay'] = [
-      '#type' => 'number',
-      '#title' => t('Hours per day', [], $tOpts),
+      '#required' => TRUE,
+      '#title' => t('Rent', [], $tOpts),
+      '#help' => t('EUR per month', [], $tOpts),
     ];
 
     $elements['lessorName'] = [
       '#type' => 'textfield',
+      '#required' => TRUE,
       '#title' => t('Lessor name', [], $tOpts),
     ];
 
     $elements['lessorPhoneOrEmail'] = [
       '#type' => 'textfield',
-      '#title' => t('Lessor phone or email', [], $tOpts),
+      '#required' => TRUE,
+      '#title' => t("Lessor's contact information", [], $tOpts),
+      '#help' => t('Email and/or telephone number', [], $tOpts),
     ];
 
-    $elements['lessorAddress'] = [
+    $elements['usage'] = [
       '#type' => 'textfield',
-      '#title' => t('Lessor address', [], $tOpts),
+      '#required' => TRUE,
+      '#title' => t('Purpose of use', [], $tOpts),
+      '#help' => t('For example, an office, storage, gathering or clubs', [], $tOpts),
     ];
 
-    $elements['lessorPostalCode'] = [
-      '#type' => 'textfield',
-      '#title' => t('Lessor postal code', [], $tOpts),
-      '#size' => 10,
-      '#maxlength' => 8,
-      '#pattern' => '^(FI-)?[0-9]{5}$',
-      '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
+    $elements['daysPerWeek'] = [
+      '#type' => 'number',
+      '#required' => TRUE,
+      '#title' => t('How many days per week is the facility used?', [], $tOpts),
     ];
 
-    $elements['lessorPostOffice'] = [
-      '#type' => 'textfield',
-      '#title' => t('Lessor post office', [], $tOpts),
+    $elements['hoursPerDay'] = [
+      '#type' => 'number',
+      '#required' => TRUE,
+      '#title' => t('How many hours per day is the facility used?', [], $tOpts),
     ];
-
     return $elements;
   }
 

--- a/public/modules/custom/grants_premises/src/Element/RentedPremiseComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/RentedPremiseComposite.php
@@ -37,13 +37,11 @@ class RentedPremiseComposite extends WebformCompositeBase {
     $elements['premiseAddress'] = [
       '#type' => 'textfield',
       '#title' => t('Street address', [], $tOpts),
-      '#required' => TRUE,
     ];
 
     $elements['premisePostalCode'] = [
       '#type' => 'textfield',
       '#title' => t('Postal Code', [], $tOpts),
-      '#required' => TRUE,
       '#size' => 10,
       '#maxlength' => 8,
       '#pattern' => '^(FI-)?[0-9]{5}$',
@@ -52,46 +50,39 @@ class RentedPremiseComposite extends WebformCompositeBase {
 
     $elements['premisePostOffice'] = [
       '#type' => 'textfield',
-      '#required' => TRUE,
       '#title' => t('City', [], $tOpts),
     ];
 
     $elements['rentSum'] = [
       '#type' => 'number',
-      '#required' => TRUE,
       '#title' => t('Rent', [], $tOpts),
       '#help' => t('EUR per month', [], $tOpts),
     ];
 
     $elements['lessorName'] = [
       '#type' => 'textfield',
-      '#required' => TRUE,
       '#title' => t('Lessor name', [], $tOpts),
     ];
 
     $elements['lessorPhoneOrEmail'] = [
       '#type' => 'textfield',
-      '#required' => TRUE,
       '#title' => t("Lessor's contact information", [], $tOpts),
       '#help' => t('Email and/or telephone number', [], $tOpts),
     ];
 
     $elements['usage'] = [
       '#type' => 'textfield',
-      '#required' => TRUE,
       '#title' => t('Purpose of use', [], $tOpts),
       '#help' => t('For example, an office, storage, gathering or clubs', [], $tOpts),
     ];
 
     $elements['daysPerWeek'] = [
       '#type' => 'number',
-      '#required' => TRUE,
       '#title' => t('How many days per week is the facility used?', [], $tOpts),
     ];
 
     $elements['hoursPerDay'] = [
       '#type' => 'number',
-      '#required' => TRUE,
       '#title' => t('How many hours per day is the facility used?', [], $tOpts),
     ];
     return $elements;

--- a/public/modules/custom/grants_premises/translations/fi.po
+++ b/public/modules/custom/grants_premises/translations/fi.po
@@ -81,7 +81,7 @@ msgid "Location"
 msgstr "Toimipaikka"
 
 msgctxt "grants_premises"
-msgid "Street Address"
+msgid "Street address"
 msgstr "Katuosoite"
 
 msgctxt "grants_premises"

--- a/public/modules/custom/grants_premises/translations/fi.po
+++ b/public/modules/custom/grants_premises/translations/fi.po
@@ -21,6 +21,10 @@ msgid "Post Code"
 msgstr "Postinumero"
 
 msgctxt "grants_premises"
+msgid "Postal Code"
+msgstr "Postinumero"
+
+msgctxt "grants_premises"
 msgid "Applicant owns property"
 msgstr "Tila on omassa omistuksessa"
 
@@ -63,10 +67,6 @@ msgstr "Erityisopiskelijat"
 msgctxt "grants_premises"
 msgid "Student Count"
 msgstr "Opiskelijamäärä"
-
-msgctxt "grants_premises"
-msgid "Premise Address"
-msgstr "Tilan osoite"
 
 msgctxt "grants_premises"
 msgid "Premise type"
@@ -157,40 +157,48 @@ msgid "Post office"
 msgstr "Toimipaikka"
 
 msgctxt "grants_premises"
+msgid "City"
+msgstr "Postitoimipaikka"
+
+msgctxt "grants_premises"
 msgid "Rent sum"
 msgstr "Vuokra"
 
 msgctxt "grants_premises"
-msgid "Usage"
-msgstr "Käyttö"
+msgid "Rent"
+msgstr "Vuokra"
 
 msgctxt "grants_premises"
-msgid "Days per week"
-msgstr "Päiviä viikossa"
+msgid "Purpose of use"
+msgstr "Käyttötarkoitus"
 
 msgctxt "grants_premises"
-msgid "Hours per day"
-msgstr "Tunteja päivässä"
+msgid "For example, an office, storage, gathering or clubs"
+msgstr "Esimerkiksi toimisto, varasto, kokoontuminen tai kerhot"
 
 msgctxt "grants_premises"
-msgid "Lessor name"
+msgid "How many days per week is the facility used?"
+msgstr "Kuinka monena päivänä viikossa tilassa on toimintaa?"
+
+msgctxt "grants_premises"
+msgid "How many hours per day is the facility used?"
+msgstr "Kuinka monta tuntia päivässä tilassa on toimintaa?"
+
+msgctxt "grants_premises"
+msgid "Lessor's name"
 msgstr "Vuokranantajan nimi"
 
 msgctxt "grants_premises"
-msgid "Lessor phone or email"
-msgstr "Vuokranantajan puhelin tai sähköposti"
+msgid "Lessor's contact information"
+msgstr "Vuokranantajan yhteystiedot"
 
 msgctxt "grants_premises"
-msgid "Lessor address"
-msgstr "Vuokranantajan osoite"
+msgid "Email and/or telephone number"
+msgstr "Sähköpostiosoite ja/tai puhelinnumero"
 
 msgctxt "grants_premises"
-msgid "Lessor postal code"
-msgstr "Vuokranantajan postinumero"
-
-msgctxt "grants_premises"
-msgid "Lessor post office"
-msgstr "Vuokranantajan toimipaikka"
+msgid "EUR per month"
+msgstr "Kuinka monta euroa kuukaudessa"
 
 msgctxt "rent_income_composite"
 msgid "Sports facility"

--- a/public/modules/custom/grants_premises/translations/sv.po
+++ b/public/modules/custom/grants_premises/translations/sv.po
@@ -37,7 +37,7 @@ msgid "Location"
 msgstr "Verksamhetsställe"
 
 msgctxt "grants_premises"
-msgid "Street Address"
+msgid "Street address"
 msgstr "Gatuadress"
 
 msgctxt "grants_premises"

--- a/public/modules/custom/grants_premises/translations/sv.po
+++ b/public/modules/custom/grants_premises/translations/sv.po
@@ -29,6 +29,10 @@ msgid "Post Code"
 msgstr "Postnummer"
 
 msgctxt "grants_premises"
+msgid "Postal Code"
+msgstr "Postnummer"
+
+msgctxt "grants_premises"
 msgid "Location"
 msgstr "Verksamhetsställe"
 
@@ -154,40 +158,49 @@ msgid "Post office"
 msgstr "Posta"
 
 msgctxt "grants_premises"
+msgid "City"
+msgstr "Postanstalt"
+
+msgctxt "grants_premises"
 msgid "Rent sum"
 msgstr "Hyressumma"
 
 msgctxt "grants_premises"
-msgid "Usage"
-msgstr "Användande"
+msgid "Rent"
+msgstr "Hyra"
 
 msgctxt "grants_premises"
-msgid "Days per week"
-msgstr "Dagar i veckan"
+msgid "Purpose of use"
+msgstr "Användning"
 
 msgctxt "grants_premises"
-msgid "Hours per day"
-msgstr "Timmar per dag"
+msgid "For example, an office, storage, gathering or clubs"
+msgstr "Till exempel kontor, lager, samling eller klubbar"
 
 msgctxt "grants_premises"
-msgid "Lessor name"
+msgid "How many days per week is the facility used?"
+msgstr "Hur många dagar i veckan ordnas verksamhet i lokalen?"
+
+msgctxt "grants_premises"
+msgid "How many hours per day is the facility used?"
+msgstr "Hur många dagar i veckan ordnas verksamhet i lokalen?"
+
+msgctxt "grants_premises"
+msgid "Lessor's name"
 msgstr "Hyresvärdens namn"
 
 msgctxt "grants_premises"
-msgid "Lessor phone or email"
-msgstr "Hyresvärdens telefon eller e-post"
+msgid "Lessor's contact information"
+msgstr "Hyresvärdens kontaktuppgifter"
 
 msgctxt "grants_premises"
-msgid "Lessor address"
-msgstr "Hyresvärdens adress"
+msgid "Email and/or telephone number"
+msgstr "E-postadress och/eller telefonnummer"
 
 msgctxt "grants_premises"
-msgid "Lessor postal code"
-msgstr "Hyresvärdens postnummer"
+msgid "EUR per month"
+msgstr "Hur många euro per månad"
 
-msgctxt "grants_premises"
-msgid "Lessor post office"
-msgstr "Hyresvärdens posta"
 msgctxt "rent_income_composite"
 msgid "Sports facility"
 msgstr "Idrottslokal"


### PR DESCRIPTION
# [AU-1788](https://helsinkisolutionoffice.atlassian.net/browse/AU-1788)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed fields on NuorToimPalk to match excel

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1788-vuokra-fields`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [nuortoimpalk](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuortoimpalkka) form
* [ ] Select "haen vuokra-avustusta" on page 2
* [ ] Go to page 5. See that the fields and help texts match the excel
* [ ] see that the form saves nicely and sends out well
* [ ] Note that the fields on page 5 are not required even if the ticket says so, because of states and multiple composites.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1788]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ