### PR TITLE
feat: AU-1988: Initial bank account confirmation file message

### DIFF
--- a/public/modules/custom/grants_attachments/grants_attachments.libraries.yml
+++ b/public/modules/custom/grants_attachments/grants_attachments.libraries.yml
@@ -7,3 +7,11 @@ grants_attachments:
       css/grants-attachments.css: {}
   dependencies:
     - core/drupalSettings
+
+# Application Timeout
+pending_bank_account_confirmation:
+  js:
+    js/pending-bank-account-confirmation.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupalSettings

--- a/public/modules/custom/grants_attachments/grants_attachments.module
+++ b/public/modules/custom/grants_attachments/grants_attachments.module
@@ -50,8 +50,8 @@ function grants_attachments_form_alter(&$form, FormStateInterface $form_state, $
   // been selected, but the confirmation file has not been upload to ATV.
   if (isset($form['#webform_id'])) {
     $bankAccount = $form_state->getValue('bank_account');
-    $selectedAccount = $bankAccount['account_number_select'] ?? FALSE;
     $otherAttachments = $form_state->getValue('muu_liite') ?? [];
+    $selectedAccount = $bankAccount['account_number_select'] ?? FALSE;
     $hasBankAccountConfirmation = FALSE;
 
     foreach ($otherAttachments as $attachment) {

--- a/public/modules/custom/grants_attachments/grants_attachments.module
+++ b/public/modules/custom/grants_attachments/grants_attachments.module
@@ -45,25 +45,36 @@ function grants_attachments_cron() {
  */
 function grants_attachments_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
 
-  // Attach a js library to the applications that displays an "Upload pending" message
-  // on the confirmation page of the forms. The message is displayed if a bank account has
-  // been selected, but the confirmation file has not been upload to ATV.
+  // Attach a .js library that displays an "Upload pending" message under the
+  // "Other attachments" section on the confirmation page of an application.
+  // The message is displayed in the scenario where a bank account has been
+  // selected, but said accounts confirmation file has not yet been uploaded
+  // to ATV.
+
   if (isset($form['#webform_id'])) {
     $bankAccount = $form_state->getValue('bank_account');
     $otherAttachments = $form_state->getValue('muu_liite') ?? [];
-    $selectedAccount = $bankAccount['account_number_select'] ?? FALSE;
-    $hasBankAccountConfirmation = FALSE;
+    $selectedAccountNumber = $bankAccount['account_number_select'] ?? FALSE;
+    $bankAccountChanged = FALSE;
+    $noConfirmationFile = TRUE;
 
     foreach ($otherAttachments as $attachment) {
       if (isset($attachment['fileType']) && $attachment['fileType'] == 45) {
-        $hasBankAccountConfirmation = TRUE;
-        break;
+        $noConfirmationFile = FALSE;
+        $description = $attachment['description'] ?? FALSE;
+
+        if (is_string($selectedAccountNumber) &&
+            is_string($description) &&
+            !str_contains($description, $selectedAccountNumber)) {
+          $bankAccountChanged = TRUE;
+          break;
+        }
       }
     }
 
-    if ($selectedAccount && !$hasBankAccountConfirmation) {
+    if (($selectedAccountNumber && $noConfirmationFile) || $bankAccountChanged) {
       $form['#attached']['library'][] = 'grants_attachments/pending_bank_account_confirmation';
-      $form['#attached']['drupalSettings']['grants_attachments']['settings']['selectedAccount'] = $selectedAccount;
+      $form['#attached']['drupalSettings']['grants_attachments']['selectedAccountNumber'] = $selectedAccountNumber;
     }
   }
 }

--- a/public/modules/custom/grants_attachments/grants_attachments.module
+++ b/public/modules/custom/grants_attachments/grants_attachments.module
@@ -14,6 +14,8 @@
  * @see https://www.drupal.org/node/2217931
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_theme().
  */
@@ -36,4 +38,32 @@ function grants_attachments_cron() {
   /** @var \Drupal\grants_attachments\AttachmentRemover $attachmentRemover */
   $attachmentRemover = \Drupal::service('grants_attachments.attachment_remover');
   $attachmentRemover->purgeAllAttachments();
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function grants_attachments_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
+
+  // Attach a js library to the applications that displays an "Upload pending" message
+  // on the confirmation page of the forms. The message is displayed if a bank account has
+  // been selected, but the confirmation file has not been upload to ATV.
+  if (isset($form['#webform_id'])) {
+    $bankAccount = $form_state->getValue('bank_account');
+    $selectedAccount = $bankAccount['account_number_select'] ?? FALSE;
+    $otherAttachments = $form_state->getValue('muu_liite') ?? [];
+    $hasBankAccountConfirmation = FALSE;
+
+    foreach ($otherAttachments as $attachment) {
+      if (isset($attachment['fileType']) && $attachment['fileType'] == 45) {
+        $hasBankAccountConfirmation = TRUE;
+        break;
+      }
+    }
+
+    if ($selectedAccount && !$hasBankAccountConfirmation) {
+      $form['#attached']['library'][] = 'grants_attachments/pending_bank_account_confirmation';
+      $form['#attached']['drupalSettings']['grants_attachments']['settings']['selectedAccount'] = $selectedAccount;
+    }
+  }
 }

--- a/public/modules/custom/grants_attachments/grants_attachments.module
+++ b/public/modules/custom/grants_attachments/grants_attachments.module
@@ -50,7 +50,6 @@ function grants_attachments_form_alter(&$form, FormStateInterface $form_state, $
   // The message is displayed in the scenario where a bank account has been
   // selected, but said accounts confirmation file has not yet been uploaded
   // to ATV.
-
   if (isset($form['#webform_id'])) {
     $bankAccount = $form_state->getValue('bank_account');
     $otherAttachments = $form_state->getValue('muu_liite') ?? [];

--- a/public/modules/custom/grants_attachments/js/pending-bank-account-confirmation.js
+++ b/public/modules/custom/grants_attachments/js/pending-bank-account-confirmation.js
@@ -36,7 +36,7 @@
       const newListItemStatus = Drupal.t("Upload pending")
       newListItem.innerHTML = newListItemDesc + "<br>" + newListItemStatus;
 
-      // Find or create the other attachments listing.
+      // Find or create the "Other attachments" listing.
       const otherAttachments = document.querySelector('.form-item-muu-liite');
       const otherAttachmentsList = otherAttachments.querySelector('ul') || document.createElement('ul');
 

--- a/public/modules/custom/grants_attachments/js/pending-bank-account-confirmation.js
+++ b/public/modules/custom/grants_attachments/js/pending-bank-account-confirmation.js
@@ -13,7 +13,7 @@
      *   Drupal settings.
      */
     attach: function (context, settings) {
-      const selectedAccount = settings.grants_attachments.settings.selectedAccount;
+      const selectedAccount = settings.grants_attachments.selectedAccountNumber;
       if (typeof selectedAccount !== 'undefined') {
         this.displayPendingBankAccountConfirmationMessage(selectedAccount);
       }
@@ -22,22 +22,31 @@
     /**
      * The displayPendingBankAccountConfirmationMessage function.
      *
-     * Desc...
+     * This function displays an "Upload pending" message under the
+     * "Other attachments" section on the confirmation page of an application.
+     * The message is displayed in the scenario where a bank account number
+     * has been selected, but the accounts confirmation file has not been
+     * uploaded to ATV.
      *
-     * @param selectedAccount
-     *   The selected bank account.
+     * @param selectedAccountNumber
+     *   The selected account number.
      */
-    displayPendingBankAccountConfirmationMessage: function(selectedAccount) {
+    displayPendingBankAccountConfirmationMessage: function(selectedAccountNumber) {
+      // Make sure we are on the "preview" page.
       if (!document.body.classList.contains('webform-submission-data-preview-page')) return;
 
       // Create the list item.
       const newListItem = document.createElement('li');
-      const newListItemDesc = Drupal.t("Confirmation file for @account", {'@account': selectedAccount});
-      const newListItemStatus = Drupal.t("Upload pending")
+      const newListItemDesc = Drupal.t("Confirmation for account @accountNumber", {'@accountNumber': selectedAccountNumber}, {context: "grants_attachments"});
+      const newListItemStatus = Drupal.t("Upload pending / File missing", {}, {context: "grants_attachments"});
       newListItem.innerHTML = newListItemDesc + "<br>" + newListItemStatus;
 
-      // Find or create the "Other attachments" listing.
+      // Find the section for "Other attachments" and clear it of any text (usually a dash).
       const otherAttachments = document.querySelector('.form-item-muu-liite');
+      if (!otherAttachments) return;
+      otherAttachments.childNodes.forEach(c => c.nodeType === Node.TEXT_NODE && c.remove());
+
+      // Find or create the "Other attachments" listing.
       const otherAttachmentsList = otherAttachments.querySelector('ul') || document.createElement('ul');
 
       // Append the new item.

--- a/public/modules/custom/grants_attachments/js/pending-bank-account-confirmation.js
+++ b/public/modules/custom/grants_attachments/js/pending-bank-account-confirmation.js
@@ -1,0 +1,50 @@
+(function ($, Drupal, drupalSettings) {
+
+  'use strict';
+
+  Drupal.behaviors.pendingBankAccountConfirmation = {
+
+    /**
+     * Attach the behavior.
+     *
+     * @param context
+     *   The context.
+     * @param settings
+     *   Drupal settings.
+     */
+    attach: function (context, settings) {
+      const selectedAccount = settings.grants_attachments.settings.selectedAccount;
+      if (typeof selectedAccount !== 'undefined') {
+        this.displayPendingBankAccountConfirmationMessage(selectedAccount);
+      }
+    },
+
+    /**
+     * The displayPendingBankAccountConfirmationMessage function.
+     *
+     * Desc...
+     *
+     * @param selectedAccount
+     *   The selected bank account.
+     */
+    displayPendingBankAccountConfirmationMessage: function(selectedAccount) {
+      if (!document.body.classList.contains('webform-submission-data-preview-page')) return;
+
+      // Create the list item.
+      const newListItem = document.createElement('li');
+      const newListItemDesc = Drupal.t("Confirmation file for @account", {'@account': selectedAccount});
+      const newListItemStatus = Drupal.t("Upload pending")
+      newListItem.innerHTML = newListItemDesc + "<br>" + newListItemStatus;
+
+      // Find or create the other attachments listing.
+      const otherAttachments = document.querySelector('.form-item-muu-liite');
+      const otherAttachmentsList = otherAttachments.querySelector('ul') || document.createElement('ul');
+
+      // Append the new item.
+      otherAttachmentsList.appendChild(newListItem);
+      otherAttachments.appendChild(otherAttachmentsList);
+    },
+
+  };
+
+})(jQuery, Drupal, drupalSettings);


### PR DESCRIPTION
# [AU-1988](https://helsinkisolutionoffice.atlassian.net/browse/AU-1988)

## What was done
This pull request implements a feature that displays an "Upload pending" message under the "Other attachments" section on the confirmation page of any application. The message is displayed in the scenario where a user has selected a bank account on the first page of the application, but the bank accounts confirmation file has not yet been uploaded to ATV.

![Screenshot 2024-01-04 at 14 12 48](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/87ca34ad-df8a-48dd-8300-9a569f470f63)


## Things to note
I've chosen to implement this feature using js. It was surprisingly difficult to implement this on the back-end without having to worry about any "dummy data" ending up in ATV. If you come up with a better approach/solution, then please feel free to share.

## How to install
Make sure your instance is up and running on the correct branch.
  * `git checkout feature/AU-1988-initial-bank-account-confirmation`
  * `make fresh`
  * `make drush-cr`

## How to test

### Setup
1. Login with a test user that has at least two bank accounts set up.

### Test 1
1. Start filling in any application and select a bank account.
2. Go to the page "Vahvista, esikatsele ja lähetä". There should be an "Upload pending" type of message for the selected account under the "Other attachments section."
3. Go back to page 1 and change bank accounts. Repeat step 2 and confirm that there is a message for the new bank account.

### Test 2
1. Start filling any application and select a bank account.
2. Save the application as a draft.
6. Edit the application and change the selected bank account.
7. Go to the page "Vahvista, esikatsele ja lähetä". There should be an "Upload pending" type of message for the selected account under the "Other attachments section."


[AU-1988]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ