### PR TITLE
fix: AU-1958: Fix attachment info multiplying on different language saves

### DIFF
--- a/public/modules/custom/grants_attachments/src/AttachmentHandler.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentHandler.php
@@ -424,10 +424,14 @@ class AttachmentHandler {
                     return TRUE;
                   }
                 }
-                // If no upload, then compare descriptions.
+                // If no upload, then compare filetypes.
+                // There should be only 1 field per filetype in application.
+                // AS we are going through "attachments" field,
+                // so we can ignore other file fields,
+                // as those are processed separately.
                 else {
-                  if (isset($item['description']) && isset($attachment['attachment']['description'])) {
-                    if ($item['description'] == $attachment['attachment']['description']) {
+                  if (isset($item['fileType']) && isset($attachment['attachment']['fileType'])) {
+                    if ($item['fileType'] == $attachment['attachment']['fileType']) {
                       return TRUE;
                     }
                   }
@@ -443,8 +447,8 @@ class AttachmentHandler {
               // We had existing attachment, but we need to update it with
               // the data from this form.
               foreach ($submittedFormData['attachments'] as $key => $att) {
-                if (isset($att['description']) && isset($attachment['attachment']['description'])) {
-                  if ($att['description'] == $attachment['attachment']['description']) {
+                if (isset($att['fileType']) && isset($attachment['attachment']['fileType'])) {
+                  if ($att['fileType'] == $attachment['attachment']['fileType']) {
                     $submittedFormData['attachments'][$key] = $attachment['attachment'];
                   }
                 }


### PR DESCRIPTION
# [AU-1958](https://helsinkisolutionoffice.atlassian.net/browse/AU-1958)

Changed attachment comparison to fileType instead of description.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1958-fix-multiple-attachment-info`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any application: https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuorisopalvelut_toiminta_ja_palk
* [ ] Go to attachment page and check some isDeliveredLater / isIncludedInOtherFile check boxes
* [ ] Save as Draft
* [ ] (You might want to open Postman and check the atvDocument data -> search for fileType and check result amount)
* [ ] Go back to edit mode and change language to a different one
* [ ] Make sure you are in attachments page and save as draft again.
* [ ] Check the updated ATV document, and make sure the fileType result count is same as before and that the description fields of attachments did change the language.

---


* Link to other PR


[AU-1958]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ