### PR TITLE
fix: AU-1889: page numbers

### DIFF
--- a/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -138,8 +138,10 @@ elements: |
       0: 'No'
   markup_01:
     '#markup': '<p>Only apply for one grant type at a time with each application.</p>'
+  4_talous:
+    '#title': '4. Budget'
   lisatiedot_ja_liitteet:
-    '#title': '4. Additional information and appendices'
+    '#title': '5. Additional information and appendices'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Additional information concerning the application'
   additional_information:
@@ -225,7 +227,7 @@ elements: |
     '#preview_next__label': 'Preview >'
     '#delete__label': 'Delete unfinished'
 settings:
-  preview_label: '5. Confirm, preview, and submit'
+  preview_label: '6. Confirm, preview, and submit'
   preview_title: 'Confirm, preview, and submit'
   wizard_prev_button_label: '< Previous'
   wizard_next_button_label: 'Next >'

--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -298,7 +298,7 @@ elements: |
     '#counter_maximum_message': '%d/1000 characters remaining'
     '#title': 'Is there some other form of valuable input or trade involved in carrying out the activities that is not listed in the budget?'
   lisatiedot_ja_liitteet:
-    '#title': '4. Additional information and attachments'
+    '#title': '7. Additional information and attachments'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Additional information concerning the application'
   additional_information:
@@ -331,7 +331,7 @@ elements: |
     '#preview_next__label': 'Preview >'
     '#delete__label': ' Delete unfinished'
 settings:
-  preview_label: '5. Confirm, preview, and submit'
+  preview_label: '8. Confirm, preview, and submit'
   preview_title: 'Confirm, preview, and submit'
   wizard_prev_button_label: '< Previous'
   wizard_next_button_label: 'Next >'

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -196,7 +196,7 @@ elements: |
   muut_menot_3:
     '#title': 'Övriga utgifter'
   lisatiedot_ja_liitteet:
-    '#title': '4. Ytterligare information och bilagor'
+    '#title': '5. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Ytterligare information för ansökan'
   additional_information:
@@ -285,5 +285,5 @@ elements: |
 settings:
   wizard_prev_button_label: '< Tidigare'
   wizard_next_button_label: 'Nästa >'
-  preview_label: '5. Bekräfta, förhandsgranska och skicka'
+  preview_label: '6. Bekräfta, förhandsgranska och skicka'
   preview_title: 'Bekräfta, förhandsgranska och skicka'

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -302,7 +302,7 @@ elements: |
     '#counter_maximum_message': '%d/1000 tecken kvar'
     '#title': 'Ingår det i verksamheten någon betydande eller värdefull annan insats eller byteshandel, som inte framgår ur budgeten?'
   lisatiedot_ja_liitteet:
-    '#title': '4. Ytterligare information och bilagor'
+    '#title': '7. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Ytterligare information för ansökan'
   additional_information:
@@ -337,5 +337,5 @@ elements: |
 settings:
   wizard_prev_button_label: '< Tidigare'
   wizard_next_button_label: 'Nästa >'
-  preview_label: '5. Bekräfta, förhandsgranska och skicka'
+  preview_label: '8. Bekräfta, förhandsgranska och skicka'
   preview_title: 'Bekräfta, förhandsgranska och skicka'

--- a/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
@@ -347,7 +347,7 @@ elements: |
   toteutuneet_menot_osio:
     '#markup': '<h4>Realiserade utgifter</h4>'
   lisatiedot_ja_liitteet:
-    '#title': '4. Ytterligare information och bilagor'
+    '#title': '7. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:
     '#title': 'Ytterligare information för ansökan'
   additional_information:

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -1059,7 +1059,7 @@ settings:
   wizard_page_type: container
   wizard_page_title_tag: h2
   preview: 2
-  preview_label: '5. Vahvista, esikatsele ja lähetä'
+  preview_label: '6. Vahvista, esikatsele ja lähetä'
   preview_title: 'Vahvista, esikatsele ja lähetä'
   preview_message: ''
   preview_attributes: {  }


### PR DESCRIPTION
# [AU-1889](https://helsinkisolutionoffice.atlassian.net/browse/AU-1889)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed missing Translations from Wizard Page labels

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1889-page-numbers`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [kuva_projekti](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti)
* [ ] Check that the Paginator has correct numbers for the pages in text in Finnish
* [ ] in Swedish
* [ ] and in English
* [ ] Go to [Kasvatus ja koulutus, toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kasvatus_ja_koulutus_toiminta_av)
* [ ] Check that the Paginator has correct numbers for the pages in text in Finnish
* [ ] in Swedish
* [ ] and in English
* [ ] Go to [kuva_toiminta](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_toiminta)
* [ ] Check that the Paginator has correct numbers for the pages in text in Finnish
* [ ] in Swedish
* [ ] and in English
* [ ] Check that code follows our standards


[AU-1889]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ