### PR TITLE
fix: AU-1800: Add description to Liikunnan yleisavustus

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_yleisavustushakemus.yml
@@ -56,6 +56,8 @@ elements: |
     '#title': 'Types of grant'
   subventions:
     '#title': Grants
+  markup_subventions:
+    '#markup': 'This form is used to apply for only one grant at a time. When you apply for a start grant, the grant amount (€500) will appear in the field automatically and cannot be changed because the amount is fixed. For other types of grant, you must specify the amount applied for in the field.'
   kayttotarkoitus:
     '#title': 'Purpose of use'
   compensation_purpose:

--- a/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
@@ -59,6 +59,8 @@ elements: |
     '#title': Understödskatego&shy;rier
   subventions:
     '#title': Understöd
+  markup_subventions:
+    '#markup': 'Med denna blankett ansöker du om ett understöd i taget. När du ansöker om startunderstöd, finns understödsbeloppet (500 €) färdigt i fältet, och du kan inte ändra beloppet, eftersom det är fast. I andra understödsslag ska du själv ange beloppet i fältet.'
   kayttotarkoitus:
     '#title': Användningsända&shy;mål
   compensation_purpose:

--- a/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
@@ -246,6 +246,9 @@ elements: |-
         '#subvention_type_id__access': false
         '#subvention_type__title': Avustuslaji
         '#subvention_amount__title': 'Avustuksen summa'
+      markup_subventions:
+        '#type': webform_markup
+        '#markup': 'Tällä lomakkeella haetaan vain yhtä avustusta kerrallaan. Hakiessasi starttiavustusta, avustussumma (500€) tulee valmiina kenttään, eikä summaa voi muuttaa, koska avustussumma on kiinteä. Muissa avustuslajeissa haettava summa tulee lisätä kenttään.'
     kayttotarkoitus:
       '#type': webform_section
       '#title': Käyttötarkoitus


### PR DESCRIPTION
# [AU-1800](https://helsinkisolutionoffice.atlassian.net/browse/AU-1800)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* New Description to Liikunnan yleisavustus

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1800-liikunta-help-text-for-startti`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Liikunnan yleisavustus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/liikunta_yleisavustushakemus)
* [ ] Go to page 2, see that there is a description below subvention types
* [ ] Check swedish
* [ ] Check English
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1800]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ