### PR TITLE
fix: AU-1917: Missing infos added to liikunta toiminta

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -116,7 +116,7 @@ elements: |
   tilankayttoavustus:
     '#title': 'Sports facility usage grant'
   maksetut_vuokrat_info:
-    '#text': "<p>Summary of rent paid by the club/association for regular training slots elsewhere than in Sports Services’ own facilities, in the previous calendar year between 1 January and 31 December.</p>\r\n"
+    '#text': "<p>Summary of rent paid by the club/association for regular training slots elsewhere than in Sports Services’ own facilities, in the previous calendar year between 1 January and 31 December. <strong>The Rents paid for sports facilities section is mandatory if you are applying for a facility use grant.</strong></p>\r\n"
   liikuntatiloista_maksetut_vuokrat_fieldset:
     '#title': 'Rent paid for sports facilities'
   tuntimaara_yhteensa:

--- a/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -119,7 +119,7 @@ elements: |
   tilankayttoavustus:
     '#title': 'Understöd för användning av idrottslokaler'
   maksetut_vuokrat_info:
-    '#text': "<p>Sammanställning av de hyror som föreningen har betalatför regelbundna träningsskift förutom idrottstjänstens egna lokaler under föregående kalenderår 1.1. - 31.12.3</p>\r\n"
+    '#text': "<p>Sammanställning av de hyror som föreningen har betalatför regelbundna träningsskift förutom idrottstjänstens egna lokaler under föregående kalenderår 1.1. - 31.12.3. <strong>Avsnittet Hyror för idrottsanläggningar är obligatoriskt om du ansöker om understöd för användning av idrottslokaler.</strong></p>\r\n"
   liikuntatiloista_maksetut_vuokrat_fieldset:
     '#title': 'Hyror betalda för idrottslokaler'
   tuntimaara_yhteensa:

--- a/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -496,7 +496,7 @@ elements: |-
       maksetut_vuokrat_info:
         '#type': processed_text
         '#text': |
-          <p>Yhteenveto seuran/yhdistyksen maksamista säännöllisten harjoitusvuorojen vuokrista, muiden kuin liikuntapalvelun omien tilojen osalta, edellisen kalenterivuoden 1.1. - 31.12. ajalta.</p>
+          <p>Yhteenveto seuran/yhdistyksen maksamista säännöllisten harjoitusvuorojen vuokrista, muiden kuin liikuntapalvelun omien tilojen osalta, edellisen kalenterivuoden 1.1. - 31.12. ajalta. <strong>Liikuntatiloista maksetut vuokrat -kohta on pakollinen täyttää, mikäli haet tilankäyttöavustusta.</strong></p>
         '#format': full_html
       liikuntatiloista_maksetut_vuokrat_fieldset:
         '#type': fieldset


### PR DESCRIPTION
# [AU-1917](https://helsinkisolutionoffice.atlassian.net/browse/AU-1917)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added bold info to maksetut vuokrat in liikunta toiminta and tilankäyttö

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1917-toiminta-infotext`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] go to [Liikunta toiminta & tilankäyttö](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/liikunta_toiminta_ja_tilankaytto)
* [ ] See that on page 2, see that there is now a bolded text in the info
* [ ] check swedish
* [ ] check english
* [ ] Check that code follows our standards


[AU-1917]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ