### PR TITLE
fix: AU-1914: fix missing translations asukaspien

### DIFF
--- a/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -419,22 +419,6 @@ elements: |-
         '#counter_maximum': 5000
         '#counter_maximum_message': '%d/5000 merkkiä jäljellä'
         '#cols': 63
-    actions:
-      '#type': webform_actions
-      '#title': 'Submit button(s)'
-      '#submit__label': Lähetä
-      '#draft__label': 'Tallenna keskeneräisenä'
-      '#wizard_prev__label': '< Edellinen'
-      '#wizard_next__label': 'Seuraava >'
-      '#preview_prev__label': '< Edellinen'
-      '#preview_next__label': 'Esikatseluun >'
-      '#delete_hide': false
-      '#delete__label': 'Poista keskeneräinen'
-      '#delete__attributes':
-        class:
-          - hds-button
-          - hds-button--primary
-      '#delete__dialog': true
   3_yhteison_tiedot:
     '#type': webform_wizard_page
     '#title': '3. Yhteisön toiminta'
@@ -600,6 +584,21 @@ elements: |-
         '#multiple__add_more_button_label': 'Lisää liite'
         '#isDeliveredLater__access': false
         '#isIncludedInOtherFile__access': false
+  actions:
+    '#title': 'Submit button(s)'
+    '#submit__label': Lähetä
+    '#draft__label': 'Tallenna keskeneräisenä'
+    '#wizard_prev__label': '< Edellinen'
+    '#wizard_next__label': 'Seuraava >'
+    '#preview_prev__label': '< Edellinen'
+    '#preview_next__label': 'Esikatseluun >'
+    '#delete_hide': false
+    '#delete__label': 'Poista keskeneräinen'
+    '#delete__attributes':
+      class:
+        - hds-button
+        - hds-button--primary
+    '#delete__dialog': true
 css: ''
 javascript: ''
 settings:

--- a/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -585,6 +585,7 @@ elements: |-
         '#isDeliveredLater__access': false
         '#isIncludedInOtherFile__access': false
   actions:
+    '#type': webform_actions
     '#title': 'Submit button(s)'
     '#submit__label': Lähetä
     '#draft__label': 'Tallenna keskeneräisenä'


### PR DESCRIPTION
# [AU-1914](https://helsinkisolutionoffice.atlassian.net/browse/AU-1914)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Previous button fixed for fi/sv in Asukasosallisuus, pienavustushakemus

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1914-previous`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as private person
* [ ] Go to [Asukasosallisuus, pienavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_pienavustushake)
* [ ] Go to preview page. See that the Previous button reads Edellinen, not Previous
* [ ] Switch to Swedish, check the above in Swedish as well.
* [ ] Check that code follows our standards


[AU-1914]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ