### PR TITLE
fix: AU-1938: add format to oma asiointi timestamp

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
+++ b/public/modules/custom/grants_oma_asiointi/templates/grants-oma-asiointi-block.html.twig
@@ -38,7 +38,7 @@
           <div class="submission">
             <p class="submission-title">{{ applicationTypes[submission['application_type']][lang] }}</p>
             <p><strong>{{ "Last saved"|t({}, {'context': 'grants_oma_asiointi'}) }}</strong> <br />
-            {{ submission['form_timestamp'] }}</p>
+            {{ submission['form_timestamp']|date('d.m.Y H:i') }}</p>
             <p><strong>{{ "Application number"|t({}, {'context': 'grants_oma_asiointi'}) }}</strong><br />
             {{ submission['application_number'] }}</p>
           </div>


### PR DESCRIPTION
# [AU-1938](https://helsinkisolutionoffice.atlassian.net/browse/AU-1938)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add format to oma asiointi timestamp

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1938-timestamp`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login and go to front page
* [ ] Check that Last saved -date is formatted correctly

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/81d17b5c-2091-49a8-b354-70daf6d75cc9)


[AU-1938]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ