### PR TITLE
fix: AU-1885: fix kuva projekti budget translations

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -271,11 +271,25 @@ elements: |
     '#markup': '<h4>Planned incomes</h4>'
   budget_static_income:
     '#plannedOtherCompensations__help': 'Including other grants from the City of Helsinki.'
+    '#sponsorships__title': 'Private funding (sponsors, corporate collaboration, donations, etc.) (€)'
+    '#entryFees__title': 'Entry and participation fees (€)'
     '#otherCompensations__help': 'Including other grants from the City of Helsinki.'
+    '#compensation__title': 'The applied grant (€)'
+    '#sales__title': 'Other incomes (€)'
+    '#ownFunding__title': 'The organizer’s own funding (€)'
   menot:
     '#markup': '<h4>Planned expenses</h4>'
   budget_static_cost:
     '#showCosts__help': 'Compensation for presenting art that is paid in other forms than salary or trade income.'
+    '#premises__title': 'Operating costs for properties, rents (€)'
+    '#performerFees__title': 'Salaries and trade incomes to artists (€)'
+    '#otherFees__title': 'Other salaries and trade incomes (production, technical staff etc.) (€)'
+    '#personnelSideCosts__title': 'Personnel costs from the salaries and trade incomes (approx. 30%) (€)'
+    '#showCosts__title': 'Fees for presenting art (€)'
+    '#travelCosts__title': 'Travel costs (€)'
+    '#transportCosts__title': 'Transportation costs (incl. car rentals) (€)'
+    '#equipment__title': 'Technical costs, equipment rents, and electricity (€)'
+    '#marketing__title': 'Publicity, marketing, and printing (€)'
   budget_other_cost:
     '#title': 'Other costs'
   muu_huomioitava_panostus_osio:

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -274,11 +274,26 @@ elements: |
     '#markup': '<h4>Planerade inkomster</h4>'
   budget_static_income:
     '#plannedOtherCompensations__help': 'Även stadens övriga understöd'
+    '#sponsorships__title': 'Privat finansiering (t.ex. sponsorering, företagssamarbete, donationer) (€)'
+    '#entryFees__title': 'Inträdes- eller deltagaravgifter (€)'
     '#otherCompensations__help': 'Även stadens övriga understöd'
+    '#compensation__title': 'Ansökt projektstöd (€)'
+    '#plannedOtherCompensations__title': 'Övriga understöd (€)'
+    '#sales__title': 'Övriga egna inkomster (€)'
+    '#ownFunding__title': 'Egenfinansiering (€)'
   menot:
     '#markup': '<h4>Planerade utgifter</h4>'
   budget_static_cost:
     '#showCosts__help': 'Övriga ersättningar för framförande, förutom löner och arvoden'
+    '#premises__title': 'Fastighetskostnader, hyror (€)'
+    '#performerFees__title': 'Löner och arvoden för konstnärer och medverkande (€)'
+    '#otherFees__title': 'Övriga löner och arvoden (produktion, teknik, etc.) (€)'
+    '#personnelSideCosts__title': 'Personbikostnader för löner och arvoden (ca 30%) (€)'
+    '#showCosts__title': 'Föreställningsersättningar (€)'
+    '#travelCosts__title': 'Resekostnader (€)'
+    '#transportCosts__title': 'Transportkostnader (inkl. hyrbil) (€)'
+    '#equipment__title': 'Teknik, hyra för utrustning, elektricitet (€)'
+    '#marketing__title': 'Information, marknadsföring och tryckkostnader (€)'
   budget_other_cost:
     '#title': 'Övriga kostnader'
   muu_huomioitava_panostus_osio:

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -935,6 +935,8 @@ elements: |-
         '#otherCompensationFromCity__access': false
         '#stateOperativeSubvention__access': false
         '#plannedOtherCompensations__help': 'Myös muut kaupungin avustukset.'
+        '#sponsorships__title': 'Yksityinen rahoitus (esim. sponsorointi, yritysyhteistyö, lahjoitukset) (€)'
+        '#entryFees__title': 'Pääsy- tai osallistumismaksut (€)'
         '#financialFundingAndInterests__access': false
         '#customerFees__access': false
         '#donations__access': false
@@ -996,12 +998,13 @@ elements: |-
         '#costsWithoutDeferredItems__access': false
         '#generalCostsTotal__access': false
         '#showCosts__help': 'Teosten esittämisestä muuna kuin palkkana tai palkkiona maksettavat korvaukset.'
+        '#premises__title': 'Kiinteistöjen käyttökulut, vuokrat (€)'
         '#totalCosts__access': false
         '#allCostsTotal__access': false
         '#plannedTotalCosts__access': false
       budget_other_cost:
         '#type': grants_budget_other_cost
-        '#title': 'Muut menot'
+        '#title': 'Muut kulut'
         '#multiple': true
         '#incomeGroup': general
         '#multiple__min_items': 1


### PR DESCRIPTION
# [AU-1885](https://helsinkisolutionoffice.atlassian.net/browse/AU-1885)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix kuva projekti budget translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1885-kuva-projekti-budget`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti)
* [ ] Go to page 6
* [ ] Check that budget fields match the ones in excel
* [ ] Repeat in SV and EN


[AU-1885]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ