### PR TITLE
fix: AU-1962: Hide old bank account confirmation files

### DIFF
--- a/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
@@ -211,6 +211,18 @@ class GrantsAttachments extends WebformCompositeBase {
       return [];
     }
 
+    // Prevent old account confirmation files from rendering
+    // if the user changed bank accounts.
+    if (isset($value['fileType']) && $value['fileType'] == 45) {
+      $accountNumber = $submissionData['bank_account']['account_number'] ?? NULL;
+      $description = $value['description'] ?? NULL;
+      if (is_string($accountNumber) &&
+          is_string($description) &&
+          !str_contains($description, $accountNumber)) {
+        return [];
+      }
+    }
+
     // This notes that we have uploaded file in process.
     if (isset($value['attachment']) && $value['attachment'] !== NULL) {
       // Load file.


### PR DESCRIPTION
# [AU-1962](https://helsinkisolutionoffice.atlassian.net/browse/AU-1962)

## What was done
This pull request fixes an issue where an old bank account confirmation file would be displayed at the "Vahvista, esikatsele ja lähetä" page when the applications selected bank account had been changed.

## Thinking out loud
The issue can be reproduced by the following steps:
1. Login with a test user.
2. Start filling in an application and select a bank account.
3. Save the application as a draft.
4. Edit the application and change the selected bank account.
5. Go to the page "Vahvista, esikatsele ja lähetä" and notice that the old confirmation file is displayed under the "Muu liite" section.

The problem exists because of the way attachments are handled; Attachments are only ever uploaded to ATV when the application is either saved as a draft, or when the application is submitted. Thus, the old confirmation file is displayed even if the account number changes. Possible solutions to this problem could be:

1. Uploading a new bank account confirmation file to ATV when a user changes bank accounts from the select menu (overkill?).
2. Uploading attachments to ATV when a user changes pages in the application (overkill?).
3. Altering the webform submission by rendering a "made up" confirmation file on the confirmation page if the account number has changed.
4. Altering the webform submission data by not rendering the old bank account confirmation file on the confirmation page if the account number has changed.

I've personally chosen to take route 4 (not rendering any old confirmation files) since it seems most straight forward. Possible places for altering the data could be:

a. The `loadData` method inside the `GrantsHandlerSubmissionStorage` class (this initiates the data).
b. The `alterForm` method inside the `GrantsHandler` class.
c. A preprocess function.
d. The `formatTextItemValue` method inside the `GrantsAttachments` class.

I've chosen route "d" and implemented a solution that simply skips the rendering of a bank account confirmation file if the account number on the file doesn't match the currently selected account number on the application. This seems like the safest way to implement this change without it affecting other parts of the application.

## How to install
Make sure your instance is up and running on the correct branch.
  * `git checkout feature/AU-1962-old-account-confirmation`
  * `make fresh`
  * `make drush-cr`

## How to test
1. Login with a test user.
2. Start filling in an application and select a bank account.
3. Save the application as a draft.
4. Edit the application and change the selected bank account.
5. Go to the page "Vahvista, esikatsele ja lähetä" and notice that the old confirmation file is not under the "Muu liite" section.
6. Submit the application and check that it goes through to ATV.


[AU-1962]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ