### PR TITLE
fix: AU-1875: remove fields from liikunta laitos

### DIFF
--- a/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
@@ -480,55 +480,6 @@ elements: |-
         '#counter_maximum': 5000
         '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
         '#cols': 63
-    edellisen_avustuksen_kayttoselvitys:
-      '#type': webform_section
-      '#title': 'Edellisen avustuksen käyttöselvitys'
-      compensation_boolean_info:
-        '#type': processed_text
-        '#text': |
-          <div class="hds-notification hds-notification--info">
-            <div class="hds-notification__content">
-              <div class="hds-notification__label" role="heading" aria-level="2">
-                <span class="hel-icon hel-icon--alert-circle-fill" aria-hidden="true"></span>
-                <span>Myöntävä vastaus avaa lisäkysymyksen</span>
-              </div>
-            </div>
-          </div>
-        '#format': full_html
-      compensation_boolean:
-        '#type': radios
-        '#title': 'Käyttöselvitys edellisenä vuonna saamastani avustuksesta'
-        '#options':
-          - 'En ole saanut Helsingin kaupungilta avustusta samaan käyttötarkoitukseen edellisenä vuonna.'
-          - 'Olen saanut Helsingin kaupungilta avustusta samaan käyttötarkoitukseen edellisenä vuonna.'
-        '#required': true
-      markup:
-        '#type': webform_markup
-        '#states':
-          visible:
-            ':input[name="compensation_boolean"]':
-              value: 'true'
-        '#markup': 'Anna k&auml;ytt&ouml;selvitys Helsingin kaupungilta saadusta avustuksesta. Avustuksen k&auml;ytt&ouml;selvitys tehd&auml;&auml;n avustuksesta, joka koskee viimeisint&auml; p&auml;&auml;ttynytt&auml; tilikautta. K&auml;ytt&ouml;selvityst&auml; ei tehd&auml; k&auml;ynniss&auml; olevalta tilikaudelta. K&auml;ytt&ouml;selvityksen antaminen on seuraavan avustuksen saamisen ehtona. Mik&auml;li k&auml;ytt&ouml;selvityst&auml; ei tehd&auml;, avustusta ei my&ouml;nnet&auml; eik&auml; makseta. My&ouml;nnetty avustus voidaan peri&auml; takaisin, jos edellisen avustuksen k&auml;ytt&ouml;&auml; ei ole hyv&auml;ksytt&auml;v&auml;sti selvitetty.'
-      compensation_explanation:
-        '#type': textarea
-        '#title': 'Selvitys avustuksen käytöstä'
-        '#help': 'K&auml;ytt&ouml;selvityksess&auml; tulee kuvata lyhyesti, miten my&ouml;nnetty avustus on k&auml;ytetty. Avustuksen saajan on j&auml;rjestett&auml;v&auml; kirjanpitonsa niin, ett&auml; avustuksen k&auml;ytt&ouml;&auml; voidaan sielt&auml; seurata. Esimerkiksi jos yhteis&ouml; on saanut vuokra-avustusta, tilinp&auml;&auml;t&ouml;ksen tuloslaskelmasta tulee k&auml;yd&auml; ilmi avustuksen toteutuminen sek&auml; tuloissa ett&auml; menoissa. Lis&auml;&auml; tietoja avustuksen k&auml;yt&ouml;st&auml; voi my&ouml;s kirjoittaa erilliseen liitteeseen, jonka voi palauttaa K&auml;ytt&ouml;selvitys-liite kohdasta.'
-        '#maxlength': 5000
-        '#counter_type': character
-        '#counter_minimum': 1
-        '#counter_maximum': 5000
-        '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
-        '#states':
-          visible:
-            ':input[name="compensation_boolean"]':
-              value: '1'
-          required:
-            ':input[name="compensation_boolean"]':
-              value: '1'
-        '#attributes':
-          class:
-            - webform--large
-        '#cols': 63
   3_yhteison_tiedot:
     '#type': webform_wizard_page
     '#title': '3. Yhteisön toiminta'


### PR DESCRIPTION
# [AU-1875](https://helsinkisolutionoffice.atlassian.net/browse/AU-1875)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove fields from laitosavustus

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1875-liikunta-laitos-remove-field`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [laitosavustus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/liikunta_laitosavustushakemus) (you may need to change the open times to get there)
* [ ] Check that on page 2 that the correct field (as defined in the ticket and excel) is missing
* [ ] Check that code follows our standards

[AU-1875]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ