### PR TITLE
fix: AU-1820: fix translations on nuortoimpalk

### DIFF
--- a/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
@@ -4,6 +4,10 @@ elements: |
     '#title': '1. Applicant details'
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
+  hakemusprofiili:
+    '#title': 'Retrieved information'
+  hakijan_tiedot:
+    '#title': 'Applicant'
   yhteiso_jolle_haetaan_avustusta:
     '#title': 'Community for which the grant is being applied for'
   prh_markup:

--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -6,6 +6,10 @@ elements: |
     '#next_button_label': 'Nästa >'
   yhteiso_jolle_haetaan_avustusta:
     '#title': 'Samfund för vilket understödet ansöks'
+  hakemusprofiili:
+    '#title': 'Den sökandes uppgifter'
+  hakijan_tiedot:
+    '#title': 'Sökande'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   contact_person_email_section:

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -881,7 +881,7 @@ class AtvSchema {
                   // File name has no visible label in the webform so we
                   // need to manually handle it.
                   if ($itemName == 'fileName') {
-                    $label = $this->t('File name', [], ['context' => 'grants_metadata']);
+                    $label = $this->t('File name');
                   }
                   elseif (
                     isset($webformMainElement['#webform_composite_elements'][$itemName]['#title']) &&

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -3,6 +3,9 @@
 msgid ""
 msgstr ""
 
+msgid "Here you can see details of your application"
+msgstr "Här kan du se detaljer om din ansökan"
+
 msgid "Application attachments"
 msgstr "Bilagor"
 


### PR DESCRIPTION
# [AU-1820](https://helsinkisolutionoffice.atlassian.net/browse/AU-1820)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1820-fix-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Nuortoimpalkka](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuortoimpalkka)
* [ ] Fill the form. Make sure to add an attachment.
* [ ] Send the form and inspect the sent form in Swedish and English and Finnish and see that the issues mentioned in the ticket
* [ ] Check that code follows our standards

[AU-1820]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ