### PR TITLE
fix: AU-1764: new texts to private person profile

### DIFF
--- a/public/modules/custom/grants_profile/grants_profile.module
+++ b/public/modules/custom/grants_profile/grants_profile.module
@@ -294,7 +294,7 @@ you can do that by going to the Helsinki-profile from this link.', [], $tOpts),
       'target' => '_blank',
     ],
   ]);
-  $editHelsinkiProfileLink = Link::fromTextAndUrl(t('Go to Helsinki-profile to edit your information.',
+  $editHelsinkiProfileLink = Link::fromTextAndUrl(t('Go to the Helsinki profile to update your email address.',
     [], $tOpts), $profileEditUrl);
   $helsinkiProfiiliDataService = \Drupal::service('helfi_helsinki_profiili.userdata');
   $helsinkiProfileContent = $helsinkiProfiiliDataService->getUserProfileData();

--- a/public/modules/custom/grants_profile/src/Controller/GrantsProfileController.php
+++ b/public/modules/custom/grants_profile/src/Controller/GrantsProfileController.php
@@ -167,7 +167,7 @@ you can do that by going to the Helsinki-profile from this link.', [], $tOpts),
     ];
 
     $build['#editHelsinkiProfileLink'] = Link::fromTextAndUrl(
-      $this->t('Go to Helsinki-profile to edit your information.', [], $tOpts),
+      $this->t('Go to the Helsinki profile to update your email address.', [], $tOpts),
       $profileEditUrl
     );
     $build['#editProfileLink'] = Link::fromTextAndUrl($editProfileText, $editProfileUrl);

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -191,7 +191,7 @@ you can do that by going to the Helsinki-profile from this link.', [], $this->tO
       ],
     ]);
     $editHelsinkiProfileLink = Link::fromTextAndUrl(
-      $this->t('Go to Helsinki-profile to edit your information.', [], $this->tOpts),
+      $this->t('Go to the Helsinki profile to update your email address.', [], $this->tOpts),
       $profileEditUrl
     );
 

--- a/public/modules/custom/grants_profile/templates/grants-profile--basic-info--private-person.html.twig
+++ b/public/modules/custom/grants_profile/templates/grants-profile--basic-info--private-person.html.twig
@@ -2,7 +2,9 @@
   <div class="container">
     <h3>{{ "Basic details"|t({}, {'context': 'Yksityishenkilön asiointi'}) }}</h3>
     <div class="grants-profile-prh-info">
-      <p>{{ "The information has been retrieved from your Helsinki profile. You need to go to your Helsinki profile to edit this information. When you have edited your information in the Helsinki profile, remember to update this field."|t({}, {'context': 'grants_profile'}) }}</p>
+      <p>{{ "The basic details have been retrieved from your Helsinki profile. The Helsinki profile retrieves the information, apart from your email address, from the official population information system and it cannot be edited."|t({}, {'context': 'grants_profile'}) }}</p>
+
+      <p>{{ "You can update your email address in your Helsinki profile. The updated email address will be added to the basic details after you have first confirmed the update with a confirmation message sent to your email. You will see the updated email address when you log into the Grants service again."|t({}, {'context': 'grants_profile'}) }}</p>
     </div>
     <hr />
     <dl class="grants-profile--wrapper">

--- a/public/modules/custom/grants_profile/templates/own-profile-private-person.html.twig
+++ b/public/modules/custom/grants_profile/templates/own-profile-private-person.html.twig
@@ -1,6 +1,6 @@
 <div class="container">
 <h2>{{ "Personal information"|t({}, {'context': 'Yksityishenkilön asiointi'}) }}</h2>
-  <p class="grants-profile--infotext">{{ "To apply for grants, the community data must be completed. When you submit a grant application, the information you have provided will be filled in automatically."|t({}, {'context': 'grants_profile'}) }}</p>
+  <p class="grants-profile--infotext">{{ "Applying for grants requires completing your own personal information. When applying for a grant the information you have provided in your personal information will automatically be imported into the grant application."|t({}, {'context': 'grants_profile'}) }}</p>
   <div class="grants-profile">
     {{ basic_info }}
     <h3 class="info-grants">{{ "Own contact information"|t({}, {'context': 'Yksityishenkilön asiointi'}) }}</h3>

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -480,6 +480,18 @@ msgid "The information has been retrieved from your Helsinki profile. You need t
 msgstr "Tiedot on haettu Helsinki-profiilistasi. Sinun pitää siirtyä Helsinki-profiiliin muokataksesi näitä tietoja. Kun olet muokannut tietojasi Helsinki-profiilissa, muista päivittää tämä kenttä."
 
 msgctxt "grants_profile"
+msgid "The basic details have been retrieved from your Helsinki profile. The Helsinki profile retrieves the information, apart from your email address, from the official population information system and it cannot be edited."
+msgstr "Perustiedot on haettu Helsinki-profiilistasi. Helsinki-profiili hakee muut kuin sähköpostiasi koskevat tiedot virallisesta väestötietojärjestelmästä, eikä niitä voi muokata."
+
+msgctxt "grants_profile"
+msgid "You can update your email address in your Helsinki profile. The updated email address will be added to the basic details after you have first confirmed the update with a confirmation message sent to your email. You will see the updated email address when you log into the Grants service again."
+msgstr "Sähköpostiosoitteen voit päivittää Helsinki-profiilissa. Päivitetty sähköpostiosoite tuodaan perustietoihin, kun olet ensin vahvistanut päivityksen sähköpostiisi saapuvan vahvistusviestin avulla. Näet päivitetyn sähköpostiosoitteen, kun kirjaudut uudestaan Avustusasiointiin."
+
+msgctxt "grants_profile"
+msgid "Applying for grants requires completing your own personal information. When applying for a grant the information you have provided in your personal information will automatically be imported into the grant application."
+msgstr "Avustusten hakeminen edellyttää omien tietojen täydentämistä. Tehdessäsi avustushakemuksia omissa tiedoissa antamasi tiedot tuodaan avustushakemukselle automaattisesti."
+
+msgctxt "grants_profile"
 msgid "By completing your own information, you will facilitate your dealings with grants. Based on the information, we can find grants that are more suitable for you or your community. In addition, filling out applications will be faster in the future."
 msgstr "Täydentämällä omat tiedot helpotat asiointiasi avustuksiin liittyen. Tietojen perusteella löydämme paremmin sinulle tai yhteisöllesi sopivat avustukset. Lisäksi hakemusten täyttäminen käy jatkossa nopeammin."
 

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -492,6 +492,10 @@ msgid "Applying for grants requires completing your own personal information. Wh
 msgstr "Avustusten hakeminen edellyttää omien tietojen täydentämistä. Tehdessäsi avustushakemuksia omissa tiedoissa antamasi tiedot tuodaan avustushakemukselle automaattisesti."
 
 msgctxt "grants_profile"
+msgid "Go to the Helsinki profile to update your email address."
+msgstr "Siirry Helsinki-profiiliin päivittääksesi sähköpostiosoitetta."
+
+msgctxt "grants_profile"
 msgid "By completing your own information, you will facilitate your dealings with grants. Based on the information, we can find grants that are more suitable for you or your community. In addition, filling out applications will be faster in the future."
 msgstr "Täydentämällä omat tiedot helpotat asiointiasi avustuksiin liittyen. Tietojen perusteella löydämme paremmin sinulle tai yhteisöllesi sopivat avustukset. Lisäksi hakemusten täyttäminen käy jatkossa nopeammin."
 

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -437,6 +437,18 @@ msgid "The information has been retrieved from your Helsinki profile. You need t
 msgstr "Informationen har hämtats från din Helsingfors-profil. Du måste gå till din Helsingforsprofil för att redigera denna information. När du har redigerat din information i Helsingforsprofilen, kom ihåg att uppdatera detta fält."
 
 msgctxt "grants_profile"
+msgid "The basic details have been retrieved from your Helsinki profile. The Helsinki profile retrieves the information, apart from your email address, from the official population information system and it cannot be edited."
+msgstr "Grundinformationen har hämtats från din Helsingforsprofil. Helsingforsprofilen hämtar övrig information utöver din e-postadress från det officiella befolkningsinformationssystemet och kan inte redigeras."
+
+msgctxt "grants_profile"
+msgid "You can update your email address in your Helsinki profile. The updated email address will be added to the basic details after you have first confirmed the update with a confirmation message sent to your email. You will see the updated email address when you log into the Grants service again."
+msgstr "Du kan uppdatera din e-postadress i din Helsingforsprofil. Den uppdaterade e-postadressen kommer att läggas till i grundinformationen efter att du först har bekräftat uppdateringen med ett bekräftelsemeddelande skickat till din e-post. Du kommer att se den uppdaterade e-postadressen när du loggar in igen i Bidragstjänsten."
+
+msgctxt "grants_profile"
+msgid "Applying for grants requires completing your own personal information. When applying for a grant the information you have provided in your personal information will automatically be imported into the grant application."
+msgstr "För att ansöka om stöd krävs att du fyller i dina egna uppgifter. När du gör ansökningar om stöd förmedlas den information du lämnar via dina personuppgifter automatiskt till din bidragsansökan."
+
+msgctxt "grants_profile"
 msgid "By completing your own information, you will facilitate your dealings with grants. Based on the information, we can find grants that are more suitable for you or your community. In addition, filling out applications will be faster in the future."
 msgstr "Genom att fylla i din egen information kommer du att underlätta din hantering av bidrag. Baserat på informationen kan vi hitta bidrag som är mer lämpade för dig eller din kommun. Dessutom kommer det gå snabbare att fylla i ansökningar i framtiden."
 

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -449,6 +449,10 @@ msgid "Applying for grants requires completing your own personal information. Wh
 msgstr "För att ansöka om stöd krävs att du fyller i dina egna uppgifter. När du gör ansökningar om stöd förmedlas den information du lämnar via dina personuppgifter automatiskt till din bidragsansökan."
 
 msgctxt "grants_profile"
+msgid "Go to the Helsinki profile to update your email address."
+msgstr "Gå till Helsingforsprofilen för att uppdatera e-postadressen."
+
+msgctxt "grants_profile"
 msgid "By completing your own information, you will facilitate your dealings with grants. Based on the information, we can find grants that are more suitable for you or your community. In addition, filling out applications will be faster in the future."
 msgstr "Genom att fylla i din egen information kommer du att underlätta din hantering av bidrag. Baserat på informationen kan vi hitta bidrag som är mer lämpade för dig eller din kommun. Dessutom kommer det gå snabbare att fylla i ansökningar i framtiden."
 


### PR DESCRIPTION
# [AU-1764](https://helsinkisolutionoffice.atlassian.net/browse/AU-1764)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added new texts to private person own profile

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1764-yksityishenkilo-profiili`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Login as private person and go to [own profile](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi/hakuprofiili)
* [x] Check that new texts match the ones in the ticket
* [x] Check that translations work

[AU-1764]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ