### PR TITLE
fix: AU-1823: Add tooltip to digital only on nuortoimpalk

### DIFF
--- a/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
@@ -155,6 +155,7 @@ elements: |
     '#title': 'Places where the association organised activities for young people during the previous year'
   jarjestimme_toimintaa_vain_digitaalisessa_ymparistossa:
     '#title': 'We only organised activities in a digital environment'
+    '#help': 'Select “Yes” if you only organised activities in a digital environment. Select “No” if you only organised activities on a physical site or in both digital and physical environments. Enter the names and postcodes of the physical premises in the fields below.'
     '#options':
       1: 'Yes'
       0: 'No'

--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -158,6 +158,7 @@ elements: |
     '#title': 'Platser där föreningen organiserade verksamhet för unga under föregående år'
   jarjestimme_toimintaa_vain_digitaalisessa_ymparistossa:
     '#title': 'Vi ordnade endast verksamhet i den digitala miljön'
+    '#help': 'Välj ”Ja” om ni endast ordnade verksamhet i en digital miljö. Välj ”Nej” om ni endast ordnade verksamhet vid ett fysiskt verksamhetsställe eller ordnade verksamhet både i en digital miljö och vid ett fysiskt verksamhetsställe. Skriv namnen på de fysiska verksamhetsställena och postnumren i fälten som öppnas nedan.'
     '#options':
       1: Ja
       0: Nej

--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -601,6 +601,7 @@ elements: |-
       jarjestimme_toimintaa_vain_digitaalisessa_ymparistossa:
         '#type': radios
         '#title': 'Järjestimme toimintaa vain digitaalisessa ympäristössä'
+        '#help': 'Valitse ”Kyllä”, mikäli järjestitte toimintaa ainoastaan digitaalisessa ympäristössä. Valitse ”Ei”, mikäli järjestitte toimintaa vain fyysisessä toimipaikassa tai järjestitte toimintaa sekä digitaalisessa että fyysisessä ympäristössä. Merkitse fyysisten toimitilojen nimet ja postinumerot alle aukeaviin kenttiin.'
         '#options':
           1: Kyllä
           0: Ei


### PR DESCRIPTION
# [AU-1823](https://helsinkisolutionoffice.atlassian.net/browse/AU-1823)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add tooltip as per ticket

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1823-tooltip-to-nuortoimpalk`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [nuortoimpalkka](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuortoimpalkka) form
* [ ] On page 3, see that there is a tooltip in the digital only radios.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1823]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ