### PR TITLE
AU-1387: Override FormErrorHandler, so we can remove errors added via messenger

### DIFF
--- a/public/modules/custom/grants_handler/src/FormErrorHandler.php
+++ b/public/modules/custom/grants_handler/src/FormErrorHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\grants_handler;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\inline_form_errors\FormErrorHandler as InlineFormErrorHandler;
+
+/**
+ * Produces inline form errors.
+ */
+class FormErrorHandler extends InlineFormErrorHandler {
+
+  /**
+   * Loops through and displays all form errors.
+   *
+   * To disable inline form errors for an entire form set the
+   * #disable_inline_form_errors property to TRUE on the top level of the $form
+   * array:
+   * @code
+   * $form['#disable_inline_form_errors'] = TRUE;
+   * @endcode
+   * This should only be done when another appropriate accessibility strategy is
+   * in place.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  protected function displayErrorMessages(array $form, FormStateInterface $form_state) {
+    // Skip generating inline form errors when opted out.
+    if (!empty($form['#disable_inline_form_error_messages'])) {
+      return;
+    }
+
+    parent::displayErrorMessages($form, $form_state);
+  }
+
+}

--- a/public/modules/custom/grants_handler/src/GrantsHandlerServiceProvider.php
+++ b/public/modules/custom/grants_handler/src/GrantsHandlerServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\grants_handler;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Overrides the form_error_handler service to enable inline form errors.
+ */
+class GrantsHandlerServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $container->getDefinition('form_error_handler')
+      ->setClass(FormErrorHandler::class)
+      ->setArguments([
+        new Reference('string_translation'),
+        new Reference('renderer'),
+        new Reference('messenger'),
+      ]);
+  }
+
+}

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -569,6 +569,8 @@ class GrantsHandler extends WebformHandlerBase {
       return;
     }
 
+    $form['#disable_inline_form_error_messages'] = TRUE;
+
     $this->alterFormNavigation($form, $form_state, $webform_submission);
 
     $form['#webform_submission'] = $webform_submission;


### PR DESCRIPTION


# [AU-1387](https://helsinkisolutionoffice.atlassian.net/browse/AU-1387)
<!-- What problem does this solve? -->

## What was done


* Webforms default behavior is to use Messenger to display errors, but as we have our own error handling / displaying system in place the default behaviour will cause 2 message boxes to appear, when the user clicks the "Preview" button.
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/465c3cab-6c17-4c87-badb-93bcf8e3cb89)


Created an override FormErroHandler class, which will check existance of `#disable_inline_form_error_messages` and skip message display if needed.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1387-hide-inline-messanger-messages`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any application ([Hyvinvoinnin ja terveyden edistämisen sekä sosiaali-, terveys- ja pelastustoimen yleisavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/form/hyte-yleisavustus))
* [ ] Go to attachment page do not fill any info.
* [ ] Click "Esikatseluun"
* [ ] You should see only 1 red box with error messages.
* [ ] Check that everything looks ok in other pages too.
* [ ] Check that preview page shows the "Tarkista lähetyksesi. Lähetyksesi on valmis vasta, kun painat "Lähetä"-painiketta!" in yellow message box.
* [ ] Check that this doesn't cause any issues with inline errors in profile forms.


[AU-1387]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ