### PR TITLE
fix: AU-1927: Add forced form import

### DIFF
--- a/.github/workflows/update-config.yml
+++ b/.github/workflows/update-config.yml
@@ -42,6 +42,7 @@ jobs:
           composer install
           $(drush sql:connect) < latest.sql
           drush cr && drush cim -y
+          drush gwi --force
           composer update drupal/helfi_* drupal/hdbt* -W
           drush cr && drush updb -y && drush cex -y
           # Update platform


### PR DESCRIPTION
# [AU-1927](https://helsinkisolutionoffice.atlassian.net/browse/AU-1927)
<!-- What problem does this solve? -->

Automatic config updates wanted to override our forms, this is because we ignore forms from basic cim. This adds forced update for all forms.


[AU-1927]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ