### PR TITLE
fix: AU-1915: fix hakijan tiedot in asukaspien

### DIFF
--- a/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -36,6 +36,9 @@ title: 'Asukasosallisuus, pienavustushakemus'
 description: ASUKASPIEN
 category: ''
 elements: |-
+  applicant_type:
+    '#type': hidden
+    '#title': 'Hakijan tyyppi'
   1_hakijan_tiedot:
     '#type': webform_wizard_page
     '#title': '1. Hakijan tiedot'
@@ -49,12 +52,9 @@ elements: |-
       '#type': hidden
       '#title': 'Hakemuksen tila'
       '#readonly': true
-    applicant_type:
-      '#type': hidden
-      '#title': 'Hakijan tyyppi'
     hakemusprofiili:
       '#type': webform_section
-      '#title': 'Hakijan tiedot'
+      '#title': 'Haetut tiedot'
       '#attributes':
         class:
           - grants-profile--imported-section
@@ -63,10 +63,14 @@ elements: |-
         '#markup': 'Tiedot on haettu hakuprofiilistasi.'
       hakijan_tiedot:
         '#type': applicant_info
-        '#title': 'Hakijan tiedot'
+        '#title': Hakija
     contact_person_email_section:
       '#type': webform_section
       '#title': Sähköposti
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
       contact_markup:
         '#type': webform_markup
         '#markup': 'Ilmoita tässä sellainen yhteisön sähköpostiosoite, jota luetaan aktiivisesti. Sähköpostiin lähetetään avustushakemukseen liittyviä yhteydenottoja esim. lisäselvitys- ja täydennyspyyntöjä.'
@@ -76,30 +80,34 @@ elements: |-
         '#help': 'Ilmoita s&auml;hk&ouml;postiosoite, johon t&auml;h&auml;n hakemukseen liittyvät viestit sek&auml; her&auml;tteet osoitetaan ja jota luetaan aktiivisesti'
         '#size': 63
         '#autocomplete': 'off'
-        '#attributes':
-          class:
-            - webform--large
-        '#required': true
+        '#states':
+          required:
+            ':input[name="applicant_type"]':
+              value: registered_community
     contact_person_section:
       '#type': webform_section
       '#title': 'Hakemuksen yhteyshenkilö'
+      '#states':
+        visible:
+          ':input[name="applicant_type"]':
+            value: registered_community
       contact_person:
         '#type': textfield
         '#title': Yhteyshenkilö
         '#autocomplete': 'off'
+        '#required': true
         '#attributes':
           class:
             - webform--large
-        '#required': true
         '#size': 63
       contact_person_phone_number:
         '#type': textfield
         '#title': Puhelinnumero
         '#required': true
+        '#autocomplete': 'off'
         '#attributes':
           class:
             - webform--medium
-        '#autocomplete': 'off'
         '#size': 32
     osoite:
       '#type': webform_section


### PR DESCRIPTION
# [AU-1915](https://helsinkisolutionoffice.atlassian.net/browse/AU-1915)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix applicant details -view for private person 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1915-asukaspien-yksityishenkilo`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Login as registered community
* [x] [Open application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_pienavustushake)
* [x] Check that you see correct fields on the first page
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/84def428-72ab-4168-8e49-c0f92d161a31)

* [x] Change to private person
* [x] [Open application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_pienavustushake)
* [x] Check that you see correct fields on the first page
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/69fd1bbb-6742-43f9-b13a-af3a0d4e02aa)



[AU-1915]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ