### PR TITLE
AU-1813: Fix ajax message errors lingering till new page load

### DIFF
--- a/public/modules/custom/grants_handler/src/Form/MessageForm.php
+++ b/public/modules/custom/grants_handler/src/Form/MessageForm.php
@@ -417,24 +417,6 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
 
   /**
    * {@inheritdoc}
-   */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-
-  }
-
-  /**
-   * Ajax callback. Not used currently.
-   *
-   * @param array $form
-   *   Form.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   State.
-   */
-  public function ajaxCallback(array $form, FormStateInterface $form_state) {
-  }
-
-  /**
-   * {@inheritdoc}
    *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */

--- a/public/modules/custom/grants_handler/src/Form/MessageForm.php
+++ b/public/modules/custom/grants_handler/src/Form/MessageForm.php
@@ -175,31 +175,8 @@ class MessageForm extends FormBase {
 
     $messageSent = $storage['message_sent'] ?? FALSE;
 
-    $errorMessages = $this->messenger()
-      ->messagesByType(MessengerInterface::TYPE_ERROR);
-    $statusMessages = $this->messenger()
-      ->messagesByType(MessengerInterface::TYPE_STATUS);
-
-    $this->messenger()->deleteByType(MessengerInterface::TYPE_ERROR);
-    $this->messenger()->deleteByType(MessengerInterface::TYPE_STATUS);
-
-    $render = [
-      '#theme' => 'status_messages',
-      '#message_list' => [
-        'status' => $statusMessages,
-        'error' => $errorMessages,
-      ],
-      '#status_headings' => [
-        'status' => $this->t('Status message'),
-        'error' => $this->t('Error message'),
-        'warning' => $this->t('Warning message'),
-      ],
-    ];
-
-    $renderedHtml = $this->renderer->render($render);
-
     $form['status_messages'] = [
-      '#markup' => $renderedHtml,
+      '#markdown' => '',
     ];
 
     if (!$messageSent) {
@@ -331,6 +308,35 @@ rtf, txt, xls, xlsx, zip.', [], $tOpts),
       $appendMessage = new AppendCommand('.webform-submission-messages__messages-list', $messageOutput);
       $ajaxResponse->addCommand($appendMessage);
     }
+
+    // Handle possible errors during the AJAX request.
+    $errorMessages = $this->messenger()
+      ->messagesByType(MessengerInterface::TYPE_ERROR);
+    $statusMessages = $this->messenger()
+      ->messagesByType(MessengerInterface::TYPE_STATUS);
+
+    $this->messenger()->deleteByType(MessengerInterface::TYPE_ERROR);
+    $this->messenger()->deleteByType(MessengerInterface::TYPE_STATUS);
+    $this->messenger()->deleteByType(MessengerInterface::TYPE_WARNING);
+
+    $render = [
+      '#theme' => 'status_messages',
+      '#message_list' => [
+        'status' => $statusMessages,
+        'error' => $errorMessages,
+      ],
+      '#status_headings' => [
+        'status' => $this->t('Status message'),
+        'error' => $this->t('Error message'),
+        'warning' => $this->t('Warning message'),
+      ],
+    ];
+
+    $renderedHtml = $this->renderer->render($render);
+
+    $form['status_messages'] = [
+      '#markup' => $renderedHtml,
+    ];
 
     $replaceCommand = new ReplaceCommand('[id^=grants-handler-message]', $form);
     $ajaxResponse->addCommand($replaceCommand);


### PR DESCRIPTION
# [AU-1813](https://helsinkisolutionoffice.atlassian.net/browse/AU-1813)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Validation error messages (Like empty messages, weren't show immediately and caused them to appear in another pages)
* Handle error messages in ajaxcallback

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1813-lingering-message-validation-error`
  * `make fresh`
* Run `make drush-cr`

## How to test

 **Validate the current problem** // Develop branch
* [ ] Create / view an application where you can send messages
* [ ] Try to send an empty message
* [ ] You should see the inline-error
* [ ] BUT, when you change a page you can see the system messages there
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/e752bce7-3b09-4958-b597-797e068d6212)

 **Validate the fix** 
* [ ] Create / view an application where you can send messages
* [ ] Try to send an empty message
* [ ] You should see both inline-error and system messages immediately 
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/dbb1ed68-bc76-441d-9409-ce4a9c0bfbbe)
* [ ] No validation messages should appear, when you change the page.

<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards




[AU-1813]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ