### PR TITLE
feat: AU-1759: Liikunta tilankäyttö: Make fields required if applying for tilankäyttöavustus

### DIFF
--- a/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -501,26 +501,49 @@ elements: |-
       liikuntatiloista_maksetut_vuokrat_fieldset:
         '#type': fieldset
         '#title': 'Liikuntatiloista maksetut vuokrat'
+        '#states':
+          required:
+            ':input[name="tilankayttosumma"]':
+              value:
+                greater: '0'
         '#attributes':
           class:
             - grants-fieldset
             - grants-fieldset-short
         tuntimaara_yhteensa:
-          '#type': number
+          '#type': textfield
           '#title': 'Tuntimäärä yhteensä'
-          '#wrapper_attributes':
+          '#input_mask': '''alias'': ''numeric'', ''groupSeparator'': '' '', ''digits'': ''0'''
+          '#pattern': '^[0-9 ]*$'
+          '#states':
+            required:
+              ':input[name="tilankayttosumma"]':
+                value:
+                  greater: '0'
+          '#attributes':
             class:
               - webform--small
           '#step': 1
         vuokrat_yhteensa:
-          '#type': number
+          '#type': textfield
           '#title': 'Yhteensä / EUR'
-          '#wrapper_attributes':
+          '#states':
+            required:
+              ':input[name="tilankayttosumma"]':
+                value:
+                  greater: '0'
+          '#input_mask': '''alias'': ''numeric'', ''groupSeparator'': '' '', ''digits'': ''2'', ''radixPoint'': '','', ''substituteRadixPoint'': ''true'''
+          '#attributes':
             class:
               - webform--small
         seuraavalle_vuodelle_suunniteltu_muutos_tilojen_kaytossa_tunnit_:
           '#type': textfield
           '#title': 'Seuraavalle vuodelle suunniteltu muutos tilojen käytössä +/- tunnit ja syy'
+          '#states':
+            required:
+              ':input[name="tilankayttosumma"]':
+                value:
+                  greater: '0'
           '#wrapper_attributes':
             class:
               - webform--small

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -707,7 +707,8 @@ class AtvSchema {
             }
             else {
               if (empty($itemValue)) {
-                // There are no fields that would have requiredInJson setting here.
+                // There are no fields that would have
+                // requiredInJson setting here.
                 if ($requiredInJson) {
                   $documentStructure[$jsonPath[0]][$jsonPath[1]][$jsonPath[2]][$elementName] = $itemValue;
                 }

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/LiikuntaTilankayttoDefinition.php
@@ -76,10 +76,14 @@ class LiikuntaTilankayttoDefinition extends ComplexDataDefinitionBase {
           ],
         ]);
 
-      $info['tuntimaara_yhteensa'] = DataDefinition::create('string')
+      $info['tuntimaara_yhteensa'] = DataDefinition::create('integer')
         ->setSetting('typeOverride', [
           'dataType' => 'string',
-          'jsonType' => 'double',
+          'jsonType' => 'int',
+        ])
+        ->setSetting('valueCallback', [
+          '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
+          'convertToInt',
         ])
         ->setSetting('jsonPath', [
           'compensation',
@@ -89,10 +93,18 @@ class LiikuntaTilankayttoDefinition extends ComplexDataDefinitionBase {
           'rentCostsHours',
         ]);
 
-      $info['vuokrat_yhteensa'] = DataDefinition::create('string')
+      $info['vuokrat_yhteensa'] = DataDefinition::create('float')
         ->setSetting('typeOverride', [
           'dataType' => 'string',
           'jsonType' => 'double',
+        ])
+        ->setSetting('valueCallback', [
+          '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
+          'convertToFloat',
+        ])
+        ->setSetting('webformValueExtracter', [
+          'service' => 'grants_metadata.converter',
+          'method' => 'extractFloatValue',
         ])
         ->setSetting('jsonPath', [
           'compensation',


### PR DESCRIPTION
# [AU-1759](https://helsinkisolutionoffice.atlassian.net/browse/AU-1759)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Make `Liikuntatiloista maksetut vuokrat` fields required, if applying for Tilankäyttöavustus
* Fixed missing input masks and some mappings

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1759-liikunta-tila-conditional-requirement`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Open a new [Liikunta, toiminta- ja tilankäyttöavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/liikunta-toiminta-ja-tilankaytto)
* [x] Page 2: Insert a value to `Tilankäyttöavustus`
* [x] Check that `Liikuntatiloista maksetut vuokrat` becomes required.
* [x] Check that requirements disappear, if you change subventions
* [x] Check that values save and maps back correctly. (Due input mask changes. Save as Draft -> Back to edit).


⚠ PHPCS virhe korjattu toisessa pullarissa, joten en viiti sitä jokaseen kopioida.

[AU-1759]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ