### PR TITLE
AU-1990: Add current node to cache tags in ServicePageAnonBlock to fix cache issues

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -242,6 +242,16 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
   /**
    * {@inheritdoc}
    */
+  public function getCacheTags() {
+    $cache_tags = parent::getCacheTags();
+    $node = $this->routeMatch->getParameter('node');
+    $nodeCacheTag = 'node:' . $node->id();
+    return Cache::mergeTags($cache_tags, [$nodeCacheTag]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCacheContexts(): array {
     // If you depends on \Drupal::routeMatch()
     // you must set context of this block with 'route' context tag.


### PR DESCRIPTION
…
# [AU-1990](https://helsinkisolutionoffice.atlassian.net/browse/AU-1990)
<!-- What problem does this solve? -->

## What was done

Currently if node is being update, the anon block clear cache in given service page, this causes some cache issues where preview link doesn't show up or update if a webform relation has been added / updates.

Add current node to cache tags so the block cache will invalidate when node is updated. 

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1990-fix-anonblock-cache`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open your local.settings.file and make sure you comment following lines.

`
//$settings['cache']['bins']['render'] = 'cache.backend.null';
//$settings['cache']['bins']['page'] = 'cache.backend.null';
//$settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
`
* [ ] `make drush-cr`
* [ ] As admin user select any service page and remove the possible linked webform and save.
* [ ] Open new browser window for anonymous user and visit the edited service page. You should see AnonBlock without a preview link

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/744b2a35-d3c8-4ae9-9b95-e328599ad1da)

* [ ] As admin: Edit the service page once again and add a webform link and save.

* [ ] As anon: Refresh the service page. You should now see preview link without any need of clearing caches.

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/246c68f1-a60a-4537-a6cf-b5c871664e0e)

You can check the orignal in develop branch with same steps, but this time cache clear is required between saves.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)



[AU-1990]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ