### PR TITLE
fix: AU-1818 Improve error handling of duplicate bank accounts

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
@@ -489,6 +489,11 @@ abstract class GrantsProfileFormBase extends FormBase {
 
     unset($bankAccountValues['actions']);
     $delta = -1;
+    /*
+     * Handle edge case where user inputs same account number twice with
+     * the help of this variable.
+     */
+    $nonEditableIbans = [];
     foreach ($bankAccountValues as $delta => $bankAccount) {
       if (array_key_exists('bank', $bankAccount) && !empty($bankAccount['bank'])) {
         $temp = $bankAccount['bank'];
@@ -508,7 +513,12 @@ abstract class GrantsProfileFormBase extends FormBase {
           isset($profileAccount['bankAccount']) &&
           self::accountsAreEqual($bankAccount['bankAccount'],
             $profileAccount['bankAccount'])) {
+          $cleanedAccount = strtoupper(str_replace(' ', '', $profileAccount['bankAccount']));
+          if (in_array($cleanedAccount, $nonEditableIbans)) {
+            break;
+          }
           $nonEditable = TRUE;
+          $nonEditableIbans[] = $cleanedAccount;
           break;
         }
       }

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
@@ -296,7 +296,10 @@ abstract class GrantsProfileFormBase extends FormBase {
    * @return bool
    *   Are account numbers equal
    */
-  protected static function accountsAreEqual(string $account1, string $account2): bool {
+  protected static function accountsAreEqual(?string $account1, ?string $account2): bool {
+    if (!$account1 || !$account2) {
+      return FALSE;
+    }
     $account1Cleaned = strtoupper(str_replace(' ', '', $account1));
     $account2Cleaned = strtoupper(str_replace(' ', '', $account2));
     return $account1Cleaned == $account2Cleaned;
@@ -454,7 +457,7 @@ abstract class GrantsProfileFormBase extends FormBase {
    * @param array $helsinkiProfileContent
    *   Helsinki profile user info for versions of bank account that need it.
    * @param array|null $bankAccounts
-   *   Current officials.
+   *   Current bank accounts in grants profile.
    * @param string|null $newItem
    *   New item.
    * @param array|null $strings
@@ -509,18 +512,17 @@ abstract class GrantsProfileFormBase extends FormBase {
       }
       $nonEditable = FALSE;
       foreach ($bankAccounts as $profileAccount) {
-        if (isset($bankAccount['bankAccount']) &&
-          isset($profileAccount['bankAccount']) &&
-          self::accountsAreEqual($bankAccount['bankAccount'],
-            $profileAccount['bankAccount'])) {
-          $cleanedAccount = strtoupper(str_replace(' ', '', $profileAccount['bankAccount']));
-          if (in_array($cleanedAccount, $nonEditableIbans)) {
-            break;
-          }
-          $nonEditable = TRUE;
-          $nonEditableIbans[] = $cleanedAccount;
+        if (!self::accountsAreEqual($bankAccount['bankAccount'], $profileAccount['bankAccount'])) {
+          continue;
+        }
+        $cleanedAccount = strtoupper(str_replace(' ', '', $profileAccount['bankAccount']));
+        // Check for doubles.
+        if (in_array($cleanedAccount, $nonEditableIbans)) {
           break;
         }
+        $nonEditable = TRUE;
+        $nonEditableIbans[] = $cleanedAccount;
+        break;
       }
       $attributes = [];
       $attributes['readonly'] = $nonEditable;

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -318,7 +318,7 @@ msgstr "Liitetiedoston poistaminen epäonnistui, virhe on kirjattu. Ota yhteytt�
 
 msgctxt "grants_profile"
 msgid "grantsProfileData not found!"
-msgstr "grantsProfileDataa ei löytnyt!"
+msgstr "grantsProfileDataa ei löytynyt!"
 
 msgid "Switch role"
 msgstr "Vaihda asiointiroolia"


### PR DESCRIPTION
# [AU-1818](https://helsinkisolutionoffice.atlassian.net/browse/AU-1818)
<!-- What problem does this solve? -->

Jos lisää vahingossa saman tilin profiilia muokatessa niin saa virheilmoituksen mutta tilinumeroa ei voi korjata.

## What was done
<!-- Describe what was done -->

* Mahdollista duplikaattiarvojen muokkaus.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1818-duplicate-bank-account-handling`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Muokkaa profiilia ja lisää pankkitilejä
* [ ] Varmista että duplikaattia saa muokattua mutta alkuperäistä arvoa ei saa.


[AU-1818]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ