### PR TITLE
fix: AU-1947: Fix states for paikat digital only nuortoimpalkka

### DIFF
--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -618,6 +618,10 @@ elements: |-
           0: Ei
       jarjestimme_toimintaa_nuorille_seuraavissa_paikoissa:
         '#type': premises_composite
+        '#states':
+          invisible:
+            ':input[name="jarjestimme_toimintaa_vain_digitaalisessa_ymparistossa"]':
+              value: 1
         '#title': 'Järjestimme toimintaa nuorille seuraavissa paikoissa'
         '#multiple': true
         '#multiple__min_items': 1


### PR DESCRIPTION
# [AU-1947](https://helsinkisolutionoffice.atlassian.net/browse/AU-1947)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1947-states-for-nuortoimpalkka`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [nuortoimpalkka](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuortoimpalkka) page 3
* [ ] Check that the "Järjestimme toimintaa nuorille seuraavissa paikoissa" composite disappears if "kyllä" is selected on "Järjestimme toimintaa vain digitaalisessa ympäristössä"
* [ ] Check that code follows our standards



[AU-1947]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ