### PR TITLE
AU-1899: Remove definitions of previously removed fields and remove pöytäkirja attachment field

### DIFF
--- a/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -896,14 +896,6 @@ elements: |-
           &nbsp;
         '#title_display': before
         '#description__access': false
-      vuosikokouksen_poytakirja:
-        '#type': grants_attachments
-        '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
-        '#multiple': false
-        '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
-        '#title_display': before
-        '#description__access': false
       toimintasuunnitelma:
         '#type': grants_attachments
         '#title': 'Toimintasuunnitelma (sille vuodelle jolle haet avustusta)'

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
@@ -119,26 +119,8 @@ class LiikuntaTilankayttoDefinition extends ComplexDataDefinitionBase {
           'rentIncomesArray',
         ]);
 
-      // Section 3: Yhteisön toiminta. Empty values not impl. in avus2 yet.
+      // Section 3: Yhteisön toiminta.
       $mappings = [
-        'miehet_20_63_vuotiaat_' => 'menGlobal',
-        'joista_helsinkilaisia_miehet_20_63' => 'menLocal',
-        'naiset_20_63_vuotiaat_' => 'womenGlobal',
-        'joista_helsinkilaisia_naiset_20_63' => 'womenLocal',
-        'muut_20_63_vuotiaat_' => 'adultOthersGlobal',
-        'joista_helsinkilaisia_muut_20_63' => 'adultOthersLocal',
-        'miehet_64' => 'seniorMenGlobal',
-        'joista_helsinkilaisia_miehet_64' => 'seniorMenLocal',
-        'naiset_64' => 'seniorWomenGlobal',
-        'joista_helsinkilaisia_naiset_64' => 'seniorWomenLocal',
-        'muut_64' => 'seniorOthersGlobal',
-        'joista_helsinkilaisia_muut_64' => 'seniorOthersLocal',
-        'pojat_20' => 'boysGlobal',
-        'joista_helsinkilaisia_pojat_20' => 'boysLocal',
-        'tytot_20' => 'girlsGlobal',
-        'joista_helsinkilaisia_tytot_20' => 'girlsLocal',
-        'muut_20' => 'juniorOthersGlobal',
-        'joista_helsinkilaisia_muut_20' => 'juniorOthersLocal',
         'miehet_20_63_vuotiaat_aktiiviharrastajat' => 'activeFanciersMenGlobal',
         'joista_helsinkilaisia_miehet_20_63_aktiiviharrastajat' => 'activeFanciersMenLocal',
         'naiset_20_63_vuotiaat_aktiiviharrastajat' => 'activeFanciersWomenGlobal',


### PR DESCRIPTION
# [AU-1899](https://helsinkisolutionoffice.atlassian.net/browse/AU-1899)
# [AU-1900](https://helsinkisolutionoffice.atlassian.net/browse/AU-1900)
<!-- What problem does this solve? -->

## What was done

* We [previously removed ](https://helsinkisolutionoffice.atlassian.net/browse/AU-1773)some fields from the form, but the definitions still exist and causes validation error when trying to send the final submit.
* Removed these definitions
* Removed vuosikokouksen pöytäkirja - attachment field

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1899-fix-validation-error-on-submit`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check from code, that the correct fields were removed

* [ ] Open a [Liikunta, toiminta- ja tilankäyttöavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/liikunta-toiminta-ja-tilankaytto)
* [ ] Fill all 'em fields
* [ ] Attachment page: check that "`vuosikokouksen pöytäkirja`" is no more.
* [ ] When submitting the application, check that no validation errors occur and that the application is sent through the integration



[AU-1899]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1900]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ