### PR TITLE
fix: AU-1835: Remove target blank from own applications list

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1383,11 +1383,6 @@ function grants_handler_preprocess_application_list_item(&$variables) {
     [
       'submission_id' => $variables['applicationNumber'],
     ],
-    [
-      'attributes' => [
-        'target' => '_blank',
-      ],
-    ]
   );
 
   $editApplicationUrl = Url::fromRoute(


### PR DESCRIPTION
# [AU-1835](https://helsinkisolutionoffice.atlassian.net/browse/AU-1835)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1835-remove-target-blank`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [omat hakemukset](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi)
* [ ] click on a view application link on a sent application
* [ ] see that it doens't open in a new tab.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1835]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ