### PR TITLE
AU-2010: Parse messages in message list preprocess to get current statuses

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1027,7 +1027,8 @@ function grants_handler_preprocess_webform_submission_messages(&$variables) {
 
   $messages = [];
   if (isset($submissionData['messages']) && is_array($submissionData['messages'])) {
-    foreach ($submissionData['messages'] as $message) {
+    $submissionMessages = ApplicationHandler::parseMessages($submissionData);
+    foreach ($submissionMessages as $message) {
       $messages[] = [
         '#theme' => 'message_list_item',
         '#message' => $message,


### PR DESCRIPTION
# [AU-2010](https://helsinkisolutionoffice.atlassian.net/browse/AU-2010)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* After reducing ATV calls, we won't parse messages in the message list (Object is missing messageStatus). Added parseMessages to message list, so we can get the up to date statuses

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2010-fix-message-list-message-status`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Ask for messages to be sent to any of your application (Or use LOCALON env and check [LOCALON-066-0000146](https://hel-fi-drupal-grant-applications.docker.so/fi/hakemus/LOCALON-066-0000146/katso)
* [ ] Unread / New messages should have to mark as read button
* [ ] In develop branch these buttons won't appear.



[AU-2010]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ