### PR TITLE
fix: AU-1963: add no applications -text

### DIFF
--- a/public/modules/custom/grants_handler/templates/application-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list.html.twig
@@ -54,7 +54,7 @@
     {% endif %}
     <ul class="list application-list">
       {% if not items and type == 'drafts' %}
-        {{ "No application in progress."|t({}, {'context': 'grants_handler'})}}
+        {{ "No applications in progress."|t({}, {'context': 'grants_handler'})}}
       {% endif %}
       {% for item in items %}
         {{ item }}

--- a/public/modules/custom/grants_handler/templates/application-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list.html.twig
@@ -24,7 +24,13 @@
       </div>
       <hr/>
       <div class="application-list__information-row">
-        <div class="application-list__count"><span class="application-list__count-value">&nbsp;</span> {{ 'Applications'|t({}, {'context': 'grants_handler'})}}</div>
+        <div class="application-list__count">
+          {% if items %}
+            <span class="application-list__count-value">&nbsp;</span> {{ 'Applications'|t({}, {'context': 'grants_handler'})}}
+          {% else %}
+            {{ 'No sent applications.'|t({}, {'context': 'grants_handler'})}}
+          {% endif %}
+        </div>
         <div class="application-list--select">
           <label for="applicationListSort" class="hds-text-input__label">{{ "Sort"|t({}, {'context': 'grants_handler'})}}</label>
           <div class="grant-applications--select-wrapper">
@@ -47,6 +53,9 @@
       </div>
     {% endif %}
     <ul class="list application-list">
+      {% if not items and type == 'drafts' %}
+        {{ "No application in progress."|t({}, {'context': 'grants_handler'})}}
+      {% endif %}
       {% for item in items %}
         {{ item }}
       {% endfor %}

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -595,7 +595,7 @@ msgid "Validation failed, please check inputs."
 msgstr "Kenttien validaatio epäonnistui, tarkista syötteet."
 
 msgctxt "grants_handler"
-msgid "No application in progress."
+msgid "No applications in progress."
 msgstr "Ei keskeneräisiä hakemuksia."
 
 msgctxt "grants_handler"

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -593,3 +593,11 @@ msgstr "Lisätietoja hakemukseen liittyen"
 msgctxt "grants_handler"
 msgid "Validation failed, please check inputs."
 msgstr "Kenttien validaatio epäonnistui, tarkista syötteet."
+
+msgctxt "grants_handler"
+msgid "No application in progress."
+msgstr "Ei keskeneräisiä hakemuksia."
+
+msgctxt "grants_handler"
+msgid "No sent applications."
+msgstr "Ei lähetettyjä hakemuksia."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -595,9 +595,9 @@ msgid "Validation failed, please check inputs."
 msgstr "Valideringen misslyckades, kontrollera ingångarna."
 
 msgctxt "grants_handler"
-msgid "No application in progress."
-msgstr "Inga ansökningar pågår"
+msgid "No applications in progress."
+msgstr "Inga pågående ansökningar."
 
 msgctxt "grants_handler"
 msgid "No sent applications."
-msgstr "Inga ansökningar skickade."
+msgstr "Inga skickade ansökningar."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -593,3 +593,11 @@ msgstr "Ytterligare information för ansökan"
 msgctxt "grants_handler"
 msgid "Validation failed, please check inputs."
 msgstr "Valideringen misslyckades, kontrollera ingångarna."
+
+msgctxt "grants_handler"
+msgid "No application in progress."
+msgstr "Inga ansökningar pågår"
+
+msgctxt "grants_handler"
+msgid "No sent applications."
+msgstr "Inga ansökningar skickade."


### PR DESCRIPTION
# [AU-1963](https://helsinkisolutionoffice.atlassian.net/browse/AU-1963)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add no applications -text

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1963-no-applications`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login with a user that has no sent applications
* [ ] Go to [Oma asiointi](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi)
* [ ] Check that you see text that indicate there is no applications

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/47e44aa0-489d-4b21-9045-63f98c3313ca)

* [ ] Create a drant and a sent application 
* [ ] Check that these texts disappear and everything looks normal

[AU-1963]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ