### PR TITLE
fix: AU-1970: Missing empty additional Information field

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -66,8 +66,7 @@ trait ApplicationDefinitionTrait {
 
       $info['community_officials'] = ListDataDefinition::create('grants_profile_application_official')
         ->setSetting('jsonPath', ['compensation', 'applicantOfficialsArray'])
-        ->setSetting('defaultValue', [])
-      ;
+        ->setSetting('defaultValue', []);
 
       $info['contact_person'] = DataDefinition::create('string')
         ->setSetting('jsonPath', [
@@ -349,16 +348,22 @@ trait ApplicationDefinitionTrait {
       ->setSetting('jsonPath', ['compensation', 'additionalInformation'])
       ->setSetting('defaultValue', "");
 
-    // Sender details.
+    /*
+     * Sender details are taken from HP login information.
+     *
+     * Also programmatic fields need Labels bc they are not taken from Webforms.
+     * */
+
     $info['sender_firstname'] = DataDefinition::create('string')
       ->setRequired(TRUE)
-      ->setLabel('firstname')
+      ->setLabel('First name')
       ->setSetting('jsonPath', [
         'compensation',
         'senderInfoArray',
         'firstname',
       ]);
     $info['sender_lastname'] = DataDefinition::create('string')
+      ->setLabel('Last name')
       ->setRequired(TRUE)
       ->setSetting('jsonPath', [
         'compensation',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -22,10 +22,8 @@ trait ApplicationDefinitionTrait {
     $applicantType = $grantsProfileService->getApplicantType();
 
     $info['hakijan_tiedot'] = ApplicantInfoDefinition::create('applicant_info')
-      // ->setRequired(TRUE)
       ->setSetting('jsonPath', ['compensation', 'applicantOfficialsArray'])
       ->setSetting('defaultValue', [])
-      ->setLabel('Applicant info')
       ->setSetting('propertyStructureCallback', [
         'service' => 'grants_applicant_info.service',
         'method' => 'processApplicantInfo',
@@ -38,7 +36,6 @@ trait ApplicationDefinitionTrait {
       ]);
 
     $info['subventions'] = ListDataDefinition::create('grants_metadata_compensation_type')
-      ->setLabel('compensationArray')
       ->setSetting('jsonPath', [
         'compensation',
         'compensationInfo',
@@ -56,7 +53,6 @@ trait ApplicationDefinitionTrait {
     if ($applicantType === 'registered_community') {
 
       $info['email'] = DataDefinition::create('email')
-        ->setLabel('Sähköpostiosoite')
         ->setSetting('jsonPath', [
           'compensation',
           'applicantInfoArray',
@@ -69,13 +65,11 @@ trait ApplicationDefinitionTrait {
         ->addConstraint('Email');
 
       $info['community_officials'] = ListDataDefinition::create('grants_profile_application_official')
-        // ->setRequired(TRUE)
         ->setSetting('jsonPath', ['compensation', 'applicantOfficialsArray'])
         ->setSetting('defaultValue', [])
-        ->setLabel('applicantOfficialsArray');
+      ;
 
       $info['contact_person'] = DataDefinition::create('string')
-        ->setLabel('currentAddressInfoArray=>contactPerson')
         ->setSetting('jsonPath', [
           'compensation',
           'currentAddressInfoArray',
@@ -83,7 +77,6 @@ trait ApplicationDefinitionTrait {
         ]);
 
       $info['contact_person_phone_number'] = DataDefinition::create('string')
-        ->setLabel('Contact person phone')
         ->setSetting('jsonPath', [
           'compensation',
           'currentAddressInfoArray',
@@ -91,7 +84,6 @@ trait ApplicationDefinitionTrait {
         ]);
 
       $info['community_street'] = DataDefinition::create('string')
-        ->setLabel('Community street')
         ->setSetting('jsonPath', [
           'compensation',
           'currentAddressInfoArray',
@@ -103,7 +95,6 @@ trait ApplicationDefinitionTrait {
         ]);
 
       $info['community_city'] = DataDefinition::create('string')
-        // ->setRequired(TRUE)
         ->setLabel('Community city')
         ->setSetting('jsonPath', [
           'compensation',
@@ -116,7 +107,6 @@ trait ApplicationDefinitionTrait {
         ]);
 
       $info['community_post_code'] = DataDefinition::create('string')
-        ->setLabel('Community postal code')
         ->setSetting('jsonPath', [
           'compensation',
           'currentAddressInfoArray',
@@ -129,7 +119,6 @@ trait ApplicationDefinitionTrait {
         ->addConstraint('ValidPostalCode');
 
       $info['community_country'] = DataDefinition::create('string')
-        ->setLabel('Community country')
         ->setSetting('jsonPath', [
           'compensation',
           'currentAddressInfoArray',
@@ -147,13 +136,11 @@ trait ApplicationDefinitionTrait {
      */
     if ($applicantType === 'unregistered_community') {
       $info['community_officials'] = ListDataDefinition::create('grants_profile_application_official')
-        // ->setRequired(TRUE)
         ->setSetting('jsonPath', ['compensation', 'applicantOfficialsArray'])
         ->setSetting('defaultValue', [])
         ->setLabel('applicantOfficialsArray');
 
       $info['account_number_owner_name'] = DataDefinition::create('string')
-        ->setLabel('accountNumber')
         ->setSetting('jsonPath', [
           'compensation',
           'bankAccountArray',
@@ -162,7 +149,6 @@ trait ApplicationDefinitionTrait {
         ->addConstraint('NotBlank');
 
       $info['account_number_ssn'] = DataDefinition::create('string')
-        ->setLabel('accountNumber')
         ->setSetting('jsonPath', [
           'compensation',
           'bankAccountArray',
@@ -216,7 +202,6 @@ trait ApplicationDefinitionTrait {
       ]);
 
     $info['application_number'] = DataDefinition::create('string')
-      // ->setRequired(TRUE)
       ->setLabel('applicationNumber')
       ->setSetting('jsonPath', [
         'compensation',
@@ -224,15 +209,12 @@ trait ApplicationDefinitionTrait {
         'applicationNumber',
       ]);
     $info['status'] = DataDefinition::create('string')
-      ->setLabel('Status')
       ->setSetting('jsonPath', [
         'compensation',
         'applicationInfoArray',
         'status',
       ]);
     $info['acting_year'] = DataDefinition::create('string')
-      ->setLabel('Vuosi, jolle haen avustusta')
-    // ->setSetting('defaultValue', "")
       ->setSetting('jsonPath', [
         'compensation',
         'applicationInfoArray',
@@ -245,7 +227,6 @@ trait ApplicationDefinitionTrait {
       ]);
 
     $info['account_number'] = DataDefinition::create('string')
-      ->setLabel('accountNumber')
       ->setSetting('jsonPath', [
         'compensation',
         'bankAccountArray',
@@ -254,7 +235,6 @@ trait ApplicationDefinitionTrait {
       ->addConstraint('NotBlank');
 
     $info['myonnetty_avustus'] = ListDataDefinition::create('grants_metadata_other_compensation')
-      ->setLabel('Myönnetty avustus')
       ->setSetting('defaultValue', [])
       ->setSetting('jsonPath', [
         'compensation',
@@ -297,8 +277,6 @@ trait ApplicationDefinitionTrait {
       ]);
 
     $info['myonnetty_avustus_total'] = DataDefinition::create('float')
-      ->setLabel('Myönnetty avustus total')
-    // ->setSetting('defaultValue', 0)
       ->setSetting('typeOverride', [
         'dataType' => 'string',
         'jsonType' => 'double',
@@ -316,7 +294,6 @@ trait ApplicationDefinitionTrait {
       ->addConstraint('NotBlank');
 
     $info['haettu_avustus_tieto_total'] = DataDefinition::create('float')
-      ->setLabel('Haettu avustus total')
       ->setSetting('defaultValue', 0)
       ->setSetting('typeOverride', [
         'dataType' => 'string',
@@ -335,8 +312,6 @@ trait ApplicationDefinitionTrait {
       ->addConstraint('NotBlank');
 
     $info['benefits_loans'] = DataDefinition::create('string')
-      ->setLabel('Loans')
-    // ->setSetting('defaultValue', "")
       ->setSetting('jsonPath', [
         'compensation',
         'benefitsInfoArray',
@@ -345,7 +320,6 @@ trait ApplicationDefinitionTrait {
 
     $info['benefits_premises'] = DataDefinition::create('string')
       ->setLabel('Premises')
-    // ->setSetting('defaultValue', "")
       ->setSetting('jsonPath', [
         'compensation',
         'benefitsInfoArray',
@@ -359,9 +333,8 @@ trait ApplicationDefinitionTrait {
         'activitiesInfoArray',
         'businessPurpose',
       ]);
-    // ->setSetting('defaultValue', '')
+
     $info['community_practices_business'] = DataDefinition::create('string')
-      ->setLabel('communityPracticesBusiness')
       ->setSetting('jsonPath', [
         'compensation',
         'activitiesInfoArray',
@@ -371,13 +344,12 @@ trait ApplicationDefinitionTrait {
         'dataType' => 'string',
         'jsonType' => 'bool',
       ]);
-    // ->setSetting('defaultValue', FALSE)
+
     $info['additional_information'] = DataDefinition::create('string')
-      ->setLabel('additionalInformation')
-      ->setSetting('jsonPath', ['compensation', 'additionalInformation']);
-    // ->setSetting('defaultValue', "")
+      ->setSetting('jsonPath', ['compensation', 'additionalInformation'])
+      ->setSetting('defaultValue', "");
+
     // Sender details.
-    // @todo Maybe move sender info to custom definition?
     $info['sender_firstname'] = DataDefinition::create('string')
       ->setRequired(TRUE)
       ->setLabel('firstname')
@@ -388,13 +360,12 @@ trait ApplicationDefinitionTrait {
       ]);
     $info['sender_lastname'] = DataDefinition::create('string')
       ->setRequired(TRUE)
-      ->setLabel('lastname')
       ->setSetting('jsonPath', [
         'compensation',
         'senderInfoArray',
         'lastname',
       ]);
-    // @todo Validate person id?
+
     $info['sender_person_id'] = DataDefinition::create('string')
       ->setRequired(TRUE)
       ->setLabel('personID')


### PR DESCRIPTION
# [AU-1970](https://helsinkisolutionoffice.atlassian.net/browse/AU-1970)
<!-- What problem does this solve? -->

It seems that our schema left out additionalInformation field altogether when it is left empty on the form. This is not specified as required field and it passes all validations @Avus2. Still, the field needs to be present or it won't show on some printed report in Avus2.

## What was done
<!-- Describe what was done -->

* Added empty default value for additionalInformation field so even when left empty on a form, the empty value will be used.
* Removed labels and unnecessary comments to satisfy SonarLinter.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1970-missing-additional-info`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill out some of the forms affected: [Kaupunginhallitus Yleisavustus](https://hel-fi-drupal-grant-applications.docker.so/fi/hakemus/kaupunginhallituksen-yleisavustushakemus), [Asukasosallisuus pienavustukset](https://hel-fi-drupal-grant-applications.docker.so/fi/form/asukasosallisuus-pienavustushake)
* [ ] Fill out some fields, leave "Lisätiedot" empty on page with attachments.
* [ ] See from ATV that the field additionalInformation is present.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-1970]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ