### PR TITLE
fix: AU-1847: Add isApplicationOpen checks to copying

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1700,8 +1700,11 @@ function grants_handler_preprocess_webform_submission_information(array &$variab
     $editApplicationLink = Link::fromTextAndUrl($editApplicationLinkText, $editApplicationUrl);
     $variables['editApplicationLink'] = $editApplicationLink;
   }
-  // Show copy button only if copying has not been disabled.
-  if ($thirdPartySettings["disableCopying"] != 1) {
+
+  $isApplicationOpen = ApplicationHandler::isApplicationOpen($webform);
+
+  // Show copy button when the application is open and copying is not disabled.
+  if ($thirdPartySettings["disableCopying"] != 1 && $isApplicationOpen) {
     $copyApplicationUrl = Url::fromRoute(
       'grants_handler.copy_application_modal',
       [

--- a/public/modules/custom/grants_handler/src/Form/CopyApplicationModalForm.php
+++ b/public/modules/custom/grants_handler/src/Form/CopyApplicationModalForm.php
@@ -183,10 +183,11 @@ class CopyApplicationModalForm extends FormBase {
     /** @var \Drupal\webform\Entity\WebformSubmission $webform_submission */
     $webform_submission = $storage['submission'];
     $webform = $webform_submission->getWebForm();
+    $isApplicationOpen = ApplicationHandler::isApplicationOpen($webform);
     $thirdPartySettings = $webform->getThirdPartySettings('grants_metadata');
 
     // If copying is disabled in 3rd party settings, do not allow forward.
-    if ($thirdPartySettings["disableCopying"] == 1) {
+    if ($thirdPartySettings["disableCopying"] == 1 || !$isApplicationOpen) {
       $form_state->setErrorByName('modal_markup', 'Copying is disabled for this form.');
     }
   }


### PR DESCRIPTION
# [AU-1847](https://helsinkisolutionoffice.atlassian.net/browse/AU-1847)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Copy application feature doesn't take into account if the application is open or not
* Add checks for that.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1847-disallow-copying-if-inactive`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Send any open application through the integration 
* [ ] If needed, check webform configuration for that application and allow copying
* [ ] Check that the copy button is available in the application summary page 
* [ ] Modify application start / end times so that the application period is closed.
* [ ] Check that the copy button is gone.


## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1847]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ