### PR TITLE
feat: AU-1910 Budget component order and print fixes

### DIFF
--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -3,7 +3,6 @@
 namespace Drupal\grants_budget_components\Element;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\webform\Element\WebformCompositeBase;
 
 /**
  * Provides a 'grants_budget_cost_static'.
@@ -20,7 +19,7 @@ use Drupal\webform\Element\WebformCompositeBase;
  * @see \Drupal\webform\Element\WebformCompositeBase
  * @see \Drupal\webform_example_composite\Element\WebformExampleComposite
  */
-class GrantsBudgetCostStatic extends WebformCompositeBase {
+class GrantsBudgetCostStatic extends GrantsBudgetStaticBase {
 
   /**
    * {@inheritdoc}
@@ -32,45 +31,13 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
   // @codingStandardsIgnoreStart
 
   /**
-   * Process default values and values from submitted data.
-   *
-   * @param array $element
-   *   Element that is being processed.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   Form state.
-   * @param array $complete_form
-   *   Full form.
-   *
-   * @return array[]
-   *   Form API element for webform element.
+   * {@inheritdoc}
    */
   public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form): array {
-
-    $element['#tree'] = TRUE;
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $dataForElement = $element['#value'];
 
-    $storage = $form_state->getStorage();
-    $errors = $storage['errors'][$element['#webform_key']] ?? [];
-
-    $element_errors = $errors['errors'] ?? [];
-    foreach ($element_errors as $errorKey => $erroValue) {
-      $element[$errorKey]['#attributes']['class'][] = $erroValue['class'];
-      $element[$errorKey]['#attributes']['error_label'] = $erroValue['label'];
-    }
-
-    $fieldKeys = array_keys(self::getFieldNames());
-
-    $fieldsInUse = [];
-
-    foreach ($fieldKeys as $fieldKey) {
-      $keyToCheck = '#' . $fieldKey . '__access';
-      if (isset($element[$keyToCheck]) && $element[$keyToCheck] === FALSE) {
-        unset($element[$fieldKey]);
-      } else {
-        $fieldsInUse[] = $fieldKey;
-      }
-    }
+    unset($element['incomeGroupName']);
 
     if (isset($dataForElement['costGroupName'])) {
       $element['costGroupName']['#value'] = $dataForElement['costGroupName'];
@@ -78,28 +45,6 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
 
     if (empty($element['costGroupName']['#value']) && isset($element['#incomeGroup'])) {
       $element['costGroupName']['#value'] = $element['#incomeGroup'];
-    }
-
-    if (getenv('PRINT_DEVELOPMENT_DEBUG_FIELDS') == '1') {
-      $element['debugging'] = [
-        '#type' => 'details',
-        '#title' => 'Dev DEBUG:',
-        '#open' => FALSE,
-      ];
-
-      $element['debugging']['fieldset'] = [
-        '#type' => 'fieldset'
-      ];
-
-      $element['debugging']['fieldset']['fields_in_use'] = [
-        '#type' => 'inline_template',
-        '#template' => "->setSetting('fieldsForApplication', [
-          {% for field in fields %}
-            '{{ field }}',<br/>
-          {% endfor %}
-        ])",
-        '#context' => ['fields' => $fieldsInUse]
-      ];
     }
 
     return $element;
@@ -190,19 +135,6 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
       "allCostsTotal" => t("allCostsTotal (€)", [], $tOpts),
       "plannedTotalCosts" => t("Planned total costs (€)", [], $tOpts),
     ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function valueCallback(&$element, $input, FormStateInterface $formState) {
-    $values = parent::valueCallback($element, $input, $formState);
-    // For some reason webform won't pass values later, if composite values
-    // Are all falsy. Bit hacky but let's insert a value that is not used
-    // any where, so we can track if user actually inserted 0 value or left
-    // field empty.
-    $values['_Temp'] = '1';
-    return $values;
   }
 
 }

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -196,11 +196,13 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
    * {@inheritdoc}
    */
   public static function valueCallback(&$element, $input, FormStateInterface $formState) {
-
-    $parent = parent::valueCallback($element, $input, $formState);
-    $parent['fake'] = '1';
-
-    return $parent;
+    $values = parent::valueCallback($element, $input, $formState);
+    // For some reason webform won't pass values later, if composite values
+    // Are all falsy. Bit hacky but let's insert a value that is not used
+    // any where, so we can track if user actually inserted 0 value or left
+    // field empty.
+    $values['_Temp'] = '1';
+    return $values;
   }
 
 }

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -192,4 +192,15 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $formState) {
+
+    $parent = parent::valueCallback($element, $input, $formState);
+    $parent['fake'] = '1';
+
+    return $parent;
+  }
+
 }

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -147,6 +147,7 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
     $tOpts = ['context' => 'grants_budget_components'];
     return [
       "salaries" => t("Salaries (€)", [], $tOpts),
+      "personnelSideCosts" => t("Personnel costs from salaries and fees (approx. 30%) (€)", [], $tOpts),
       "personnelSocialSecurityCosts" => t("personnelSocialSecurityCosts (€)", [], $tOpts),
       "rentSum" => t("Rents (€)", [], $tOpts),
       "materials" => t("Materials (€)", [], $tOpts),
@@ -173,7 +174,6 @@ class GrantsBudgetCostStatic extends WebformCompositeBase {
       "netCosts" => t("netCosts (€)", [], $tOpts),
       "performerFees" => t("Salaries and fees for performers and artists (€)", [], $tOpts),
       "otherFees" => t("Other salaries and fees (production, technology, etc.) (€)", [], $tOpts),
-      "personnelSideCosts" => t("Personnel costs from salaries and fees (approx. 30%) (€)", [], $tOpts),
       "generalCosts" => t("generalCosts (€)", [], $tOpts),
       "permits" => t("permits (€)", [], $tOpts),
       "setsAndCostumes" => t("setsAndCostumes (€)", [], $tOpts),

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -203,4 +203,14 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $formState) {
+    $values = parent::valueCallback($element, $input, $formState);
+    // @See GrantsBudgetCostStatic::valueCallback() for details.
+    $values['_Temp'] = '1';
+    return $values;
+  }
+
 }

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -3,7 +3,6 @@
 namespace Drupal\grants_budget_components\Element;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\webform\Element\WebformCompositeBase;
 
 /**
  * Provides a 'grants_budget_income_static'.
@@ -20,7 +19,7 @@ use Drupal\webform\Element\WebformCompositeBase;
  * @see \Drupal\webform\Element\WebformCompositeBase
  * @see \Drupal\webform_example_composite\Element\WebformExampleComposite
  */
-class GrantsBudgetIncomeStatic extends WebformCompositeBase {
+class GrantsBudgetIncomeStatic extends GrantsBudgetStaticBase {
 
   /**
    * {@inheritdoc}
@@ -28,84 +27,6 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
   public function getInfo() {
     return parent::getInfo() + ['#theme' => 'grants_budget_income_static'];
   }
-
-  // @codingStandardsIgnoreStart
-
-  /**
-   * Process default values and values from submitted data.
-   *
-   * @param array $element
-   *   Element that is being processed.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   Form state.
-   * @param array $complete_form
-   *   Full form.
-   *
-   * @return array[]
-   *   Form API element for webform element.
-   */
-  public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form): array {
-
-    $element['#tree'] = TRUE;
-    $element = parent::processWebformComposite($element, $form_state, $complete_form);
-    $dataForElement = $element['#value'];
-
-    $storage = $form_state->getStorage();
-    $errors = $storage['errors'][$element['#webform_key']] ?? [];
-
-    $element_errors = $errors['errors'] ?? [];
-    foreach ($element_errors as $errorKey => $erroValue) {
-      $element[$errorKey]['#attributes']['class'][] = $erroValue['class'];
-      $element[$errorKey]['#attributes']['error_label'] = $erroValue['label'];
-    }
-
-    $fieldKeys = array_keys(self::getFieldNames());
-
-    $fieldsInUse = [];
-
-    foreach ($fieldKeys as $fieldKey) {
-      $keyToCheck = '#' . $fieldKey . '__access';
-      if (isset($element[$keyToCheck]) && $element[$keyToCheck] === FALSE) {
-        unset($element[$fieldKey]);
-      } else {
-        $fieldsInUse[] = $fieldKey;
-      }
-    }
-
-    if (isset($dataForElement['incomeGroupName'])) {
-      $element['incomeGroupName']['#value'] = $dataForElement['incomeGroupName'];
-    }
-
-    if (empty($element['incomeGroupName']['#value']) && isset($element['#incomeGroup'])) {
-      $element['incomeGroupName']['#value'] = $element['#incomeGroup'];
-    }
-
-    if (getenv('PRINT_DEVELOPMENT_DEBUG_FIELDS') == '1') {
-      $element['debugging'] = [
-        '#type' => 'details',
-        '#title' => 'Dev DEBUG:',
-        '#open' => FALSE,
-      ];
-
-      $element['debugging']['fieldset'] = [
-        '#type' => 'fieldset'
-      ];
-
-      $element['debugging']['fieldset']['fields_in_use'] = [
-        '#type' => 'inline_template',
-        '#template' => "->setSetting('fieldsForApplication', [
-          {% for field in fields %}
-            '{{ field }}',<br/>
-          {% endfor %}
-        ])",
-        '#context' => ['fields' => $fieldsInUse]
-      ];
-    }
-
-    return $element;
-  }
-
-  // @codingStandardsIgnoreEnd
 
   /**
    * {@inheritdoc}
@@ -201,16 +122,6 @@ class GrantsBudgetIncomeStatic extends WebformCompositeBase {
       "totalIncomeWithoutSubventions" => t("Income without subsidies (€)", [], $tOpts),
       "totalIncome" => t("Total income (€)", [], $tOpts),
     ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function valueCallback(&$element, $input, FormStateInterface $formState) {
-    $values = parent::valueCallback($element, $input, $formState);
-    // @See GrantsBudgetCostStatic::valueCallback() for details.
-    $values['_Temp'] = '1';
-    return $values;
   }
 
 }

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetStaticBase.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetStaticBase.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\grants_budget_components\Element;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Element\WebformCompositeBase;
+
+/**
+ * Base class for Static budget components.
+ */
+class GrantsBudgetStaticBase extends WebformCompositeBase {
+
+  /**
+   * Process default values and values from submitted data.
+   *
+   * @param array $element
+   *   Element that is being processed.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   * @param array $complete_form
+   *   Full form.
+   *
+   * @return array[]
+   *   Form API element for webform element.
+   */
+  public static function processWebformComposite(&$element, FormStateInterface $form_state, &$complete_form): array {
+
+    $element['#tree'] = TRUE;
+    $element = parent::processWebformComposite($element, $form_state, $complete_form);
+    $dataForElement = $element['#value'];
+
+    $storage = $form_state->getStorage();
+    $errors = $storage['errors'][$element['#webform_key']] ?? [];
+
+    $element_errors = $errors['errors'] ?? [];
+    foreach ($element_errors as $errorKey => $erroValue) {
+      $element[$errorKey]['#attributes']['class'][] = $erroValue['class'];
+      $element[$errorKey]['#attributes']['error_label'] = $erroValue['label'];
+    }
+
+    $fieldKeys = array_keys(self::getFieldNames());
+
+    $fieldsInUse = [];
+
+    foreach ($fieldKeys as $fieldKey) {
+      $keyToCheck = '#' . $fieldKey . '__access';
+      if (isset($element[$keyToCheck]) && $element[$keyToCheck] === FALSE) {
+        unset($element[$fieldKey]);
+      }
+      else {
+        $fieldsInUse[] = $fieldKey;
+      }
+    }
+
+    if (isset($dataForElement['incomeGroupName'])) {
+      $element['incomeGroupName']['#value'] = $dataForElement['incomeGroupName'];
+    }
+
+    if (empty($element['incomeGroupName']['#value']) && isset($element['#incomeGroup'])) {
+      $element['incomeGroupName']['#value'] = $element['#incomeGroup'];
+    }
+
+    if (getenv('PRINT_DEVELOPMENT_DEBUG_FIELDS') == '1') {
+      $element['debugging'] = [
+        '#type' => 'details',
+        '#title' => 'Dev DEBUG:',
+        '#open' => FALSE,
+      ];
+
+      $element['debugging']['fieldset'] = [
+        '#type' => 'fieldset',
+      ];
+
+      $element['debugging']['fieldset']['fields_in_use'] = [
+        '#type' => 'inline_template',
+        '#template' => "->setSetting('fieldsForApplication', [
+          {% for field in fields %}
+            '{{ field }}',<br/>
+          {% endfor %}
+        ])",
+        '#context' => ['fields' => $fieldsInUse],
+      ];
+    }
+
+    return $element;
+  }
+
+  /**
+   * Get field names for this element.
+   *
+   * @return array
+   *   Array of the field keys.
+   */
+  public static function getFieldNames(): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function valueCallback(&$element, $input, FormStateInterface $formState) {
+    $values = parent::valueCallback($element, $input, $formState);
+    // For some reason webform won't pass values later, if composite values
+    // Are all falsy. Bit hacky but let's insert a value that is not used
+    // any where, so we can track if user actually inserted 0 value or left
+    // field empty.
+    $values['_Temp'] = '1';
+    return $values;
+  }
+
+}

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetStaticBase.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetStaticBase.php
@@ -38,7 +38,7 @@ class GrantsBudgetStaticBase extends WebformCompositeBase {
       $element[$errorKey]['#attributes']['error_label'] = $erroValue['label'];
     }
 
-    $fieldKeys = array_keys(self::getFieldNames());
+    $fieldKeys = array_keys(static::getFieldNames());
 
     $fieldsInUse = [];
 

--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -405,6 +405,11 @@ class GrantsBudgetComponentService {
     }
 
     $webformMainElement = $webform->getElement($propertyKey);
+
+    if (!$webformMainElement) {
+      return $values;
+    }
+
     $elements = $webform->getElementsDecodedAndFlattened();
     $elementKeys = array_keys($elements);
 

--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -4,6 +4,7 @@ namespace Drupal\grants_budget_components;
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\TypedData\ListInterface;
+use Drupal\Core\TypedData\Plugin\DataType\Map;
 use Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler;
 use Drupal\grants_metadata\AtvSchema;
 
@@ -17,17 +18,25 @@ class GrantsBudgetComponentService {
     'incomeGroupName',
   ];
 
+  const MULTIVALUE_FIELDS = [
+    'grants_budget_other_income',
+    'grants_budget_other_cost',
+  ];
+
   /**
    * Parse budget income fields.
    *
-   * @param \Drupal\Core\TypedData\ListInterface $property
+   * @param \Drupal\Core\TypedData\Map $property
    *   Property that is handled.
    *
    * @return array
    *   Processed items.
    */
-  public static function processBudgetStaticValues($property): array {
+  public static function processBudgetStaticValues(Map $property): array {
     $items = [];
+
+    $propertyDef = $property->getDataDefinition();
+    $f = $propertyDef->getSetting('fieldsForApplication');
 
     foreach ($property as $item) {
       $itemName = $item->getName();
@@ -36,18 +45,21 @@ class GrantsBudgetComponentService {
       $itemDefinition = $item->getDataDefinition();
       $valueTypes = AtvSchema::getJsonTypeForDataType($itemDefinition);
 
-      if (!in_array($itemName, self::IGNORED_FIELDS)) {
+      if (!in_array($itemName, self::IGNORED_FIELDS) && in_array($itemName, $f)) {
 
         $value = $item->getValue();
 
-        if (is_null($value) || $value === "") {
-          continue;
+        if (is_null($value) || trim($value) === '') {
+          $value = '';
+        }
+        else {
+          $value = (string) GrantsHandler::convertToFloat($value);
         }
 
         $items[] = [
           'ID' => $itemName,
           'label' => $itemDefinition->getLabel(),
-          'value' => (string) GrantsHandler::convertToFloat($value),
+          'value' => $value,
           'valueType' => $valueTypes['jsonType'],
         ];
       }
@@ -396,6 +408,8 @@ class GrantsBudgetComponentService {
     $elements = $webform->getElementsDecodedAndFlattened();
     $elementKeys = array_keys($elements);
 
+    $pluginId = $webformMainElement['#webform_plugin_id'];
+
     $pages = $webform->getPages('edit');
 
     $pageId = $webformMainElement['#webform_parents'][0];
@@ -423,8 +437,15 @@ class GrantsBudgetComponentService {
 
       $fieldId = $value['ID'];
 
-      $webformLabelElement = $webformMainElement['#webform_composite_elements'][$fieldId] ?? $webformMainElement['#webform_key'];
-      $label = $webformLabelElement['#title'] ?? $webformMainElement['#title'];
+      $compositeElements = $webformMainElement['#webform_composite_elements'];
+      $webformLabelElement = $compositeElements[$fieldId] ?? $compositeElements['value'];
+
+      if (in_array($pluginId, self::MULTIVALUE_FIELDS)) {
+        $label = $value['label'];
+      }
+      else {
+        $label = $webformLabelElement['#title'] ?? $webformMainElement['#title'];
+      }
 
       $element = [
         'label' => $label,

--- a/public/modules/custom/grants_budget_components/src/Plugin/WebformElement/GrantsBudgetBase.php
+++ b/public/modules/custom/grants_budget_components/src/Plugin/WebformElement/GrantsBudgetBase.php
@@ -70,7 +70,11 @@ class GrantsBudgetBase extends WebformCompositeBase {
   /**
    * {@inheritdoc}
    */
-  protected function formatHtmlItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []): array|string {
+  protected function formatHtmlItemValue(
+    array $element,
+    WebformSubmissionInterface $webform_submission,
+    array $options = []
+  ): array|string {
     $format = $this->getItemFormat($element);
     $items = [];
     $composite_elements = $this->getInitializedCompositeElement($element);

--- a/public/modules/custom/grants_budget_components/src/Plugin/WebformElement/GrantsBudgetBase.php
+++ b/public/modules/custom/grants_budget_components/src/Plugin/WebformElement/GrantsBudgetBase.php
@@ -81,18 +81,27 @@ class GrantsBudgetBase extends WebformCompositeBase {
       }
 
       $composite_element = $composite_elements[$composite_key];
+
+      // Skip disabled / hidden fields.
+      if (isset($composite_element['#access']) && $composite_element['#access'] === FALSE) {
+        continue;
+      }
+
       $composite_title = (isset($composite_element['#title']) && $format !== 'raw') ? $composite_element['#title'] : $composite_key;
       $composite_value = $this->formatCompositeHtml($element, $webform_submission, ['composite_key' => $composite_key] + $options);
-      if ($composite_value !== '') {
-        $items[$composite_key] = [
-          '#type' => 'inline_template',
-          '#template' => '<b>{{ title }}:</b> {{ value }}',
-          '#context' => [
-            'title' => $composite_title,
-            'value' => $composite_value,
-          ],
-        ];
+
+      if ($composite_value === '') {
+        $composite_value = '-';
       }
+
+      $items[$composite_key] = [
+        '#type' => 'inline_template',
+        '#template' => '<b>{{ title }}:</b> {{ value }}',
+        '#context' => [
+          'title' => $composite_title,
+          'value' => $composite_value,
+        ],
+      ];
     }
     return $items;
   }

--- a/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
@@ -459,6 +459,11 @@ class ApplicationController extends ControllerBase {
           'langcode' => $langcode,
         ]);
       }
+
+      if ($field['value'] === '') {
+        $field['value'] = '-';
+      }
+
       $newField = [
         'ID' => $field['ID'],
         'value' => $labelData['element']['valueTranslation'] ?? $field['value'],

--- a/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
+++ b/public/modules/custom/grants_handler/src/Element/CompensationsComposite.php
@@ -114,7 +114,10 @@ class CompensationsComposite extends WebformCompositeBase {
         if ($item['amount'] == '0,00€' || empty($item['amount'])) {
           $zeroes++;
           if ($requiredSubvention === $item['subventionType']) {
-            $formState->setErrorByName('subventions', t('You must apply for the "@subventionType"', ['@subventionType' => $item['subventionTypeTitle']], $tOpts));
+            $formState->setErrorByName(
+              'subventions',
+              t('You must apply for the "@subventionType"', ['@subventionType' => $item['subventionTypeTitle']], $tOpts)
+            );
           }
         }
         else {

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoToimintaDefinition.php
@@ -172,15 +172,10 @@ class KaskoToimintaDefinition extends ComplexDataDefinitionBase {
             ->setSetting('budgetGroupName', 'useOfCustomerFeeIncome')
             ->setSetting('fieldsForApplication', [
               'salaries',
-              'personnelSocialSecurityCosts',
+              'personnelSideCosts',
               'rentSum',
               'materials',
-              'servicesTotal',
-              'suppliesTotal',
               'services',
-              'supplies',
-              'otherFees',
-              'personnelSideCosts',
             ])
         )
         ->setPropertyDefinition(


### PR DESCRIPTION
# [AU-1910](https://helsinkisolutionoffice.atlassian.net/browse/AU-1910)
# [AU-1909](https://helsinkisolutionoffice.atlassian.net/browse/AU-1909)
<!-- What problem does this solve? -->

## What was done

* Reorder personel side costs below salaries
* Fix print view to show all budget component fields that were fillable in form view.



## How to install

* Make sure your instance is up and running on correct branch.
  * `git feature/AU-1910-budget-component-order-and-print`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

**Re-order:** 

* [ ] Open [Kasvatus ja koulutus, toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-toiminta-av)
* [ ] Page 4. Check that `Henkilöstösivukulut palkoista ja palkkioista (n. 30%) (€)` is right below `Palkat ja palkkiot (€)` on sections `Menot` & `Asiakasmaksutulojen käyttö (ja mahdolliset lahjoitukset)`

**Print view:**

* [ ] Insert some values to budget fields. Also insert some 0 values and leave few fields empty.
* [ ] Muut menot / muut tulot insert some label + value combos, and try to remember what you inserted.
* [ ] Save as draft
* [ ] Check that preview show 0 values as `"0"` and empty values as `"-"`
* [ ] Print the page and check that all budget fields are present in the print view and that the 0 values are shown and unfilled fields are displayed as "-"
* [ ] Check that Muut tulot / Muut menot is using the labels user gave


⚠️ Case default code smells are fixed in different PR.

[AU-1910]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1909]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ