### PR TITLE
fix: AU-1795: Make it so that link forwarding works with links that have inner elements

### DIFF
--- a/public/modules/custom/grants_handler/js/webform.form.unsaved.js
+++ b/public/modules/custom/grants_handler/js/webform.form.unsaved.js
@@ -105,7 +105,7 @@
               unsaved = false;
               $(this).dialog('close');
               modal = true;
-              window.top.location.href = event.target.href;
+              window.top.location.href = event.currentTarget.href;
             },
           },
           {


### PR DESCRIPTION
# [AU-1795](https://helsinkisolutionoffice.atlassian.net/browse/AU-1795)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* made the "target" into a "currentTarget" in the javascript that controls the navigate-away-from-forms-when-there-are-changes behaviour.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1795-undefined-response-url`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Clear browser caches. You have old javascript there that needs to go away for this to work.
* [ ] Log in, navigate to [a form](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuorisopalvelut_toiminta_ja_palk).
* [ ] Write something in a field.
* [ ] Click on "Avustusasiointi" text in the top navigation and select "leave application". The link should work correctly instead of directing to undefined.
* [ ] Check that code follows our standards


[AU-1795]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ