### PR TITLE
fix: AU-1836: translate "previous" to finnish and swedisn on form

### DIFF
--- a/conf/cmi/language/en/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/language/en/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -178,6 +178,8 @@ elements: |
     '#help': 'How many community members does the community currently have in Helsinki who have paid the membership fee? Community members are non-individual members, such as associations, foundations, companies or municipalities.'
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and appendices'
+    '#prev_button_label': '< Previous'
+    '#next_button_label': 'Next >'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Additional information concerning the application'
   additional_information:

--- a/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -193,6 +193,8 @@ elements: |
     '#help': 'How many community members does the community currently have in Helsinki who have paid the membership fee? Community members are non-individual members, such as associations, foundations, companies or municipalities.'
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and appendices'
+    '#prev_button_label': '< Previous'
+    '#next_button_label': 'Next >'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Additional information concerning the application'
   additional_information:

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -195,6 +195,8 @@ elements: |
     '#help': 'Hur m&aring;nga samfundsmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
+    '#prev_button_label': '< Tidigare'
+    '#next_button_label': 'Nästa >'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Ytterligare information för ansökan'
   additional_information:

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -210,6 +210,8 @@ elements: |
     '#help': 'Hur m&aring;nga samfundsmedlemmar fr&aring;n Helsingfors som har betalat medlemsavgiften har samfundet f&ouml;r n&auml;rvarande? Samfundsmedlemmar &auml;r andra &auml;n personmedlemmar, s&aring;som f&ouml;reningar, stiftelser, f&ouml;retag eller kommuner.'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
+    '#prev_button_label': '< Tidigare'
+    '#next_button_label': 'Nästa >'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Ytterligare information för ansökan'
   additional_information:

--- a/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -540,6 +540,8 @@ elements: |-
   lisatiedot_ja_liitteet:
     '#type': webform_wizard_page
     '#title': '4. Lisätiedot ja liitteet'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
     lisatietoja_hakemukseen_liittyen:
       '#type': webform_section
       '#title': 'Lisätietoja hakemukseen liittyen'

--- a/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -605,6 +605,8 @@ elements: |-
   lisatiedot_ja_liitteet:
     '#type': webform_wizard_page
     '#title': '4. Lisätiedot ja liitteet'
+    '#prev_button_label': '< Edellinen'
+    '#next_button_label': 'Seuraava >'
     lisatietoja_hakemukseen_liittyen:
       '#type': webform_section
       '#title': 'Lisätietoja hakemukseen liittyen'


### PR DESCRIPTION
# [AU-1836](https://helsinkisolutionoffice.atlassian.net/browse/AU-1836)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* fixed missing previous translation from a couple of forms

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1836-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [this form](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_yleis_ja_toimin)
* [ ] navigate to page four. See that the "previous" button is translated
* [ ] switch to swedish, see that it works there too
* [ ] Go to [this form](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_pienavustushake)
* [ ] navigate to page four. See that the "previous" button is translated
* [ ] switch to swedish, see that it works there too
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1836]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ