### PR TITLE
AU-1857: Subvention type fixes for ymp: yleisavustus, remove single subvention limit

### DIFF
--- a/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -15,8 +15,7 @@ third_party_settings:
       registered_community: registered_community
     applicationTypeTerms:
       45: '45'
-      47: '47'
-      51: '51'
+      48: '48'
       52: '52'
     applicationTargetGroup: '31'
     applicationOpen: '2023-09-11T12:00:00'
@@ -230,10 +229,8 @@ elements: |-
         '#multiple': true
         '#subventionType':
           1: '1'
-          4: '4'
-          8: '8'
+          5: '5'
           9: '9'
-        '#onlyOneSubventionPerApplication': 1
         '#required': true
         '#multiple__header': true
         '#multiple__empty_items': 0
@@ -250,9 +247,6 @@ elements: |-
         '#subvention_type_id__access': false
         '#subvention_type__title': Avustuslaji
         '#subvention_amount__title': 'Avustuksen summa'
-      markup_01:
-        '#type': webform_markup
-        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
     kayttotarkoitus:
       '#type': webform_section
       '#title': Käyttötarkoitus


### PR DESCRIPTION
# [AU-1857](https://helsinkisolutionoffice.atlassian.net/browse/AU-1857)
# [AU-1856](https://helsinkisolutionoffice.atlassian.net/browse/AU-1856)
<!-- What problem does this solve? -->

## What was done

* Remove single subvention type
* Change subvention type to excel spec:

Toiminta-avustus
Vuokra-avustus
Muu

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1857-kymp-subvention-fix`
  * `make fresh`
* Run `make drush-cr`


* [ ] Open a new [Ympäristöpalvelut, yleisavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/hakemus/ymparistopalvelut-yleisavustushakemus)
* [ ] Page 2: Check that listed subventions match the spec in excel
* [ ] Check that you are not limited to only 1 subvention type.
* [ ] ADMIN: https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/ymparistopalvelut_yleisavustus/settings check that avustuslaji koodit are correct ()



[AU-1857]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1856]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ