### PR TITLE
fix: AU-1789: Show additional information data in print view

### DIFF
--- a/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
@@ -379,7 +379,7 @@ class ApplicationController extends ControllerBase {
       // Handle application type field.
       if ($field['ID'] === 'applicantType' && $field['value'] === 'registered_community') {
         $field['value'] = '' . $this->t('Registered community', [], ['langcode' => $langcode]);
-        // @todo other types when needed.
+        // Add other types here when needed.
       }
       // Handle dates.
       if (preg_match(self::ISO8601, $field['value'])) {

--- a/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
@@ -546,6 +546,33 @@ class ApplicationController extends ControllerBase {
         });
       }
     }
+
+    if (isset($compensation['additionalInformation'])) {
+      $tOpts = [
+        'context' => 'grants_handler',
+        'langcode' => $langcode,
+      ];
+      $field = [
+        'ID' => 'additionalInformationField',
+        'value' => $compensation['additionalInformation'],
+        'valueType' => 'string',
+        'label' => $this->t('Additional Information', [], $tOpts),
+        'weight' => 1,
+      ];
+      $sections = [];
+      $sections['section'] = [
+        'label' => $this->t('Additional information concerning the application', [], $tOpts),
+        'id' => 'additionalInformationPageSection',
+        'weight' => 1,
+        'fields' => [$field],
+      ];
+      $newPages['additionalInformation'] = [
+        'label' => t('Additional Information', [], $tOpts),
+        'id' => 'additionalInformationPage',
+        'sections' => $sections,
+      ];
+    }
+
     // Set correct template.
     $build = [
       '#theme' => 'grants_handler_print_atv_document',

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -581,3 +581,11 @@ msgstr "Keskeneräiseen hakemukseen ei voi lähettää viestejä."
 msgctxt "grants_handler"
 msgid "Messages cannot be sent to a resolved application."
 msgstr "Ratkaistuun hakemukseen ei voi lähettää viestejä."
+
+msgctxt "grants_handler"
+msgid "Additional Information"
+msgstr "Lisätiedot"
+
+msgctxt "grants_handler"
+msgid "Additional information concerning the application"
+msgstr "Lisätietoja hakemukseen liittyen"

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -581,3 +581,11 @@ msgstr "Du kan inte skicka meddelanden till en pågående ansökan"
 msgctxt "grants_handler"
 msgid "Messages cannot be sent to a resolved application."
 msgstr "Du kan inte skicka meddelanden till ett löst ansökan."
+
+msgctxt "grants_handler"
+msgid "Additional Information"
+msgstr "Ytterligare information"
+
+msgctxt "grants_handler"
+msgid "Additional information concerning the application"
+msgstr "Ytterligare information för ansökan"


### PR DESCRIPTION
# [AU-1789](https://helsinkisolutionoffice.atlassian.net/browse/AU-1789)
<!-- What problem does this solve? -->

Näytä lisätiedot hakemusta tulostaessa

## What was done
<!-- Describe what was done -->

Tee lisätietoja varten oma paikka tulostusnäkymään huolehtien että data on käyttökelpoista ilman riippuvuuksia webformiin.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1789-additional-information-in-print`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Täytä hakemuksessa lisätiedot kenttä
* [ ] Tarkasta että data tulee mukaan tulostusnäkymään oikealla kielellä

[AU-1789]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ