### PR TITLE
fix: AU-1826: nuortoimpalk titles (all languages)

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -138,9 +138,9 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\NuorisoToimintaDefinition
         definitionId: grants_metadata_nuorisotoiminta
       labels:
-        fi: 'Nuorisotoiminta, toiminta- ja palkkausavustushakemus'
-        en: 'EN Nuorisotoiminta, toiminta- ja palkkausavustushakemus'
-        sv: 'SV Nuorisotoiminta, toiminta- ja palkkausavustushakemus'
+        fi: 'Nuorisopalvelu, toiminta- ja palkkausavustushakemus'
+        en: 'Youth service, operations and employment grant application'
+        sv: 'Ungdomstjänst, ansökan om verksamhets- och anställningsbidrag'
     65:
       id: NUORLOMALEIR
       code: NUORLOMALEIR

--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -1,5 +1,4 @@
 title: 'Ungdomstjänst, ansökan om verksamhets- och anställningsbidrag'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'

--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -32,7 +32,7 @@ uid: 1
 template: false
 archive: false
 id: nuortoimpalkka
-title: 'Nuorisotoiminta, toiminta- ja palkkausavustushakemus'
+title: 'Nuorisopalvelu, toiminta- ja palkkausavustushakemus'
 description: NUORTOIMPALKKA
 category: ''
 elements: |-

--- a/public/modules/custom/grants_metadata/src/Plugin/DataType/NuorisoToimintaPalkkaData.php
+++ b/public/modules/custom/grants_metadata/src/Plugin/DataType/NuorisoToimintaPalkkaData.php
@@ -9,7 +9,7 @@ use Drupal\Core\TypedData\Plugin\DataType\Map;
  *
  * @DataType(
  * id = "grants_metadata_nuorisotoiminta",
- * label = @Translation("Nuorisotoiminta, toiminta- ja palkkausavustushakemus"),
+ * label = @Translation("Nuorisopalvelu, toiminta- ja palkkausavustushakemus"),
  * definition_class =
  *   "\Drupal\grants_metadata\TypedData\Definition\NuorisoToimintaDefinition"
  * )


### PR DESCRIPTION
# [AU-1826](https://helsinkisolutionoffice.atlassian.net/browse/AU-1826)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Nuortoimpalk now has correct title in all three languages

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [nuortoimpalk](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuortoimpalkka)
* [ ] See that the title matches the one on Excel's "Hakemuksen nimet ja käännökset" tab's title
* [ ] Switch to English
* [ ] See that the title matches the one on Excel's "Hakemuksen nimet ja käännökset" tab's title
* [ ] Switch to Swedish
* [ ] See that the title matches the one on Excel's "Hakemuksen nimet ja käännökset" tab's title
* [ ] Check that code follows our standards


[AU-1826]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ