### PR TITLE
fix: AU-1785: make post-code not required in Premises Composite

### DIFF
--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -660,6 +660,7 @@ elements: |-
         '#multiple__add_more_button_label': 'Lisää uusi tila'
         '#premiseType__access': false
         '#premiseAddress__access': false
+        '#postCode__required': true
         '#location__access': false
         '#streetAddress__access': false
         '#address__access': false

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -880,6 +880,7 @@ elements: |-
         '#location__access': false
         '#streetAddress__access': false
         '#address__access': false
+        '#postCode__required': true
         '#studentCount__access': false
         '#specialStudents__access': false
         '#groupCount__access': false

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -516,6 +516,7 @@ elements: |-
         '#premiseType__access': false
         '#premiseAddress__access': false
         '#location__access': false
+        '#postCode__required': true
         '#streetAddress__access': false
         '#address__access': false
         '#studentCount__access': false

--- a/conf/cmi/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -482,6 +482,7 @@ elements: |-
         '#multiple__add': false
         '#multiple__add_more_input': false
         '#premiseAddress__access': false
+        '#postCode__required': true
         '#location__access': false
         '#streetAddress__access': false
         '#address__access': false
@@ -624,6 +625,7 @@ elements: |-
         '#multiple__add_more_input': false
         '#premiseType__access': false
         '#premiseAddress__access': false
+        '#postCode__required': true
         '#location__access': false
         '#streetAddress__access': false
         '#address__access': false

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
@@ -652,6 +652,7 @@ elements: |-
         '#multiple__min_items': 0
         '#multiple__empty_items': 0
         '#multiple__sorting': false
+        '#postCode__required': true
         '#multiple__add': false
         '#multiple__add_more_input': false
         '#multiple__add_more_button_label': 'Lisää uusi tila'

--- a/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
+++ b/public/modules/custom/grants_premises/src/Element/PremisesComposite.php
@@ -76,7 +76,6 @@ class PremisesComposite extends WebformCompositeBase {
       '#maxlength' => 8,
       '#pattern' => ValidPostalCodeValidator::$postalCodePattern,
       '#pattern_error' => t('Use the format FI-XXXXX or enter a five-digit postcode.', [], $tOpts),
-      '#required' => TRUE,
     ];
 
     $elements['studentCount'] = [


### PR DESCRIPTION
# [AU-1785](https://helsinkisolutionoffice.atlassian.net/browse/AU-1785)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Made postal code in premises composite not be required by hardcode and made sure that forms have the correct required fields.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1785-postalcode`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check through all the forms. See that the postal code "required" state works the same for Postal Code as it does for other related fields (like premise name). This is not an exact science, since the excel is useless.
* [ ] Check that you can send all the forms with premises composite
* [ ] Check that code follows our standards


[AU-1785]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ