### PR TITLE
fix: AU-1994: fix translation in closed application

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -670,7 +670,10 @@ class GrantsHandler extends WebformHandlerBase {
 
     if (!ApplicationHandler::isSubmissionChangesAllowed($webform_submission)) {
       $this->messenger()
-        ->addError('Application period is closed, no further editing is allowed.');
+        ->addError(
+          $this->t('Application period is closed, no further editing is allowed.',
+            [],
+            $tOpts));
       $form['#disabled'] = TRUE;
     }
 

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -367,6 +367,7 @@ msgctxt "grants_handler"
 msgid "The status change can take from seconds to few minutes."
 msgstr "Tilan vaihtuminen voi kestää sekunneista muutamaan minuuttiin."
 
+msgctxt "grants_handler"
 msgid "Application period is closed, no further editing is allowed."
 msgstr "Hakemusaika on päättynyt, lisämuokkaukset on estetty."
 

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -367,6 +367,7 @@ msgctxt "grants_handler"
 msgid "The status change can take from seconds to few minutes."
 msgstr "Statusändringen kan ta från sekunder till några minuter."
 
+msgctxt "grants_handler"
 msgid "Application period is closed, no further editing is allowed."
 msgstr "Ansökningsperioden är stängd, ingen ytterligare redigering är tillåten."
 


### PR DESCRIPTION
# [AU-1994](https://helsinkisolutionoffice.atlassian.net/browse/AU-1994)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix translation in closed application

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1994-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go edit a draft of an application that has closed application period
* [ ] Check that warning notification is translated 


[AU-1994]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ