### PR TITLE
fix: AU-1950: Add try catch to getCompanyApplications and log error cases

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1768,7 +1768,19 @@ class ApplicationHandler {
       }
 
       if (array_key_exists($document->getType(), ApplicationHandler::getApplicationTypes())) {
-        $submissionObject = self::submissionObjectFromApplicationNumber($document->getTransactionId(), $document);
+        try {
+          $submissionObject = self::submissionObjectFromApplicationNumber($document->getTransactionId(), $document);
+        }
+        catch (\Throwable $e) {
+          \Drupal::logger('application_handler')->error(
+            'Failed to get submission object from application number. Submission skipped in application listing. ID: @id Error: @error',
+            [
+              '@error' => $e->getMessage(),
+              '@id'    => $document->getTransactionId(),
+            ]
+          );
+          continue;
+        }
 
         if (!$submissionObject) {
           continue;


### PR DESCRIPTION
# [AU-1950](https://helsinkisolutionoffice.atlassian.net/browse/AU-1950)
<!-- What problem does this solve? -->

* Add try catch to getCompanyDocuments, so the application listing won't disappear due singular failure.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1950-fix-application-listing`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] If you have an account combination which doesn't show any application in development, check that accounts application in this branch.

(Otherwise you may test LOCALOTEST & Default Nordea & Maanrakennus Ari Eero T:mi combination)

[AU-1950]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ