### PR TITLE
hotfix: AU-2029: Fix immediate page crash on new profiles

### DIFF
--- a/public/modules/custom/grants_profile/src/GrantsProfileService.php
+++ b/public/modules/custom/grants_profile/src/GrantsProfileService.php
@@ -675,7 +675,7 @@ class GrantsProfileService {
     // Get grants profile.
     $grantsProfileDocument = $this->getGrantsProfile($selectedCompany);
 
-    $profileUpdatedAt = $grantsProfileDocument->getUpdatedAt();
+    $profileUpdatedAt = $grantsProfileDocument?->getUpdatedAt();
     $profileUpdatedAt = strtotime($profileUpdatedAt);
     return $profileUpdatedAt;
   }
@@ -695,7 +695,7 @@ class GrantsProfileService {
     // Get grants profile.
     $grantsProfileDocument = $this->getGrantsProfile($selectedCompany);
 
-    $profileMetadata = $grantsProfileDocument->getMetadata();
+    $profileMetadata = $grantsProfileDocument?->getMetadata();
     $notification_shown = $profileMetadata['notification_shown'] ?? 0;
     return $notification_shown;
   }


### PR DESCRIPTION
# [AU-2029](https://helsinkisolutionoffice.atlassian.net/browse/AU-2029)
<!-- What problem does this solve? -->

## What was done

Current logic will cause fatal PHP error which will make it impossible to use our service if the current user doesn't have a profile.
Quick fix to get ahead of these errors.

You can check the error by logging in with a private user in your local environment which you haven't used before (220798-998A might be good candidate) - After logging in as private user you should be greeted by errors.

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2029-fix-page-crash-on-new-profile`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as private user that you haven't used before (Maybe 220798-998A)
* [ ] Select the private user option and check that the page won't crash.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1093


[AU-2029]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ