### PR TITLE
AU-1941: Fix conditional toiminta fields appearing to atv doc on amount 5000

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -191,7 +191,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['toiminta_tasa_arvo'] = DataDefinition::create('string')
-        ->setLabel('Miten monimuotoisuus ja tasa-arvo toteutuu ja näkyy toiminnan järjestäjissä ja organisaatioissa sekä toiminnan sisällöissä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?')
         ->setSetting('defaultValue', '')
         ->setSetting('addConditionally', [
           'class' => self::class,
@@ -205,7 +204,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['toiminta_saavutettavuus'] = DataDefinition::create('string')
-        ->setLabel('Miten toiminta tehdään kaupunkilaiselle sosiaalisesti, kulttuurisesti, kielellisesti, taloudellisesti, fyysisesti, alueellisesti tai muutoin mahdollisimman saavutettavaksi? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?')
         ->setSetting('defaultValue', '')
         ->setSetting('addConditionally', [
           'class' => self::class,
@@ -219,7 +217,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['toiminta_yhteisollisyys'] = DataDefinition::create('string')
-        ->setLabel('Miten toiminta vahvistaa yhteisöllisyyttä, verkostomaista yhteistyöskentelyä ja miten kaupunkilaisten on mahdollista osallistua toiminnan eri vaiheisiin? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?')
         ->setSetting('defaultValue', '')
         ->setSetting('addConditionally', [
           'class' => self::class,
@@ -233,7 +230,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['toiminta_kohderyhmat'] = DataDefinition::create('string')
-        ->setLabel('Keitä toiminnalla tavoitellaan? Miten kyseiset kohderyhmät aiotaan tavoittaa ja mitä osaamista näiden kanssa työskentelyyn on?')
         ->setSetting('defaultValue', '')
         ->setSetting('jsonPath', [
           'compensation',
@@ -243,7 +239,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['toiminta_ammattimaisuus'] = DataDefinition::create('string')
-        ->setLabel('Kuvaa toiminnan järjestämisen ammattimaisuutta ja organisoimista')
         ->setSetting('defaultValue', '')
         ->setSetting('addConditionally', [
           'class' => self::class,
@@ -257,7 +252,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['toiminta_ekologisuus'] = DataDefinition::create('string')
-        ->setLabel('Miten ekologisuus huomioidaan toiminnan järjestämisessä? Minkälaisia toimenpiteitä, resursseja ja osaamista on asian edistämiseksi?')
         ->setSetting('defaultValue', '')
         ->setSetting('addConditionally', [
           'class' => self::class,
@@ -271,7 +265,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['toiminta_yhteistyokumppanit'] = DataDefinition::create('string')
-        ->setLabel('Nimeä keskeisimmät yhteistyökumppanit ja kuvaa yhteistyön muotoja ja ehtoja.')
         ->setSetting('defaultValue', '')
         ->setSetting('jsonPath', [
           'compensation',
@@ -281,7 +274,6 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['tapahtuma_tai_esityspaivien_maara_helsingissa'] = DataDefinition::create('integer')
-        ->setLabel('Tapahtuma- tai esityspäivien määrä Helsingissä.')
         ->setSetting('jsonPath', [
           'compensation',
           'activityInfo',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -741,7 +741,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
       }
     }
 
-    return $subventionsTotalAmount >= 5000;
+    return $subventionsTotalAmount > 5000;
   }
 
   /**


### PR DESCRIPTION
# [AU-1941](https://helsinkisolutionoffice.atlassian.net/browse/AU-1941)
<!-- What problem does this solve? -->

## What was done

* Fix definition condition statement to check if value is 5001 or greater, as we show these fields only then amount is 5001 or higher, but currently we include the fields to atv doc when it's 5000 or higher.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1941-fix-kuva-toiminta-fields-atv-doc`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [Taide- ja kulttuuriavustukset: projektiavustukset](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kuva-projekti)
* [ ] Add subvention value of 5000
* [ ] Go to page 5 and check that there is 2 questions.
* [ ] Save as draft.
* [ ] Open document and use search string `toiminta_`
* [ ] Check that only 2 results appear.
* [ ] Edit draft and change subvention value to 5001 or higher 
* [ ] Check page 5 and that there is 8 questions
* [ ] After saving, check atv document again and make sure there is 8 x `toiminta_` fields

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[AU-1941]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ