### PR TITLE
fix: AU-1815: Add translations to Cancel Grants Profile Creation

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
@@ -904,7 +904,7 @@ rtf, txt, xls, xlsx, zip.', [], $this->tOpts),
 
       try {
         $atvService->deleteDocument($profileDocument);
-        \Drupal::messenger()->addStatus('Grants profile creation canceled.');
+        \Drupal::messenger()->addStatus(t('Grants profile creation canceled.', [], ['context' => 'grants_profile']));
       }
       catch (\Throwable $e) {
         \Drupal::logger('grants_profile')

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -583,3 +583,7 @@ msgstr "Poista oma profiili"
 msgctxt "grants_profile"
 msgid "Use the format FI-XXXXX or enter a five-digit postcode."
 msgstr "Käytä muotoa FI-XXXXX tai syötä postinumero viisinumeroisena."
+
+msgctxt "grants_profile"
+msgid "Grants profile creation canceled."
+msgstr "Asiointiprofiilin luonti peruttu."

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -540,3 +540,7 @@ msgstr "Radera min profil"
 msgctxt "grants_profile"
 msgid "Use the format FI-XXXXX or enter a five-digit postcode."
 msgstr "Använd formen FI-XXXXX eller ange ett femsiffrigt postnummer."
+
+msgctxt "grants_profile"
+msgid "Grants profile creation canceled."
+msgstr "Skapandet av en transaktionsprofil avbröts."


### PR DESCRIPTION
# [AU-1815](https://helsinkisolutionoffice.atlassian.net/browse/AU-1815)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add missing tranlsation

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1815-grants-profile-creation-cancel-message`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Create new unregistered community
* [ ] cancel the creation on the page
* [ ] see that the translation of the status message works
* [ ] do the same in Swedish
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1815]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ