### PR TITLE
fix: AU-1822: Remove unused street address

### DIFF
--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -618,6 +618,7 @@ elements: |-
         '#address__access': false
         '#studentCount__access': false
         '#specialStudents__access': false
+        '#streetAddress__access': false
         '#groupCount__access': false
         '#specialGroups__access': false
         '#personnelCount__access': false


### PR DESCRIPTION
# [AU-1822](https://helsinkisolutionoffice.atlassian.net/browse/AU-1822)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove unused Street Address from page 3 of nuortoimpalk

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1822-remove-street-address-nuortoimapalk`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Nuortoimpalk](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuortoimpalkka)
* [ ] go to page 3, see that the street address has been removed
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1822]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ