### PR TITLE
fix: AU-1851: Add label translations for premises component

### DIFF
--- a/public/modules/custom/grants_premises/src/GrantsPremisesService.php
+++ b/public/modules/custom/grants_premises/src/GrantsPremisesService.php
@@ -94,6 +94,7 @@ class GrantsPremisesService {
    * Get meta field data from components.
    *
    * So far only to return label to support structure, will be filled in time.
+   *
    * @param string $label
    *   Label of the field.
    *

--- a/public/modules/custom/grants_premises/src/GrantsPremisesService.php
+++ b/public/modules/custom/grants_premises/src/GrantsPremisesService.php
@@ -72,7 +72,7 @@ class GrantsPremisesService {
             $label = $label->render();
           }
         }
-        $elementMeta = self::getMeta($itemDefinition);
+        $elementMeta = self::getMeta($label);
         $metaData = AtvSchema::getMetaData($pageMeta, $sectionMeta, $elementMeta);
         $completeMeta = json_encode($metaData, JSON_UNESCAPED_UNICODE);
 
@@ -93,14 +93,16 @@ class GrantsPremisesService {
   /**
    * Get meta field data from components.
    *
-   * So far only to return empty to support structure, will be filled in time.
+   * So far only to return label to support structure, will be filled in time.
+   * @param string $label
+   *   Label of the field.
    *
    * @return array
    *   Metadata.
    */
-  private static function getMeta($itemDefinition): array {
+  private static function getMeta($label): array {
     return [
-      'label' => $itemDefinition->getLabel(),
+      'label' => $label,
     ];
   }
 

--- a/public/modules/custom/grants_premises/src/GrantsPremisesService.php
+++ b/public/modules/custom/grants_premises/src/GrantsPremisesService.php
@@ -29,6 +29,11 @@ class GrantsPremisesService {
     $items = [];
 
     $dataDefinition = $property->getDataDefinition();
+    $propertyName = $property->getName();
+    $webformElement = [];
+    if (isset($arguments['webform'])) {
+      $webformElement = $arguments['webform']->getElement($propertyName);
+    }
     $usedFields = $dataDefinition->getSetting('fieldsForApplication');
 
     foreach ($property as $itemIndex => $p) {
@@ -60,31 +65,21 @@ class GrantsPremisesService {
         if (!$itemValue) {
           continue;
         }
-
-        $elementMeta = self::getMeta($itemDefinition);
-        $completeMeta = json_encode(AtvSchema::getMetaData(
-          $pageMeta, $sectionMeta, $elementMeta,
-        ), JSON_UNESCAPED_UNICODE);
-
-        // Process boolean values separately.
-        if (
-          $itemName == 'isOwnedByCity' ||
-          $itemName == 'isOthersUse' ||
-          $itemName == 'isOwnedByApplicant'
-        ) {
-          $itemValues[] = [
-            'ID' => $itemName,
-            'label' => $itemDefinition->getLabel(),
-            'value' => $itemValue,
-            'valueType' => $valueTypes['jsonType'],
-            'meta' => $completeMeta,
-          ];
-          continue;
+        $label = $itemDefinition->getLabel();
+        if (isset($webformElement['#webform_composite_elements'][$itemName]['#title'])) {
+          $label = $webformElement['#webform_composite_elements'][$itemName]['#title'];
+          if (!is_string($label)) {
+            $label = $label->render();
+          }
         }
+        $elementMeta = self::getMeta($itemDefinition);
+        $metaData = AtvSchema::getMetaData($pageMeta, $sectionMeta, $elementMeta);
+        $completeMeta = json_encode($metaData, JSON_UNESCAPED_UNICODE);
+
         // Add items.
         $itemValues[] = [
           'ID' => $itemName,
-          'label' => $itemDefinition->getLabel(),
+          'label' => $label,
           'value' => $itemValue,
           'valueType' => $valueTypes['jsonType'],
           'meta' => $completeMeta,


### PR DESCRIPTION
# [AU-1851](https://helsinkisolutionoffice.atlassian.net/browse/AU-1851)
<!-- What problem does this solve? -->

Korjaa käännösongelma liittyen premises-komponenttiin

## What was done
<!-- Describe what was done -->

Käsittele label tieto GrantsPremisesService-luokassa.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1851-handle-premises-translation-issue`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Täytä lomake ja erityisesti tilakenttä
* [ ] Varmista että kaikki kääntyy kuten pitää


[AU-1851]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ