### PR TITLE
fix: AU-1827: fix kasko toiminta-avustus names

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -178,9 +178,9 @@ third_party_options:
         definitionClass: Drupal\grants_metadata\TypedData\Definition\KaskoToimintaDefinition
         definitionId: grants_metadata_kaskotoiminta
       labels:
-        fi: 'Kasvatus ja koulutus:  toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille'
-        en: 'EN Kasvatus ja koulutus:  toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille'
-        sv: 'SV Kasvatus ja koulutus:  toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille'
+        fi: 'Kasvatus ja koulutus, toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille'
+        en: 'Education, grant application for organisers of afternoon activities for school children'
+        sv: 'Fostran och utbildning, ansökan om verksamhetsbidrag för organisatörer av eftermiddagsverksamhet för skolbarn'
     60:
       id: LIIKUNTATILANKAYTTO
       code: LIIKUNTATILANKAYTTO

--- a/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -1,4 +1,4 @@
-title: 'City Board, general grant application'
+title: 'Education, grant application for organisers of afternoon activities for school children'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Applicant details'

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -1,5 +1,4 @@
 title: 'Fostran och utbildning, ansökan om verksamhetsbidrag för organisatörer av eftermiddagsverksamhet för skolbarn'
-description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:
     '#title': '1. Den sökandes uppgifter'

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -1,4 +1,4 @@
-title: 'Stadsstyrelsen, allmän bidragsansökan'
+title: 'Fostran och utbildning, ansökan om verksamhetsbidrag för organisatörer av eftermiddagsverksamhet för skolbarn'
 description: 'MVP-f&ouml;rm'
 elements: |
   1_hakijan_tiedot:

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -30,7 +30,7 @@ uid: 1
 template: false
 archive: false
 id: kasvatus_ja_koulutus_toiminta_av
-title: 'Kasvatus ja koulutus: toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille'
+title: 'Kasvatus ja koulutus, toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille'
 description: KASKOIPTOIM
 category: ''
 elements: |-


### PR DESCRIPTION
# [AU-1827](https://helsinkisolutionoffice.atlassian.net/browse/AU-1827)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix kasko toiminta-avustushakemus title translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1827-kasko-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] [Open application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kasvatus_ja_koulutus_toiminta_av)
* [ ] Check that title translations are correct


[AU-1827]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ