### PR TITLE
fix: AU-1955 Show rented premise component in print view

### DIFF
--- a/public/modules/custom/grants_premises/translations/sv.po
+++ b/public/modules/custom/grants_premises/translations/sv.po
@@ -183,7 +183,7 @@ msgstr "Hur många dagar i veckan ordnas verksamhet i lokalen?"
 
 msgctxt "grants_premises"
 msgid "How many hours per day is the facility used?"
-msgstr "Hur många dagar i veckan ordnas verksamhet i lokalen?"
+msgstr "Hur många timmar om dagen ordnas verksamhet i lokalen?"
 
 msgctxt "grants_premises"
 msgid "Lessor's name"

--- a/public/modules/custom/grants_webform_print/grants_webform_print.module
+++ b/public/modules/custom/grants_webform_print/grants_webform_print.module
@@ -32,6 +32,9 @@ function grants_webform_print_theme($existing, $type, $theme, $path) {
     'premises_composite_print' => [
       'render element' => 'element',
     ],
+    'rented_premises_composite_print' => [
+      'render element' => 'element',
+    ],
     'textarea_print' => [
       'render element' => 'element',
     ],
@@ -85,7 +88,7 @@ function grants_webform_print_preprocess_webform_progress_tracker(&$variables) {
     }
 
     // Add the visited and error classes if it has been logged.
-    if ((isset($all_errors[$key]) && !empty($all_errors[$key]))) {
+    if (isset($all_errors[$key]) && !empty($all_errors[$key])) {
       // Add an error class if the page has errors or complete class if not.
       $variables['page_classes'][$key][] = 'has-errors';
     }

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -208,6 +208,10 @@ class GrantsWebformPrintController extends ControllerBase {
         $element['#theme'] = 'premises_composite_print';
         break;
 
+      case 'rented_premise_composite':
+        $element['#theme'] = 'rented_premises_composite_print';
+        break;
+
       case 'community_address_composite':
       case 'community_officials_composite':
       case 'textarea':

--- a/public/modules/custom/grants_webform_print/templates/rented-premises-composite-print.html.twig
+++ b/public/modules/custom/grants_webform_print/templates/rented-premises-composite-print.html.twig
@@ -1,0 +1,66 @@
+<div>
+  <h4 class="print-label">{{ element['#title'] }}</h4>
+  <h4 class="print-label">{{ 'Street address'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <h4 class="print-label">{{ 'Postal code'|t }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <h4 class="print-label">{{ 'City'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <h4 class="print-label">{{ 'Rent'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <div class="webform-element-description">
+    {{ 'EUR per month'|t({}, {'context': 'grants_premises'}) }}
+  </div>
+  <h4 class="print-label">{{ 'Lessor\'s name'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <h4 class="print-label">{{ 'Lessor\'s contact information'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <div class="webform-element-description">
+    {{ 'Email and/or telephone number'|t({}, {'context': 'grants_premises'}) }}
+  </div>
+  <h4 class="print-label">{{ 'Purpose of use'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <div class="webform-element-description">
+    {{ 'For example, an office, storage, gathering or clubs'|t({}, {'context': 'grants_premises'}) }}
+  </div>
+  <h4 class="print-label">{{ 'How many days per week is the facility used?'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+  <h4 class="print-label">{{ 'How many hours per day is the facility used?'|t({}, {'context': 'grants_premises'}) }}</h4>
+  <div class="hds-text-input__input-wrapper">
+    <div class="hide-input form-text hds-text-input__input webform_large" type="text">
+      &nbsp;
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# [AU-1955](https://helsinkisolutionoffice.atlassian.net/browse/AU-1955)
<!-- What problem does this solve? -->

Näytä vuokrattavan tilan tiedot esikatselu näkymässä.

## What was done
<!-- Describe what was done -->

* Lisää komposiitille oma käsittely webform prints -moduulissa.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1955-rent-premise-in-print`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Varmista että lomake näyttää siltä miltä pitää https://hel-fi-drupal-grant-applications.docker.so/fi/tietoja-avustuksista/nuortoimpalkka/tulosta

[AU-1955]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ