### PR TITLE
fix: AU-1946: AU-1948: Fix missing required field and hide computed twig 

### DIFF
--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -800,6 +800,7 @@ elements: |-
         '#rentSum__required': true
         '#lessorName__required': true
         '#lessorPhoneOrEmail__required': true
+        '#usage__required': true
         '#daysPerWeek__required': true
         '#hoursPerDay__required': true
     lisatiedot_osio:
@@ -1038,7 +1039,8 @@ settings:
   submission_exception_message: ''
   submission_locked_message: ''
   submission_log: true
-  submission_excluded_elements: {  }
+  submission_excluded_elements:
+    hakee_vuokra_avustusta: hakee_vuokra_avustusta
   submission_exclude_empty: false
   submission_exclude_empty_checkbox: false
   submission_views: {  }

--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -969,6 +969,7 @@ elements: |-
     '#wrapper_attributes':
       class:
         - hidden
+    '#display_on': form
     '#template': '{{ data.haen_vuokra_avustusta }}'
   actions:
     '#type': webform_actions


### PR DESCRIPTION
# [AU-1946](https://helsinkisolutionoffice.atlassian.net/browse/AU-1946)
# [AU-1948](https://helsinkisolutionoffice.atlassian.net/browse/AU-1948)

## What was done

* Add missing required attribute to `Käyttötarkoitus` subelement.
* Hid computed twig in submission page.

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1946-nuor-palkka-fixes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open a new https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka
* [ ] Page 2:  `Haen vuokra-avustusta  -> Kyllä`
* [ ] Page 5: Check that Käyttötarkoitus has required mark
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/9e9716d6-2b81-4667-bef0-b01e18ea29e8)
* [ ] Save as Draft 
* [ ] Check that the computed twig doesn't show up at the bottom of the page.

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/ea7caffe-9f62-49fb-b5b8-778b20979005)




[AU-1946]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-1948]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ