### PR TITLE
fix: AU-1236: add tooltip to kh yleisavustus

### DIFF
--- a/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
@@ -39,7 +39,6 @@ elements: |
   community_officials:
     '#help': 'If you want to add, delete or change people, save the application as a draft and go to maintain the people&#39;s information in your own data.'
     '#title': 'Persons responsible for operations'
-    '#multiple__no_items_message': 'No persons responsible for the operation. Add a new person below.'
     '#multiple__add_more_button_label': 'Add person'
     '#community_officials_select__title': 'Select official'
   2_avustustiedot:

--- a/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
@@ -209,6 +209,7 @@ elements: |
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>The contents of the attachments cannot be viewed afterwards</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Please note that you will not be able to open the attachments after you have attached them to the form. You will only see the file name of the attachment.</p>\r\n\r\n<p>Although you cannot view the attachments afterwards, the attachments to the form are sent along with the other information on the form to the grant application processor.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
   yhteison_saannot:
     '#title': 'Community Rules'
+    '#help': 'New applicant or changed rules.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -211,6 +211,7 @@ elements: |
     '#text': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Innehållet i bilagorna kan inte granskas i efterhand</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Observera att du inte kan öppna bilagorna efter att du har bifogat dem blanketten. Du ser bara bilagans filnamn.</p>\r\n\r\n<p>Även om du inte kan granska innehållet i bilagorna i efterhand skickas bilagorna som bifogats blanketten med övriga uppgifter till personen som behandlar ansökan om understöd.</p>\r\n</div>\r\n</div>\r\n</div>\r\n"
   yhteison_saannot:
     '#title': 'Gemenskapens regler'
+    '#help': 'Ny s&ouml;kande eller stadgar som &auml;ndrats.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -53,13 +53,13 @@ elements: |
   acting_year:
     '#title': 'År för vilket jag ansöker om understöd'
   avustuslajit:
-    '#title': Understödskatego&shy;rier
+    '#title': 'Understödskatego&shy;rier'
   subventions:
     '#title': Understöd
   markup_01:
     '#markup': '<p>Ans&ouml;k alltid endast om en typ av underst&ouml;d &aring;t g&aring;ngen.</p>'
   kayttotarkoitus:
-    '#title': Användningsända&shy;mål
+    '#title': 'Användningsända&shy;mål'
   compensation_purpose:
     '#title': 'En kort beskrivning av användningsändamålet för det/de understöd som ansöks'
     '#help': 'Ange f&ouml;r vilket &auml;ndam&aring;l underst&ouml;det ans&ouml;ks och vid behov specificera de olika &auml;ndam&aring;len. Ange ocks&aring; vad underst&ouml;det &auml;r avsett f&ouml;r och vilka m&aring;l som &auml;r relaterade till den underst&ouml;dda verksamheten.'

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -684,6 +684,7 @@ elements: |-
         '#title': 'Yhteisön säännöt'
         '#multiple': false
         '#filetype': '7'
+        '#help': 'Uusi hakija tai s&auml;&auml;nn&ouml;t muuttuneet.'
         '#title_display': ''
         '#description__access': false
       vahvistettu_tilinpaatos:

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -35,7 +35,7 @@ archive: false
 id: yleisavustushakemus
 title: 'Kaupunginhallitus, yleisavustushakemus'
 description: ECONOMICGRANTAPPLICATION
-categories: {  }
+category: ''
 elements: |-
   applicant_type:
     '#type': hidden

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -35,7 +35,7 @@ archive: false
 id: yleisavustushakemus
 title: 'Kaupunginhallitus, yleisavustushakemus'
 description: ECONOMICGRANTAPPLICATION
-category: ''
+categories: {  }
 elements: |-
   applicant_type:
     '#type': hidden


### PR DESCRIPTION
# [AU-1236](https://helsinkisolutionoffice.atlassian.net/browse/AU-1236)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add tooltip to kh yleisavustus

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1236-kh-tooltip`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/yleisavustushakemus)
* [ ] Go to page 4
* [ ] Check that Yhteisön säännöt has a tooltip
* [ ] Repeat in EN and SV

[AU-1236]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ