### PR TITLE
fix: AU-1905: Change method signature to prevent crashes when label extraction fails

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
+++ b/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
@@ -598,13 +598,13 @@ class TypedDataToDocumentContentWithWebform {
    * @param string $itemName
    *   The name of the item we are iterating over.
    *
-   * @return string
+   * @return string|null
    *   A label.
    */
   protected static function extractLabel(
     DataDefinitionInterface $definition,
     array $webformMainElement,
-    string $itemName): string {
+    string $itemName): string|null {
 
     if ($itemName == 'issuerName') {
       $itemName = 'issuer_name';


### PR DESCRIPTION
# [AU-1905](https://helsinkisolutionoffice.atlassian.net/browse/AU-1905)
<!-- What problem does this solve? -->

## What was done

extractLabel  method signature tells that return type is string, but this might also be null in some edge-cases. Update signature.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1905-fix-label-crash`
  * `make fresh`
* Run `make drush-cr`

## How to test

### Verity problem in **develop**

* [ ] [Nuorisopalvelu, toiminta- ja palkkausavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka)
* [ ] Page 2. Select "Kyllä" in **Haen vuokra-avustusta** 
* [ ] Page 5. Insert random data to premise fields
* [ ] Save as draft
* [ ] Application should crash due error.

## git checkout feature/AU-1905-fix-label-crash

* [ ] Repeat previous steps.
* [ ] Draft should save correctly

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-1905]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ