### PR TITLE
fix: AU-1896: Private person applicant info, get email and name from helsinki profiili

### DIFF
--- a/public/modules/custom/grants_applicant_info/grants_applicant_info.services.yml
+++ b/public/modules/custom/grants_applicant_info/grants_applicant_info.services.yml
@@ -2,5 +2,6 @@ services:
   grants_applicant_info.service:
     class: Drupal\grants_applicant_info\ApplicantInfoService
     arguments: [
-      '@grants_profile.service'
+      '@grants_profile.service',
+      '@helfi_helsinki_profiili.userdata',
     ]

--- a/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
+++ b/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
@@ -7,6 +7,7 @@ use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\grants_applicant_info\TypedData\Definition\ApplicantInfoDefinition;
 use Drupal\grants_metadata\AtvSchema;
 use Drupal\grants_profile\GrantsProfileService;
+use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
 
 /**
  * HAndle applicant info service.
@@ -27,13 +28,26 @@ class ApplicantInfoService {
   protected GrantsProfileService $grantsProfileService;
 
   /**
+   * The helfi_helsinki_profiili.userdata service.
+   *
+   * @var \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData
+   */
+  protected HelsinkiProfiiliUserData $helsinkiProfiiliUserData;
+
+  /**
    * Construct the service object.
    *
    * @param \Drupal\grants_profile\GrantsProfileService $grantsProfileService
    *   Grants profile access.
+   * @param \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData $helsinkiProfiiliUserData
+   *   The helfi_helsinki_profiili.userdata service.
    */
-  public function __construct(GrantsProfileService $grantsProfileService) {
+  public function __construct(
+    GrantsProfileService $grantsProfileService,
+    HelsinkiProfiiliUserData $helsinkiProfiiliUserData,
+  ) {
     $this->grantsProfileService = $grantsProfileService;
+    $this->helsinkiProfiiliUserData = $helsinkiProfiiliUserData;
   }
 
   /**
@@ -293,6 +307,7 @@ class ApplicantInfoService {
 
     $roleId = $this->grantsProfileService->getSelectedRoleData();
     $profile = $this->grantsProfileService->getGrantsProfileContent($roleId);
+    $helsinkiProfile = $this->helsinkiProfiiliUserData->getUserData();
 
     if ($profile) {
       $addressPath = [
@@ -328,7 +343,7 @@ class ApplicantInfoService {
         // Add contact person from user data.
         [
           'ID' => 'contactPerson',
-          'value' => $roleId["name"] ?? '',
+          'value' => $helsinkiProfile["name"] ?? '',
           'valueType' => 'string',
           'label' => 'Yhteyshenkilö',
         ],
@@ -357,7 +372,7 @@ class ApplicantInfoService {
         ],
         [
           'ID' => 'email',
-          'value' => $profile["email"],
+          'value' => $helsinkiProfile["email"],
           'valueType' => 'string',
           'label' => 'Sähköpostiosoite',
         ]);


### PR DESCRIPTION
# [AU-1896](https://helsinkisolutionoffice.atlassian.net/browse/AU-1896)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Private person applicantInfoArray is now always Helsinki Profiili data, so we won't use possibly old email from grants_profile.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1896-private-applicant-info-from-hp`
  * `make fresh`
* Run `make drush-cr`

## Original problem (test in develop)

* [ ] You need to change account email, so pick non-default user from test data.
* [ ] Log in as private user
* [ ] Change the account email @ https://profiili.test.hel.ninja/loginsso
* [ ] Log out from the grants service
* [ ] Log in back.
* [ ] [Create a new application 
](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti)
* [ ] Save as draft
* [ ] Check ATV document, you should see different emails in `senderInfoArray` & `applicantInfoArray`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] git checkout feature/AU-1896-private-applicant-info-from-hp
* [ ] Edit the draft / or create a new application
* [ ] Save as draft.
* [ ] Now both emails should be the email you changed in helsinki profiili.


