### PR TITLE
fix: AU-1779: show attachment description in application view

### DIFF
--- a/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
@@ -160,7 +160,20 @@ class GrantsAttachments extends WebformCompositeBase {
       $value = $element['#default_value'];
     }
 
-    // Return multiple (delta) value or composite (composite_key) value.
+    $this->handleMultiDeltaValue($value, $options);
+    return $value;
+
+  }
+
+  /**
+   * Handle values for multivalue and composite elements.
+   *
+   * @param mixed $value
+   *   Element value.
+   * @param mixed $options
+   *   An array of options.
+   */
+  private function handleMultiDeltaValue(&$value, $options) {
     if (is_array($value)) {
       // Return $options['delta'] which is used by tokens.
       // @see _webform_token_get_submission_value()
@@ -174,9 +187,6 @@ class GrantsAttachments extends WebformCompositeBase {
         $value = $value[$options['composite_key']] ?? NULL;
       }
     }
-
-    return $value;
-
   }
 
   /**

--- a/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
@@ -246,8 +246,8 @@ class GrantsAttachments extends WebformCompositeBase {
       }
     }
 
-    if (isset($value["description"]) && (isset($element["#description"]) &&
-      $element["#description"] == 'muu_liite')) {
+    if (isset($value["description"]) && (isset($element["#webform_key"]) &&
+      $element["#webform_key"] == 'muu_liite')) {
       $lines[] = $value["description"];
     }
 

--- a/public/modules/custom/grants_metadata/src/CompensationService.php
+++ b/public/modules/custom/grants_metadata/src/CompensationService.php
@@ -55,6 +55,7 @@ class CompensationService {
     $hasToimintaAvustus = !empty($toimintaAvustus) && !empty($usedToimintaAvustus);
     $webform = $arguments['webform'];
     $elements = $webform->getElementsDecodedAndFlattened();
+    $retval = [];
 
     if ($hasToimintaAvustus) {
       // Parse them.
@@ -114,6 +115,7 @@ class CompensationService {
 
     $hasPalkkausAvustus = !empty($palkkausAvustus) && !empty($usedPalkkausAvustus);
     [$page, $section] = $this->getPageAndSectionMeta($webform, 'edellisen_avustuksen_kayttoselvitys');
+    $retval = [];
 
     if ($hasPalkkausAvustus) {
       $palkkausAvustusArray = [


### PR DESCRIPTION
# [AU-1779](https://helsinkisolutionoffice.atlassian.net/browse/AU-1779)
<!-- What problem does this solve? -->

## What was done

* A wrong if statement caused description to not show up for muu_liite attachments. Fixed this
* Fixed PHP warnings in NUOR TOIMPALKKA

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1779-attachment-description`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any application: [Nuorisopalvelu, toiminta- ja palkkausavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka)
* [ ] In attachment page:  Insert a new Muu liite attachment and add a description to it.
* [ ] Save as draft.
* [ ] Check that you can see the description:
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/fde58977-faeb-4271-97de-86b8c7cdc5c9)



[AU-1779]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ