### PR TITLE
fix: AU-2025: Select translations

### DIFF
--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -116,7 +116,6 @@ elements: |
           1: Stat
           4: Övrig
           5: Fundament
-          6: Fundament
         '#title': ' Bidragsgivare'
       issuer_name:
         '#title': 'Emittentens namn'

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -348,7 +348,11 @@ class GrantsWebformPrintController extends ControllerBase {
   public function getTranslatedOptions(array $element, array $translatedFields): array {
     if (isset($translatedFields[$element['#id']]['#options'])
       && is_array($translatedFields[$element['#id']]['#options'])) {
-      return $translatedFields[$element['#id']]['#options'];
+      foreach ($translatedFields[$element['#id']]['#options'] as $key => $value) {
+        if (isset($element['#options'][$key])) {
+          $element['#options'][$key] = $value;
+        }
+      }
     }
     return $element['#options'];
   }


### PR DESCRIPTION
# [AU-2025](https://helsinkisolutionoffice.atlassian.net/browse/AU-2025)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Swedish/English wasn't working for all selects in the preview print view

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2025-STEA-EU-translation-fixes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [A random print page](https://hel-fi-drupal-grant-applications.docker.so/sv/tietoja-avustuksista/kuva_projekti/tulosta)
* [ ] See that STEA is translated as STEA (find STEA on page, if you get a hit it works) and EU is translated as EU (a few rows above)
* [ ] Go to [Nuortoimpalkka print page](https://hel-fi-drupal-grant-applications.docker.so/sv/tietoja-avustuksista/nuortoimpalkka/tulosta)
* [ ] See that STEA is translated as STEA (find STEA on page, if you get a hit it works)
* [ ] Check that code follows our standards


[AU-2025]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ