### PR TITLE
fix: AU-XX: Add key-exists type check to ExtractDataForWebform

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
+++ b/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
@@ -450,15 +450,15 @@ class ApplicantInfoService {
 
     $values = AtvSchema::extractDataForWebForm($content, $keys);
 
-    if ($values['applicantType'] == self::REGISTERED_COMMUNITY) {
+    if ($values['applicantType'] ?? '' == self::REGISTERED_COMMUNITY) {
       $values['applicantType'] = 'registered_community';
       $values['applicant_type'] = 'registered_community';
     }
-    if ($values['applicantType'] == self::UNREGISTERED_COMMUNITY) {
+    if ($values['applicantType'] ?? '' == self::UNREGISTERED_COMMUNITY) {
       $values['applicantType'] = 'unregistered_community';
       $values['applicant_type'] = 'unregistered_community';
     }
-    if ($values['applicantType'] == self::PRIVATE_PERSON) {
+    if ($values['applicantType'] ?? '' == self::PRIVATE_PERSON) {
       $values['applicantType'] = 'private_person';
       $values['applicant_type'] = 'private_person';
     }


### PR DESCRIPTION
# Fix Errors
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/10397961/d8080bed-0a30-431c-a0cd-c173bbb6da65)

* This thing was fixed
* No idea how AtvSchema::extractDataForWebForm with the correct keys gives an answer without ApplicantType for a profile, but this ignores the issue.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-XX-fix-error-in-applicantinfo`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Uh... Log in with default user and maanrakennus and see no errors on oma profiili
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
