### PR TITLE
AU-1961: Fix inputmask metadata

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
+++ b/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
@@ -129,10 +129,11 @@ class TypedDataToDocumentContentWithWebform {
         $section = $extractedMetaData['section'];
         $element = $extractedMetaData['element'];
 
-        // InputmaskHandler::addInputmaskToMetadata(
-        // $element,
-        // $webformMainElement ?? [],
-        // );.
+        InputmaskHandler::addInputmaskToMetadata(
+          $element,
+          $webformMainElement ?? [],
+        );
+
         $metaData = AtvSchema::getMetaData($page, $section, $element);
       }
       // Handle other types of fields.
@@ -685,11 +686,14 @@ class TypedDataToDocumentContentWithWebform {
         $metaData['element']['label'] = $label;
         $metaData['element']['hidden'] = in_array($itemName, $hiddenFields);
 
-        // InputmaskHandler::addInputmaskToMetadata(
-        // $metaData['element'],
-        // $webformMainElement['#webform_composite_elements'][$itemName] ?? [],
-        // );.
-        $fieldValues[] = self::getValueArray($itemName, $itemValue, $itemTypes['jsonType'], $label, $metaData);
+        $itemMetaData = $metaData;
+
+        InputmaskHandler::addInputmaskToMetadata(
+          $itemMetaData['element'],
+          $webformMainElement['#webform_composite_elements'][$itemName] ?? [],
+        );
+
+        $fieldValues[] = self::getValueArray($itemName, $itemValue, $itemTypes['jsonType'], $label, $itemMetaData);
       }
     }
     return $fieldValues;


### PR DESCRIPTION
# [AU-1961](https://helsinkisolutionoffice.atlassian.net/browse/AU-1961)
<!-- What problem does this solve? -->

Old implementation of adding input mask data to meta field caused some problems with composite elements, where the input data would stay in later iterations of property item loop and cause values transform to incorrect ones.

**You can validate the problem in develop branch:**

* Open `TypedDataToDocumentContentWithWebform` class file
* Uncomment `InputmaskHandler::addInputmaskToMetadata` calls on lines 132 & 688
* Open a new [Nuorisopalvelu, toiminta- ja palkkausavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka)
* Page 2 select Haen vuokra-avustusta
* Page 5: Enter data to `Vuokrattu tila`

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/fca23787-711d-4c05-a727-628cfc362474)

* Save as draft
* Now the fields should contain incorrect data
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/5d3f2051-cc12-4b16-8975-38abb27a88e5)


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1961-fix-inputmask-metadata`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

*  [ ]Open a new [Nuorisopalvelu, toiminta- ja palkkausavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka)
* [ ] Page 2 select Haen vuokra-avustusta
* [ ] Page 5: Enter data to `Vuokrattu tila`
* [ ] Save as draft and make sure that the data matches.
* [ ] Go back to edit mode and check that data looks ok
* [ ] Try other application and composite elements and check that number fields are behaving correctly when saving.



[AU-1961]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ