### PR TITLE
fix: AU-1931 filter empty array fields from atv doc.

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
+++ b/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\grants_metadata;
 
+use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\TypedData\DataDefinitionInterface;
 use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\grants_attachments\Element\GrantsAttachments as GrantsAttachmentsElement;
@@ -193,6 +194,7 @@ class TypedDataToDocumentContentWithWebform {
         if (is_array($itemValue) && AtvSchema::numericKeys($itemValue)) {
           if ($fullItemValueCallback) {
             self::handleFullItemValueCallback($reference, $elementName, $fullItemValueCallback, $property, $requiredInJson);
+            self::handlePossibleEmptyArray($documentStructure, $reference, $jsonPath);
             continue;
           }
           if (empty($itemValue) && $requiredInJson) {
@@ -947,6 +949,26 @@ class TypedDataToDocumentContentWithWebform {
     if ($file) {
       fwrite($file, $jsonString);
       fclose($file);
+    }
+  }
+
+  /**
+   * Check and handle empty array values.
+   *
+   * @param array $documentStructure
+   *   The whole document structure.
+   * @param array $reference
+   *   Array to check.
+   * @param array $jsonPath
+   *   Json path of the given element.
+   */
+  protected static function handlePossibleEmptyArray(
+    array &$documentStructure,
+    array $reference,
+    array $jsonPath
+  ) {
+    if (is_array($reference) && empty($reference)) {
+      NestedArray::unsetValue($documentStructure, $jsonPath);
     }
   }
 

--- a/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
+++ b/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
@@ -202,6 +202,7 @@ class TypedDataToDocumentContentWithWebform {
             continue;
           }
           self::handlePropertyItems($reference, $elementName, $property, $webformMainElement, $defaultValue, $hiddenFields, $metaData);
+          self::handlePossibleEmptyArray($documentStructure, $reference, $jsonPath);
           continue;
         }
         $valueArray = self::getValueArray($elementName, $itemValue, $itemTypes['jsonType'], $label, $metaData);
@@ -214,6 +215,7 @@ class TypedDataToDocumentContentWithWebform {
         $metaData = AtvSchema::getMetaData($page, $section, $element);
         if (is_array($itemValue) && AtvSchema::numericKeys($itemValue) && $propertyType == 'list') {
           self::handlePropertyItems($reference, $elementName, $property, $webformMainElement, $defaultValue, $hiddenFields, $metaData);
+          self::handlePossibleEmptyArray($documentStructure, $reference, $jsonPath);
           continue;
         }
         if ($schema['type'] == 'string') {

--- a/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
+++ b/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
@@ -598,13 +598,13 @@ class TypedDataToDocumentContentWithWebform {
    * @param string $itemName
    *   The name of the item we are iterating over.
    *
-   * @return string
+   * @return string|null
    *   A label.
    */
   protected static function extractLabel(
     DataDefinitionInterface $definition,
     array $webformMainElement,
-    string $itemName): string {
+    string $itemName): string|null {
 
     if ($itemName == 'issuerName') {
       $itemName = 'issuer_name';


### PR DESCRIPTION
# [AU-1931](https://helsinkisolutionoffice.atlassian.net/browse/AU-1931)
<!-- What problem does this solve? -->

## What was done

We are now (after the major refactor) adding some empty elements, which we should not - as the integration doesn't like this. Add some empty array handling.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1931-filter-empty-array-fields`
  * `make fresh`
* Run `make drush-cr`

## Verify problem in develop branch

* [ ] [Nuorisopalvelu, toiminta- ja palkkausavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka)
* [ ] Fill only the required fields - as minimal as you can.
* [ ] After you send, the application should get stuck in "Submitted" state and never change to received.

## git checkout feature/AU-1931-filter-empty-array-fields
* [ ] Repeat previous steps, but this time the application should reach the received status.




[AU-1931]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ