### PR TITLE
fix: AU-1866: fix kuva projekti translations

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -48,46 +48,44 @@ elements: |
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
   avustuksen_tiedot:
-    '#title': 'Grant details'
+    '#title': 'Information regarding the grant'
   acting_year:
-    '#title': 'Year for which I am applying for a grant'
+    '#title': 'The year, I’m applying the grant for'
   subventions:
-    '#title': Grants
-  markup:
-    '#markup': '<p>Only apply for one grant type at a time with each application.</p>'
+    '#title': 'Grant type'
   ensisijainen_taiteen_ala:
     '#title': 'Primary field of art'
-    '#help': 'Choose the option that best describes the activity from the drop-down menu.'
+    '#help': 'Choose the option that best describes your activities.'
     '#options':
-      'Design ja käsityö': 'Design and craftsmanship'
+      'Design ja käsityö': 'Design and crafts'
       'Elokuva, valokuva ja media': 'Film, photography and media'
-      Kaupunkikulttuuri: 'Urban culture'
+      Kaupunkikulttuuri: 'Urban art and culture'
       Kirjallisuus: Literature
       'Kuvataide ja sarjakuva': 'Visual arts and comics'
-      Monitaide: Multi-arts
+      Monitaide: 'Multidisciplinary art'
       Museo: Museum
       Musiikki: Music
       Muu: Other
       Sirkus: Circus
       Tanssi: Dance
-      Teatteri: Theater
+      Teatteri: Theatre
   hankkeen_nimi:
-    '#title': 'Project name'
-    '#help': 'Choose a name for the project that can be published when the decision is made.'
+    '#title': 'Name of the project'
+    '#help': 'Choose a name for the project that can be published along with the decision.'
   kyseessa_on_festivaali_tai_tapahtuma:
-    '#title': 'It is a festival or an event'
-    '#help': 'This refers to a festival or event that takes place within a short period of time and is broader in terms of program and duration than a single concert, performance, etc. A festival or event contains several different program contents, e.g. performances, between which the audience can also change. For example, neighborhood events. Not, for example, show series. A festival or event can be recurring or one-off.'
+    '#title': 'Festival or event'
+    '#help': 'Here a festival or event is defined as taking place within a limited timeframe, and as being broader in program and duration than a single concert, play etc. A festival or event includes a variety of programs, between which the audience can also change. For example, a neighborhood festival. Not, for example, a series of concerts. A festival or event can be either a recurring event or a one-off event.'
     '#options':
       1: 'Yes'
       0: 'No'
   hankkeen_tai_toiminnan_lyhyt_esittelyteksti:
     '#title': 'A short description of the project or the activities'
-    '#help': 'The text can be published or it can be used as an introductory text in connection with the decision as is or edited.'
+    '#help': 'The text can be published or used as a presentation as such or in a modified form along with the decision. Max 500 characters.'
     '#counter_maximum_message': '%d/500 characters remaining'
   muut_samaan_tarkoitukseen_myonnetyt_avustukset:
-    '#title': 'Other grants received for the same purpose'
+    '#title': 'Other grants awarded for the same purpose'
   info_muut_samaan_tarkoitukseen_myonnetty:
-    '#text': "<p>Indicate here only the grants received from somewhere other than the City of Helsinki in the current and two previous tax years.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\">An affirmative answer opens a further question</div>\r\n</div>\r\n</div>\r\n"
+    '#text': "<p>List only grants from other instances than the City of Helsinki in the current year and the two previous years before that.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\">An affirmative answer opens a further question</div>\r\n</div>\r\n</div>\r\n"
   olemme_saaneet_muita_avustuksia:
     '#title': 'We have received other grants'
     '#options':
@@ -117,81 +115,81 @@ elements: |
         '#help': 'Give a brief description, for what purpose has the grant been granted?'
         '#counter_maximum_message': '%d/1000 characters remaining'
   3_yhteison_tiedot:
-    '#title': '3. Activities of the community'
+    '#title': '3. Information regarding the organization'
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
   jasenmaara:
     '#title': Members
   jasenmaara_fieldset:
     '#title': Members
-    '#help': 'If the community has members, please list them here.'
+    '#help': 'If your organization has members, mark their numbers here.'
   members_applicant_person_global:
-    '#title': 'Total number of individual members'
+    '#title': Members
   members_applicant_person_local:
-    '#title': 'Total number of individual members in Helsinki'
+    '#title': 'Of which residents of Helsinki'
   members_applicant_community_global:
-    '#title': 'Community members'
+    '#title': 'Organizational members'
   members_applicant_community_local:
-    '#title': 'Total number of community members in Helsinki'
+    '#title': 'Of which are registered in Helsinki'
   henkilosto_hankkeessa_jolle_avustusta_haetaan:
-    '#title': ' Personnel in the project for which the grant is applied for with this application.'
+    '#title': 'Personnel in the project that you are applying the grant for'
   henkilosto_hankkeessa:
     '#title': Personnel
-    '#help': 'Personnel other than paid employees can be included, e.g. those working with bonuses or other compensation or work purchased as a purchase service. Full-time employees may also include temporary employees if they work full-time. A person&#39;s work year describes the work input of a person converted to full-time. For example, a person working full-time for 6 months can be calculated as 0.5 person-years of work. Similarly, a person doing 30% of the workload part-time for the whole year can be calculated as 0.3 person-years of work. This is an estimate that gives an indicative description of the work input of the personnel participating in the project.'
+    '#help': 'The personnel includes the personnel on salary, but can also include people working for other forms of compensation, like trade income, or as purchased service. The full-time personnel can include temporary staff if they work full-time. The person year depicts a person&rsquo;s workload when converted to full-time work. For example, a person that works full-time for 6 months can be counted as 0,5 person years. Similarly, a person that works part-time with 30% workload for a full year can be counted as 0,3 person years. The numbers are viewed as estimates that give a general outline of the workload of the personnel involved in the project.'
   kokoaikainen_henkilosto:
     '#title': 'Full-time: Persons'
   kokoaikainen_henkilotyovuosia:
-    '#title': ' Full-time: Personnel years'
+    '#title': 'Full-time: Person years'
   osa_aikainen_henkilosto:
     '#title': 'Part-time: Persons'
   osa_aikainen_henkilotyovuosia:
-    '#title': 'Part-time: Personnel years'
+    '#title': 'Part-time: Person years'
   vapaaehtoinen_henkilosto:
     '#title': 'Volunteers: Persons'
   4_suunniteltu_toiminta:
-    '#title': '4. Planned activity'
+    '#title': '4. Activities'
+    '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
   arvio_maarista:
-    '#title': 'An estimate of quantities'
-    '#description': 'Enter the information regarding the entire project for which the grant is applied for. Enter the information only for physical performances, exhibitions and workshops, do not include only digital program content.'
+    '#title': 'Estimated numbers'
+    '#description': 'Answer regarding the whole project that you are applying the grant for. Only include information about physical performances, exhibitions, and workshops, do not include contents that are carried out solely in digital format.'
   tapahtuma_tai_esityspaivien_maara_helsingissa:
     '#title': 'Number of days during which the events take place in Helsinki'
   esityspaivien_maara_helsingissa_fieldset:
-    '#title': 'Amount in Helsinki'
+    '#title': 'Number in Helsinki'
   esitykset_maara_helsingissa:
-    '#title': Performances
+    '#title': 'Performances or screenings'
   nayttelyt_maara_helsingissa:
     '#title': Exhibitions
   tyopaja_maara_helsingissa:
-    '#title': 'A workshop or other form of inclusive activity'
+    '#title': 'Workshops, or other participatory activities'
   esityspaivien_maara_kaikkiaan_fieldset:
-    '#title': ' Amount in total'
-    '#help': 'Fill in the figures, including the entire operation both in Finland and possibly abroad.'
+    '#title': 'Number in total'
   esitykset_maara_kaikkiaan:
-    '#title': Performances
+    '#title': 'Performances or screenings'
   nayttelyt_maara_kaikkiaan:
     '#title': Exhibitions
   tyopaja_maara_kaikkiaan:
-    '#title': 'A workshop or other form of inclusive activity'
+    '#title': 'Workshops, or other participatory activities'
   maara_helsingissa:
     '#title': 'Number of visitors in Helsinki'
-    '#help': 'Do not fill the same visitors twice, e.g. a workshop organized in the exhibition space for both exhibitions and workshops.'
+    '#help': 'Do not include the same visitors twice, for example do not include the visitors of a workshop in a gallery as both visitors of an exhibition and a workshop.'
   maara_kaikkiaan:
     '#title': 'Total number of visitors'
-    '#help': 'In the &quot;Total number of visitors&quot; section, fill in the numbers including the entire operation both in Finland and possibly abroad.'
+    '#help': 'The number in total should include the numbers in total, both in Finland and possibly internationally.'
   esityksista:
-    '#title': 'About performances'
+    '#title': 'Regarding performances'
   kantaesitysten_maara:
-    '#title': ' The number of premieres'
+    '#title': Premieres
     '#help': 'A premiere means the first public performance of a completely new and previously unseen piece of work.'
   ensi_iltojen_maara_helsingissa:
-    '#title': 'Number of premieres of productions in Helsinki'
+    '#title': 'Premieres of productions in Helsinki'
     '#help': 'A premiere of a production means the first public performance of the production in question. Fill in the premieres of productions that take place in Helsinki.'
   yleisolle_avoin_toiminta:
-    '#title': 'Activities open to the public'
-    '#help': 'Activities open to the public here mean e.g. performances, exhibitions and workshops or other inclusive activities.'
+    '#title': 'The locations of the public events in Helsinki'
+    '#help': 'Here the public events refer to, for example, performances, screenings, exhibitions, and workshops, or other participatory activities.'
   ensimmainen_tila_fieldset:
-    '#title': 'The first place of an event open to the public in Helsinki'
+    '#title': 'Location of the first public event in Helsinki'
   ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa:
     '#title': 'Premise name'
   postinumero:
@@ -207,9 +205,9 @@ elements: |
   aikataulu:
     '#title': Schedule
   ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara:
-    '#title': 'The date of the first event open to the public'
+    '#title': 'The date of the first public event'
   festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
-    '#title': 'For a festival or event, the dates of the event'
+    '#title': 'The dates, in case of festivals and events'
   hanke_alkaa:
     '#title': 'The project begins'
   hanke_loppuu:
@@ -218,8 +216,8 @@ elements: |
     '#title': 'Project description'
   laajempi_hankekuvaus:
     '#counter_maximum_message': '%d/2500 characters remaining'
-    '#title': 'Broader project description'
-    '#help': 'Tell about the project in detail. For example, why, what, for whom, how and what are the goals.'
+    '#title': 'A more comprehensive project description'
+    '#help': 'Describe the project in brief, for example, why, what, for whom, how, and what are the goals.'
   5_toiminnan_lahtokohdat:
     '#title': '5. The basis for the activities'
     '#prev_button_label': '< Previous'
@@ -261,7 +259,7 @@ elements: |
     '#prev_button_label': '< Previous'
     '#next_button_label': 'Next >'
   talousarvio:
-    '#title': 'Budget (for the year for which you are applying for a grant)'
+    '#title': 'Planned budget'
   markup_01:
     '#markup': 'Regarding the whole project that the grant is applied for.'
   organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_:
@@ -270,16 +268,16 @@ elements: |
       1: 'Yes'
       0: 'No'
   tulot:
-    '#markup': '<h4>Planned income</h4>'
+    '#markup': '<h4>Planned incomes</h4>'
   menot:
     '#markup': '<h4>Planned expenses</h4>'
   budget_other_cost:
-    '#title': 'Other expenses'
+    '#title': 'Other costs'
   muu_huomioitava_panostus_osio:
     '#markup': '<h4>Other notable input</h4>'
   muu_huomioitava_panostus:
     '#counter_maximum_message': '%d/1000 characters remaining'
-    '#title': 'Does the implementation of the activity include any other contribution of monetary value or barter that is not reflected in the budget?'
+    '#title': 'Is there some other form of valuable input or trade involved in carrying out the activities that is not listed in the budget?'
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and attachments'
   lisatietoja_hakemukseen_liittyen:
@@ -291,7 +289,7 @@ elements: |
   liitteet:
     '#title': Attachments
   attachments_info:
-    '#markup': "&nbsp;<br />\r\nAll the attachments listed below must be submitted for the processing of the grant application. The grant application may be rejected if the attachments are not submitted. If any of the attachments is missing, let us know in the Further clarification on attachments section of the application.<br />\r\n<br />\r\n<strong>Required attachments</strong><br />\r\nFor the processing of the grant application, the required attachments are a project plan for the applied period and a budget for the applied period.<br />\r\n<br />\r\nAs a new applicant or when your banking information has changed, you are also required to submit a bank statement or similar document indicating the account holder&rsquo;s name and the account number in the applicant&rsquo;s Own information.<br />\r\n<br />\r\n<strong>Submission of several attachments as a single file</strong><br />\r\nIf you wish, you can submit several attachments as a single file. In this case, under the other attachment headings, indicate &ldquo;The attachment has been submitted as a single file or with another application.&rdquo;"
+    '#markup': "All the attachments listed below must be submitted for the processing of the grant application. The<br role=\"presentation\" />\r\ngrant application may be rejected if the attachments are not submitted. If any of the attachments is<br role=\"presentation\" />\r\nmissing, let us know in the Further clarification on attachments section of the application.<br />\r\n<br />\r\n<strong>Required attachments</strong><br />\r\nFor the processing of the grant application, the required attachments are curricula vitae of the<br role=\"presentation\" />\r\nmembers of the working group in the case of a project by art professionals.<br />\r\n<br />\r\nAs a new applicant or when your banking information has changed, you are also required to submit<br role=\"presentation\" />\r\na bank statement or similar document indicating the account holder&#39;s name and the account<br role=\"presentation\" />\r\nnumber in the applicant&#39;s my data.<br />\r\n<br />\r\n<strong>Submission of several attachments as a single file</strong><br />\r\nYou can submit several curricula vitae of the members of the working group as separate files in the<br role=\"presentation\" />\r\nOther attachment. If you wish, you can also submit several attachments as a single file."
   notification_attachments:
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>The contents of the attachments cannot be viewed afterwards</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Please note that you will not be able to open the attachments after you have attached them to the form. You will only see the file name of the attachment.</p>\r\n\r\n<p>Although you cannot view the attachments afterwards, the attachments to the form are sent along with the other information on the form to the grant application processor.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
   extra_info:

--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -269,8 +269,13 @@ elements: |
       0: 'No'
   tulot:
     '#markup': '<h4>Planned incomes</h4>'
+  budget_static_income:
+    '#plannedOtherCompensations__help': 'Including other grants from the City of Helsinki.'
+    '#otherCompensations__help': 'Including other grants from the City of Helsinki.'
   menot:
     '#markup': '<h4>Planned expenses</h4>'
+  budget_static_cost:
+    '#showCosts__help': 'Compensation for presenting art that is paid in other forms than salary or trade income.'
   budget_other_cost:
     '#title': 'Other costs'
   muu_huomioitava_panostus_osio:

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -49,48 +49,46 @@ elements: |
     '#prev_button_label': '< Tidigare'
     '#next_button_label': 'Nästa >'
   avustuksen_tiedot:
-    '#title': 'Uppgifter om understödet'
+    '#title': 'Preciserad information'
   acting_year:
-    '#title': 'År för vilket jag ansöker om understöd'
+    '#title': 'År för vilket man ansöker om stöd'
   subventions:
-    '#title': Understöd
-  markup:
-    '#markup': '<p>Ans&ouml;k alltid endast om en typ av underst&ouml;d &aring;t g&aring;ngen.</p>'
+    '#title': 'Typ av stöd'
   ensisijainen_taiteen_ala:
     '#title': 'Huvudsaklig konstart '
-    '#help': 'V&auml;lj det alternativ som b&auml;st beskriver aktiviteten fr&aring;n rullgardinsmenyn.'
+    '#help': 'V&auml;lj det alternativ, som b&auml;st motsvarar er verksamhet'
     '#options':
       'Design ja käsityö': 'Design och hantverk'
       'Elokuva, valokuva ja media': 'Film, foto och media'
-      Kaupunkikulttuuri: 'Urban kultur'
+      Kaupunkikulttuuri: Stadskultur
       Kirjallisuus: Litteratur
-      'Kuvataide ja sarjakuva': 'Bildkonst och serier'
-      Monitaide: Multikonst
+      'Kuvataide ja sarjakuva': 'Bildkonst och seriekonst'
+      Monitaide: 'Tvärkonstnärlig verksamhet'
       Museo: Museum
       Musiikki: Musik
-      Muu: Övrig
+      Muu: Annat
       Sirkus: Cirkus
-      Tanssi: Dansa
+      Tanssi: Dans
       Teatteri: Teater
   hankkeen_nimi:
-    '#title': Projektnamn
-    '#help': 'V&auml;lj ett namn p&aring; projektet som kan publiceras n&auml;r beslutet &auml;r taget.'
+    '#title': 'Projektets namn'
+    '#help': 'V&auml;lj ett projektnamn, som kan publiceras i samband med att beslutet om st&ouml;d fattas'
   kyseessa_on_festivaali_tai_tapahtuma:
-    '#title': 'Det är en festival eller ett evenemang'
-    '#help': 'H&auml;r avses en festival eller ett evenemang som &auml;ger rum inom en kort tidsperiod och &auml;r bredare till program och varaktighet &auml;n en enskild konsert, f&ouml;rest&auml;llning etc. En festival eller evenemang inneh&aring;ller flera olika programinneh&aring;ll, t ex f&ouml;rest&auml;llningar, mellan vilka publiken kan ocks&aring; f&ouml;r&auml;ndras. Till exempel grannevenemang. Inte till exempel showserier. En festival eller ett evenemang kan vara &aring;terkommande eller enstaka tillf&auml;llen.'
+    '#title': 'Festival eller evenemang'
+    '#help': 'H&auml;r avses en festival eller ett evenemang, som sker inom en best&auml;md tidsrymd och som &auml;r mer omfattande &auml;n en enskild konsert, f&ouml;rest&auml;llning eller motsvarande. Festivalen eller evenemanget har flera programinneh&aring;ll, till exempel f&ouml;rest&auml;llningar, d&auml;r publiken &auml;ven kan variera, till exempel stadsdelsevenemang, dock inte f&ouml;rest&auml;llningsserier. En festival eller ett evenemang kan vara &aring;terkommande eller ske endast en g&aring;ng.'
     '#options':
       1: Ja
       0: Nej
   hankkeen_tai_toiminnan_lyhyt_esittelyteksti:
-    '#title': 'En kort introduktionstext av projektet eller aktiviteten'
-    '#help': 'Texten kan publiceras eller den kan anv&auml;ndas som en inledande text i samband med beslutet i befintligt skick eller &auml;ndrat.'
+    '#title': 'En kort presentationstext om projektet eller verksamheten'
+    '#help': 'Texten kan som s&aring;dan eller i f&ouml;rkortad version publiceras eller anv&auml;ndas som presentationsunderlag i anslutning till beslutsfattandet om st&ouml;d. Max 500 tecken.'
     '#counter_maximum_message': '%d/500 tecken kvar'
   muut_samaan_tarkoitukseen_myonnetyt_avustukset:
-    '#title': 'Övriga understöd som beviljats för samma ändamål'
+    '#title': 'Övriga stöd som beviljats för samma ändamål'
   info_muut_samaan_tarkoitukseen_myonnetty:
-    '#text': "<p>Ange här endast de understöd som beviljats från annanstans än Helsingfors stad under det innevarande beskattningsåret eller de föregående två beskattningsåren.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\">Ett jakande svar öppnar ytterligare en fråga</div>\r\n</div>\r\n</div>\r\n"
+    '#text': "<p>Anmäl här endast de stöd som beviljats av andra parter än Helsingfors stad, under både innevarande och de två senaste skatteåren.</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\">Ett jakande svar öppnar ytterligare en fråga</div>\r\n</div>\r\n</div>\r\n"
   olemme_saaneet_muita_avustuksia:
-    '#title': 'Vi har fått andra understöd'
+    '#title': 'Vi har fått andra stöd för samma ändamål'
     '#options':
       1: Ja
       0: Nej
@@ -127,37 +125,37 @@ elements: |
     '#title': Medlemmar
     '#help': 'Om samfundet har medlemmar, v&auml;nligen ange dem h&auml;r.'
   members_applicant_person_global:
-    '#title': 'Personmedlemmar sammanlagt'
+    '#title': Medlemmar
   members_applicant_person_local:
-    '#title': 'Personmedlemmar från Helsingfors sammanlagt'
+    '#title': 'Andel helsingforsare'
   members_applicant_community_global:
     '#title': Samfundsmedlemmar
   members_applicant_community_local:
-    '#title': 'Samfundsmedlemmar från Helsingfors sammanlagt'
+    '#title': 'Andel helsingforsiska samfund'
   henkilosto_hankkeessa_jolle_avustusta_haetaan:
-    '#title': 'Personal i projektet som bidraget söks för med denna ansökan.'
+    '#title': 'Personal i projektet, för vilket man ansöker om stöd'
   henkilosto_hankkeessa:
-    '#title': Personal
-    '#help': 'Annan personal &auml;n avl&ouml;nade kan ing&aring;, t.ex. de som arbetar med bonusar eller annan ers&auml;ttning eller arbete k&ouml;pt som k&ouml;ptj&auml;nst. Till heltidsanst&auml;llda kan &auml;ven ing&aring; tillf&auml;lligt anst&auml;llda om de arbetar heltid. En persons arbets&aring;r beskriver arbetsinsatsen f&ouml;r en person omvandlad till heltid. Till exempel kan en person som arbetar heltid i 6 m&aring;nader ber&auml;knas som 0,5 &aring;rsverken. P&aring; samma s&auml;tt kan en person som g&ouml;r 30 % av arbetsbelastningen p&aring; deltid f&ouml;r hela &aring;ret ber&auml;knas som 0,3 &aring;rsverken. Detta &auml;r en uppskattning som ger en v&auml;gledande beskrivning av arbetsinsatsen f&ouml;r den personal som deltar i projektet.'
+    '#title': Personer
+    '#help': 'I personalen kan ing&aring; &auml;ven andra &auml;n anst&auml;llda personer, t ex personer som lyfter arvoden eller andra ers&auml;ttningar eller personer som levererar k&ouml;ptj&auml;nster. Heltidsanst&auml;lla kan &auml;ven omfatta visstidsanst&auml;llda personer om dessa arbetar heltid. En personarbets&aring;r beskriver en persons arbetsinsats under ett helt &aring;r. En person som arbetar t.ex. 6 m&aring;n. p&aring; heltid motsvarar en arbetsinsats p&aring; 0,5 personarbetsh&aring;. P&aring; samma s&auml;tt utg&ouml;r en deltidsanst&auml;lld person, som arbetar ett helt &aring;r med en 30% arbetsinsats, 0,3 personarbets&aring;r. Det &auml;r allts&aring; fr&aring;ga om en riktgivande uppskattning av arbetstiden f&ouml;r de personer, som arbetar inom och f&ouml;r projektet.'
   kokoaikainen_henkilosto:
-    '#title': 'Heltid: Personer'
+    '#title': 'Heltidsanställda: Personer'
   kokoaikainen_henkilotyovuosia:
-    '#title': 'Heltid: Personalår'
+    '#title': 'Heltidsanställda: Personarbetsår'
   osa_aikainen_henkilosto:
-    '#title': 'Deltid: Personer'
+    '#title': 'Deltidsanställda: Personer'
   osa_aikainen_henkilotyovuosia:
-    '#title': 'Deltid: Personalår'
+    '#title': 'Deltidsanställda: Personarbetsår'
   vapaaehtoinen_henkilosto:
-    '#title': 'Volontärer: Personer'
+    '#title': 'Frivilliga: Personer'
   4_suunniteltu_toiminta:
-    '#title': '4. Planerad åtgärd'
+    '#title': '4. Verksamhet'
     '#prev_button_label': '< Tidigare'
     '#next_button_label': 'Nästa >'
   arvio_maarista:
-    '#title': 'En uppskattning av kvantiteter'
-    '#description': 'Fyll i uppgifterna om hela projektet som bidraget s&ouml;ks f&ouml;r. Ange informationen endast f&ouml;r fysiska f&ouml;rest&auml;llningar, utst&auml;llningar och workshops, inkludera inte endast digitalt programinneh&aring;ll.'
+    '#title': 'En uppskattning av omfattningen på verksamheten'
+    '#description': 'Mata in uppgifterna g&auml;llande hela projektet, som st&ouml;det g&auml;ller. Mata in uppgifterna enbart f&ouml;r de fysiska f&ouml;rest&auml;llningarna, utst&auml;llningarna och verkst&auml;derna, r&auml;kna inte in de enbart digitalt genomf&ouml;rda programinneh&aring;llen.'
   tapahtuma_tai_esityspaivien_maara_helsingissa:
-    '#title': 'Antal evenemang eller föreställningsdagar i Helsingfors'
+    '#title': 'Antalet evenemangs- eller föreställningsdagar i Helsingfors'
   esityspaivien_maara_helsingissa_fieldset:
     '#title': 'Antal i Helsingfors'
   esitykset_maara_helsingissa:
@@ -165,35 +163,34 @@ elements: |
   nayttelyt_maara_helsingissa:
     '#title': Utställningar
   tyopaja_maara_helsingissa:
-    '#title': 'En workshop eller annan form av inkluderande aktivitet'
+    '#title': 'Verkstad eller annan interaktiv verksamhetsform'
   esityspaivien_maara_kaikkiaan_fieldset:
     '#title': 'Antal totalt'
-    '#help': 'Fyll i siffrorna inklusive hela verksamheten b&aring;de i Finland och eventuellt utomlands.'
   esitykset_maara_kaikkiaan:
     '#title': Föreställningar
   nayttelyt_maara_kaikkiaan:
     '#title': Utställningar
   tyopaja_maara_kaikkiaan:
-    '#title': 'En workshop eller annan form av inkluderande aktivitet'
+    '#title': 'Verkstad eller annan interaktiv verksamhetsform'
   maara_helsingissa:
-    '#title': 'Antal besökare i Helsingfors'
-    '#help': 'Fyll inte samma bes&ouml;kare tv&aring; g&aring;nger, t ex en workshop anordnad i utst&auml;llningslokalen f&ouml;r b&aring;de utst&auml;llningar och workshops.'
+    '#title': 'Estimerad publikmängd i Helsingfors'
+    '#help': 'R&auml;kna inte samma bes&ouml;kare fler &auml;n en g&aring;ng. N&auml;r det g&auml;ller t.ex. program som ordnas i ett utst&auml;llningsutrymme, vill vi endast veta antalet enskilda bes&ouml;kare - inte om de deltar i flera program.'
   maara_kaikkiaan:
-    '#title': 'Totalt antal besökare'
-    '#help': 'I avsnittet &quot;Totalt antal bes&ouml;kare&quot; fyller du i siffrorna inklusive hela verksamheten b&aring;de i Finland och eventuellt utomlands.'
+    '#title': 'Estimerad publikmängd totalt'
+    '#help': 'Svaret p&aring; estimerad publikm&auml;ngd totalt innefattar hela verksamheten, i Finland och ev. utomlands.'
   esityksista:
-    '#title': 'Om föreställningar'
+    '#title': 'Om föreställningarna'
   kantaesitysten_maara:
     '#title': 'Antalet uruppföranden'
     '#help': 'Med uruppf&ouml;rande avser vi ett verk, som uppf&ouml;rs f&ouml;r f&ouml;rsta g&aring;ngen, ett helt nytt verk. En nypremi&auml;r &auml;r t.ex. inte ett uruppf&ouml;rande.'
   ensi_iltojen_maara_helsingissa:
-    '#title': 'Antal premiärer i Helsingfors'
+    '#title': 'Antalet premiärer i Helsingfors'
     '#help': 'Med premi&auml;r avser vi den f&ouml;rsta f&ouml;rest&auml;llningen av en produktion. Fyll i de premi&auml;rer som sker i Helsingfors.'
   yleisolle_avoin_toiminta:
-    '#title': 'Aktiviteter öppna för allmänheten'
-    '#help': 'Aktiviteter som &auml;r &ouml;ppna f&ouml;r allm&auml;nheten betyder h&auml;r t.ex. f&ouml;rest&auml;llningar, utst&auml;llningar och workshops eller andra inkluderande aktiviteter.'
+    '#title': 'Öppen verksamhet för publik i Helsingfors'
+    '#help': 'Med &ouml;ppen verksamhet avser vi h&auml;r t.ex. f&ouml;rest&auml;llningar, utst&auml;llningar, verkst&auml;der eller annan verksamhet, d&auml;r publiken kan vara delaktig.'
   ensimmainen_tila_fieldset:
-    '#title': 'Första platsen för ett evenemang öppet för allmänheten i Helsingfors'
+    '#title': 'Platsen för det första öppna programmet i Helsingfors'
   ensimmainen_yleisolle_avoimen_tilaisuuden_paikka_helsingissa:
     '#title': Premissnamn
   postinumero:
@@ -209,19 +206,19 @@ elements: |
   aikataulu:
     '#title': Tidtabell
   ensimmaisen_yleisolle_avoimen_tilaisuuden_paivamaara:
-    '#title': 'Datumet för det första evenemanget öppet för allmänheten'
+    '#title': 'Datum för det första öppna evenemanget'
   festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
-    '#title': 'För en festival eller evenemang, datumen för evenemanget'
+    '#title': 'Datum för festivalen eller evenemanget'
   hanke_alkaa:
     '#title': 'Projektet inleds'
   hanke_loppuu:
     '#title': 'Projektet avslutas'
   hankekuvaus:
-    '#title': 'Projekt beskrivning'
+    '#title': 'Beskrivning av projektet'
   laajempi_hankekuvaus:
     '#counter_maximum_message': '%d/2500 tecken kvar'
-    '#title': 'Bredare projektbeskrivning'
-    '#help': 'Ber&auml;tta om projektet i detalj. Till exempel varf&ouml;r, vad, f&ouml;r vem, hur och vad &auml;r m&aring;len.'
+    '#title': 'En mer ingående projektbeskrivning'
+    '#help': 'Ber&auml;tta kort och koncist om projektet. Varf&ouml;r, vad, f&ouml;r vem, hur och med vilka m&aring;ls&auml;ttningar?'
   5_toiminnan_lahtokohdat:
     '#title': '5. Utgångspunkten för verksamheten'
     '#prev_button_label': '< Tidigare'
@@ -229,37 +226,37 @@ elements: |
   toiminnan_sisallot:
     '#title': 'Verksamhetens innehåll'
   toiminta_taiteelliset_lahtokohdat:
-    '#title': ' Beskriver verksamhetens konstnärliga utgångspunkter och mål, konstnärlig professionalitet och position inom konstområdet.'
+    '#title': 'Beskriv de konstnärliga utgångspunkterna och målsättningarna för verksamheten, den konstnärliga professionaliteten och er/ organisationens position på konstfältet.'
     '#counter_maximum_message': '%d/1000 tecken kvar'
-    '#help': 'Du kan ocks&aring; lyfta fram till exempel nyckelpriser eller andra offerter.'
+    '#help': 'Ni kan &auml;ven lyfta fram eventuella pris och utm&auml;rkelser.'
   toiminta_tasa_arvo:
-    '#title': 'Hur förverkligas och återspeglas mångfald och jämställdhet i verksamhetens arrangörer och organisationer och i verksamhetens innehåll? Vad finns det för åtgärder, resurser och kunnande för att främja frågan?'
+    '#title': 'Hur förverkligar ni jämställdheten och mångfalden i er organisation och verksamhet samt i verksamhetens innehåll? Vilka åtgärder vidtar ni, vilka resurser och vilket kunnande har ni gällande detta?'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   toiminnan_tavoittavuus:
-    '#title': 'Aktivitets tillgänglighet'
+    '#title': 'Verksamhetens tillgänglighet'
   toiminta_saavutettavuus:
-    '#title': 'Hur kan verksamheten göras socialt, kulturellt, språkligt, ekonomiskt, fysiskt, regionalt eller på annat sätt så tillgänglig som möjligt för stadsborna? Vad finns det för åtgärder, resurser och kunnande för att främja frågan?'
+    '#title': 'Hur gör ni er verksamhet socialt, kulturellt, språkligt, ekonomiskt, fysiskt, geografiskt eller på annat sätt tillgänglig för helsingforsarna? Vilka åtgärder vidtar ni, vilka resurser och vilket kunnande har ni gällande detta? '
     '#counter_maximum_message': '%d/1000 tecken kvar'
   toiminta_yhteisollisyys:
-    '#title': 'Hur stärker verksamheten känslan av gemenskap, nätverksliknande samarbete och hur är det möjligt för stadsborna att delta i verksamhetens olika skeden? Vad finns det för åtgärder, resurser och kunnande för att främja frågan?'
+    '#title': 'Hur stärker ni samhörighet och nätverkande samarbete inom staden genom er verksamhet? Hur kan invånarna delta i olika skeden av er verksamhet? Vilka åtgärder vidtar ni, vilka resurser och vilket kunnande har ni gällande detta?'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   toiminta_kohderyhmat:
-    '#title': 'Vem riktar sig verksamheten till? Hur ska dessa målgrupper nås och vilken kompetens finns att arbeta med dem?'
+    '#title': 'Vilka är målgrupperna för er verksamhet? Hur når ni dessa målgrupper och vad har ni för kunnande när det gäller att arbeta med dessa målgrupper?'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   toiminnan_jarjestaminen:
-    '#title': 'Organisera aktiviteten'
+    '#title': 'Verksamhetens struktur'
   toiminta_ammattimaisuus:
-    '#title': 'Beskriver professionaliteten och organisationen av verksamhetens organisation'
+    '#title': 'Beskriv hur er verksamhet är organiserad och på vilket sätt den är professionell'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   toiminta_ekologisuus:
-    '#title': 'Hur beaktas ekologi i organisationen av aktiviteter? Vad finns det för åtgärder, resurser och kunnande för att främja frågan?'
+    '#title': 'Hur beaktar ni ekologiska aspekter när ni planerar och genomför er verksamhet? Vilka åtgärder vidtar ni, vilka resurser och vilket kunnande har ni gällande detta? '
     '#counter_maximum_message': '%d/1000 tecken kvar'
   toiminta_yhteistyokumppanit:
-    '#title': 'Nämn de viktigaste partnerna och beskriv samarbetsformer och villkor.'
+    '#title': 'Namnge era fem mest centrala samarbetsparter och beskriv formen och villkoren för ert samarbete. '
     '#help': 'N&auml;mn h&ouml;gst cirka fem partners.'
     '#counter_maximum_message': '%d/1000 tecken kvar'
   6_talous:
-    '#title': '6. Ekonomisk'
+    '#title': '6. Ekonomi'
     '#prev_button_label': '< Tidigare'
     '#next_button_label': 'Nästa >'
   talousarvio:
@@ -267,7 +264,7 @@ elements: |
   markup_01:
     '#markup': 'G&auml;llande hela projektet, som ni s&ouml;ker st&ouml;d f&ouml;r.'
   organisaatio_kuuluu_valtionosuusjarjestelmaan_vos_:
-    '#title': 'Organisationen får statsandelar (VOS)'
+    '#title': 'Organisationen får stadsandelar (VOS)'
     '#options':
       1: Ja
       0: Nej
@@ -276,12 +273,12 @@ elements: |
   menot:
     '#markup': '<h4>Planerade utgifter</h4>'
   budget_other_cost:
-    '#title': 'Andra utgifter'
+    '#title': 'Övriga kostnader'
   muu_huomioitava_panostus_osio:
-    '#markup': '<h4>Övrig betydande insats</h4>'
+    '#markup': '<h4>&Ouml;vrig betydande insats</h4>'
   muu_huomioitava_panostus:
     '#counter_maximum_message': '%d/1000 tecken kvar'
-    '#title': 'Inkluderar genomförandet av verksamheten något annat bidrag av monetärt värde eller byteshandel som inte återspeglas i budgeten?'
+    '#title': 'Ingår det i verksamheten någon betydande eller värdefull annan insats eller byteshandel, som inte framgår ur budgeten?'
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:
@@ -293,7 +290,7 @@ elements: |
   liitteet:
     '#title': Bilagor
   attachments_info:
-    '#markup': "&nbsp;<br />\r\nAlla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan om underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas, meddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Obligatoriska bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs projektplan f&ouml;r den tid som ans&ouml;kan g&auml;ller och budget f&ouml;r den tid som ans&ouml;kan g&auml;ller.<br />\r\n<br />\r\nF&ouml;r ny s&ouml;kande eller om bankkontaktuppgifterna har &auml;ndrats beh&ouml;vs &auml;ven kontoutdrag eller motsvarande dokument som anger kontoinnehavarens namn och kontonummer i den s&ouml;kandes egna uppgifter.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor i en fil</strong><br />\r\nOm du vill kan du l&auml;mna in flera bilagor i en fil. Ange i detta fall vid andra bilagor att &rdquo;Bilagan har l&auml;mnats in som en fil eller i samband med en annan ans&ouml;kan&rdquo;."
+    '#markup': "Alla bilagor som anges nedan m&aring;ste l&auml;mnas in f&ouml;r behandling av ans&ouml;kan om underst&ouml;d. Ans&ouml;kan<br role=\"presentation\" />\r\nom underst&ouml;d kan avsl&aring;s om bilagorna inte har l&auml;mnats in. Om n&aring;gon av bilagorna saknas,<br role=\"presentation\" />\r\nmeddela oss om det i punkten Ytterligare information om bilagor i ans&ouml;kan.<br />\r\n<br />\r\n<strong>Obligatoriska bilagor</strong><br />\r\nF&ouml;r behandling av ans&ouml;kan om underst&ouml;d beh&ouml;vs meritf&ouml;rteckningar f&ouml;r arbetsgruppens<br role=\"presentation\" />\r\nmedlemmar n&auml;r det g&auml;ller projekt f&ouml;r yrkesm&auml;ssiga konstut&ouml;vare.<br />\r\n<br />\r\nF&ouml;r ny s&ouml;kande eller om bankkontaktuppgifterna har &auml;ndrats beh&ouml;vs &auml;ven kontoutdrag eller<br role=\"presentation\" />\r\nmotsvarande dokument som anger kontoinnehavarens namn och kontonummer i den s&ouml;kandes<br role=\"presentation\" />\r\negna uppgifter.<br />\r\n<br />\r\n<strong>Inl&auml;mning av flera bilagor</strong><br />\r\nDu kan bifoga flera meritf&ouml;rteckningar f&ouml;r arbetsgruppens medlemmar som enskilda bilagor genom<br role=\"presentation\" />\r\natt l&auml;gga till dem under rubriken &Ouml;vriga bilagor. Om du vill kan du ocks&aring; l&auml;mna in flera bilagor i en<br role=\"presentation\" />\r\nfil."
   notification_attachments:
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Innehållet i bilagorna kan inte granskas i efterhand</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Observera att du inte kan öppna bilagorna efter att du har bifogat dem blanketten. Du ser bara bilagans filnamn.</p>\r\n\r\n<p>Även om du inte kan granska innehållet i bilagorna i efterhand skickas bilagorna som bifogats blanketten med övriga uppgifter till personen som behandlar ansökan om understöd.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
   extra_info:

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -8,6 +8,8 @@ elements: |
     '#title': 'Hämtade uppgifter'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">Informationen har h&auml;mtats fr&aring;n din profil.</div>'
+  hakijan_tiedot:
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:
@@ -270,8 +272,13 @@ elements: |
       0: Nej
   tulot:
     '#markup': '<h4>Planerade inkomster</h4>'
+  budget_static_income:
+    '#plannedOtherCompensations__help': 'Även stadens övriga understöd'
+    '#otherCompensations__help': 'Även stadens övriga understöd'
   menot:
     '#markup': '<h4>Planerade utgifter</h4>'
+  budget_static_cost:
+    '#showCosts__help': 'Övriga ersättningar för framförande, förutom löner och arvoden'
   budget_other_cost:
     '#title': 'Övriga kostnader'
   muu_huomioitava_panostus_osio:

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -277,9 +277,6 @@ elements: |-
         '#subvention_type_id__access': false
         '#subvention_type__title': Avustuslaji
         '#subvention_amount__title': 'Avustuksen summa'
-      markup:
-        '#type': webform_markup
-        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
       ensisijainen_taiteen_ala:
         '#type': select
         '#title': 'Ensisijainen taiteenala'
@@ -594,7 +591,6 @@ elements: |-
         '#attributes':
           class:
             - grants-fieldset
-        '#help': 'T&auml;yt&auml; luvut sis&auml;lt&auml;en toiminnan kokonaisuudessaan sek&auml; Suomessa ett&auml; mahdollisesti ulkomailla.'
         esitykset_maara_kaikkiaan:
           '#type': textfield
           '#maxlength': 9


### PR DESCRIPTION
# [AU-1866](https://helsinkisolutionoffice.atlassian.net/browse/AU-1866)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed translations in kuva projekti

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1866-kuva-translations`
  * `make fresh`
* Run `make drush-cr`
* IF NEEDED:
* Go to [Ignore](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/config/development/configuration/ignore)
* Remove webform-line and save
* Run `drush cim` in shell

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] [Open application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti)
* [ ] Go through en and sv and check that translations match excel
* [ ] Custom composite fields were not changed bc they are global (premises, budget)

[AU-1866]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ