### PR TITLE
fix: AU-1829: Bring first page of nuortoimpalk to match the other forms

### DIFF
--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -152,21 +152,25 @@ elements: |-
       '#type': hidden
       '#title': 'Hakemuksen tila'
       '#readonly': true
-    yhteiso_jolle_haetaan_avustusta:
+    hakemusprofiili:
       '#type': webform_section
-      '#title': 'Yhteisö, jolle haetaan avustusta'
+      '#title': 'Haetut tiedot'
       '#attributes':
         class:
           - grants-profile--imported-section
       prh_markup:
         '#type': webform_markup
-        '#markup': '<div class="grants-profile-prh-info">Tiedot on haettu Patentti- ja rekisterihallinnon rekisteristä (PRH), eikä niitä voi tämän takia muokata.</div>'
+        '#markup': 'Tiedot on haettu hakuprofiilistasi.'
       hakijan_tiedot:
         '#type': applicant_info
-        '#title': 'Hakijan tiedot'
+        '#title': Hakija
     contact_person_email_section:
       '#type': webform_section
       '#title': Sähköposti
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
       contact_markup:
         '#type': webform_markup
         '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
@@ -176,27 +180,34 @@ elements: |-
         '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
         '#size': 63
         '#autocomplete': 'off'
-        '#required': true
+        '#states':
+          required:
+            ':input[name="applicant_type"]':
+              value: registered_community
     contact_person_section:
       '#type': webform_section
       '#title': 'Hakemuksen yhteyshenkilö'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
       contact_person:
         '#type': textfield
         '#title': Yhteyshenkilö
         '#autocomplete': 'off'
+        '#required': true
         '#attributes':
           class:
             - webform--large
-        '#required': true
         '#size': 63
       contact_person_phone_number:
         '#type': textfield
-        '#attributes':
-          class:
-            - webform--medium
         '#title': Puhelinnumero
         '#required': true
         '#autocomplete': 'off'
+        '#attributes':
+          class:
+            - webform--medium
         '#size': 32
     osoite:
       '#type': webform_section


### PR DESCRIPTION
# [AU-1829](https://helsinkisolutionoffice.atlassian.net/browse/AU-1829)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Make front page of Nuortoimpalk match other front pages

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1829-nuortoimapalk-unregistered-frontpage`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as unregistered community
* [ ] Go to [Nuortoimpalk](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuortoimpalkka) and see that the first page matches [some other form](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti) that you can access as unregistered community.
* [ ] Repeat as registered community.
* [ ] Check that code follows our standards


[AU-1829]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ