### PR TITLE
AU-1799: Limit Budget and Compensation field lengths

### DIFF
--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -120,7 +120,7 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
         '#title' => $fieldName,
         '#type' => 'textfield',
         '#input_mask' => "'alias': 'decimal', 'groupSeparator': ' ', 'digits': '2', 'radixPoint': ',', 'substituteRadixPoint': 'true'",
-        '#size' => 20,
+        '#maxlength' => 20,
         '#attributes' => [
           'class' => ['webform--small'],
         ],

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -120,7 +120,7 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
         '#title' => $fieldName,
         '#type' => 'textfield',
         '#input_mask' => "'alias': 'decimal', 'groupSeparator': ' ', 'digits': '2', 'radixPoint': ',', 'substituteRadixPoint': 'true'",
-        '#size' => 20,
+        '#maxlength' => 20,
         '#attributes' => [
           'class' => ['webform--small'],
         ],

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherCost.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherCost.php
@@ -84,7 +84,7 @@ class GrantsBudgetOtherCost extends WebformCompositeBase {
       '#title' => t('Amount (€)', [], $tOpts),
       '#type' => 'textfield',
       '#input_mask' => "'alias': 'decimal', 'groupSeparator': ' ', 'digits': '2', 'radixPoint': ',', 'substituteRadixPoint': 'true'",
-      '#size' => 20,
+      '#maxlength' => 20,
       '#element_validate' => [
         [LabelValueValidator::class, 'validate'],
       ],

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherIncome.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetOtherIncome.php
@@ -84,7 +84,7 @@ class GrantsBudgetOtherIncome extends WebformCompositeBase {
       '#title' => t('Amount (€)', [], $tOpts),
       '#type' => 'textfield',
       '#input_mask' => "'alias': 'decimal', 'groupSeparator': ' ', 'digits': '2', 'radixPoint': ',', 'substituteRadixPoint': 'true'",
-      '#size' => 20,
+      '#maxlength' => 20,
       '#element_validate' => [
         [LabelValueValidator::class, 'validate'],
       ],

--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -66,6 +66,7 @@ class CompensationsComposite extends WebformCompositeBase {
       '#input_mask' => "'alias': 'currency', 'prefix': '', 'suffix': '€','groupSeparator': ' ','radixPoint':','",
       '#attributes' => ['class' => ['input--borderless']],
       '#pattern' => '[0-9, ]+€',
+      '#maxlength' => 20,
       '#element_validate' => [
         '\Drupal\grants_handler\Element\CompensationsComposite::validateAmount',
         '\Drupal\grants_handler\Element\CompensationsComposite::validateRequiredFields',


### PR DESCRIPTION
# [AU-1799](https://helsinkisolutionoffice.atlassian.net/browse/AU-1799)
<!-- What problem does this solve? -->

* Add maxlength limits to compensation and budget fields.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1799-budget-length-limit`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open a [Taide- ja kulttuuriavustukset: projektiavustukset](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kuva-projekti)
* [ ] Check that subvention amount (page 2) won't allow  20+ characters
* [ ] Check that Budget components (page 6) won't allow 20+ characters


[AU-1799]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ