### PR TITLE
fix: AU-1928: Update ATV to 0.9.16

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5544,16 +5544,16 @@
         },
         {
             "name": "drupal/helfi_atv",
-            "version": "0.9.15",
+            "version": "0.9.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv.git",
-                "reference": "f473d536a50a8f162440965a67e86ad7534169e9"
+                "reference": "6dd7c0e338554a1acdd4390210c81f3b8e85fe2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/f473d536a50a8f162440965a67e86ad7534169e9",
-                "reference": "f473d536a50a8f162440965a67e86ad7534169e9",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-atv/zipball/6dd7c0e338554a1acdd4390210c81f3b8e85fe2b",
+                "reference": "6dd7c0e338554a1acdd4390210c81f3b8e85fe2b",
                 "shasum": ""
             },
             "require": {
@@ -5570,10 +5570,10 @@
             ],
             "description": "ATV integration module",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/0.9.15",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/tree/0.9.16",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-atv/issues"
             },
-            "time": "2023-11-29T06:24:03+00:00"
+            "time": "2023-11-30T08:35:57+00:00"
         },
         {
             "name": "drupal/helfi_audit_log",


### PR DESCRIPTION
# [AU-1928](https://helsinkisolutionoffice.atlassian.net/browse/AU-1928)

## What was done
ATV Module update to fix profile attachment uploading 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1928-atv-version-update`
  * `make fresh`
* Run `make drush-cr`

## How to test

* [ ] Check that profile form attachment uploads works correctly
* [ ] Check that application form attachments uploads works correctly.



[AU-1928]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ