### PR TITLE
fix: AU-1828: Throw an exception if selectedCompany is empty during access check

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -2091,6 +2091,11 @@ class ApplicationHandler {
 
     // If we have account number, load details.
     $selectedCompany = $this->grantsProfileService->getSelectedRoleData();
+
+    if (empty($selectedCompany)) {
+      throw new CompanySelectException('User not authorised');
+    }
+
     $grantsProfileDocument = $this->grantsProfileService->getGrantsProfile($selectedCompany);
     $profileContent = $grantsProfileDocument->getContent();
     $webformData = $webform_submission->getData();


### PR DESCRIPTION

# [AU-1828](https://helsinkisolutionoffice.atlassian.net/browse/AU-1828)


## What was done


* Sentry https://sentry.hel.fi/organizations/city-of-helsinki/issues/15388/?project=163&referrer=project-issue-stream is throwing a unhandled exception notifications.

When user has been logged automatically and then performs the login action in edit page 403, Drupal will memorize the url and redirect there, even though the user hasn't done a role selection.

* Throw CompanySelectException, so the subscriber can pickup the exception and redirect user to the mandate selection page.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1824-profile-unhandled-exception?`
  * `make fresh`
* Run `make drush-cr`

### Problem repro (current dev)

* [ ] Create a draft and copy the edit url to notepad or to pastebuffer (Should look something like this: https://hel-fi-drupal-grant-applications.docker.so/fi/hakemus/liikunta_toiminta_ja_tilankaytto/1146/muokkaa)
* [ ] Logout
* [ ] Visit the copied page, you should see "no permission" page
* [ ] Click the login button at the bottom (Don't use navbar link)
* [ ] Do the login process and get the error message


## How to test

* [ ] Create a draft and copy the edit url to notepad or to pastebuffer (Should look something like this: https://hel-fi-drupal-grant-applications.docker.so/fi/hakemus/liikunta_toiminta_ja_tilankaytto/1146/muokkaa)
* [ ] Logout
* [ ] Visit the copied url, you should see no permission page
* [ ] Click the login button at the bottom
* [ ] Do the login process 
* [ ] You should be redirected to the role selection page.



[AU-1824]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-1828]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ