### PR TITLE
fix: AU-2039: change confs translate non-translations

### DIFF
--- a/conf/cmi/language/en/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/language/en/webform.webform.hyte_yleisavustus.yml
@@ -78,8 +78,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': ' Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'
@@ -110,8 +112,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -78,8 +78,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -80,8 +80,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': ' Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/language/en/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -81,8 +81,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'
@@ -113,8 +115,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -99,8 +99,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': ' Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
@@ -117,8 +117,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_laitosavustushakemus.yml
@@ -78,8 +78,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'
@@ -110,8 +112,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -98,8 +98,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/conf/cmi/language/en/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -78,8 +78,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': ' Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'
@@ -109,8 +111,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
@@ -79,8 +79,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'
@@ -111,9 +113,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
-          6: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -119,8 +119,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': ' Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/language/en/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -87,8 +87,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
@@ -78,8 +78,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'
@@ -110,8 +112,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
-          5: ' Foundation'
+          5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -79,8 +79,10 @@ elements: |
       issuer:
         '#options':
           1: State
+          3: EU
           4: Other
           5: Foundation
+          6: STEA
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'

--- a/conf/cmi/language/sv/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.hyte_yleisavustus.yml
@@ -81,8 +81,10 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
+          6: STEA
         '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
@@ -113,9 +115,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -81,9 +81,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -83,9 +83,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
-          4: ' Övrig'
+          3: EU
+          4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -84,9 +84,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'
@@ -116,9 +118,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -102,9 +102,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
@@ -116,8 +116,10 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
+          6: STEA
         '#title': 'Bidragsgivare'
       issuer_name:
         '#title': 'Emittentens namn'

--- a/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
@@ -81,9 +81,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'
@@ -113,9 +115,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -101,9 +101,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -82,9 +82,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
-          4: ' Övrig'
+          3: EU
+          4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'
@@ -113,9 +115,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -82,9 +82,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': '<p>Vilket organ har beviljat bidraget (t.ex. namnet på departementet)</p>'
@@ -114,9 +116,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': '<p>Vilket organ har beviljat bidraget (t.ex. namnet på departementet)</p>'

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -122,8 +122,10 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
+          6: STEA
         '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -90,8 +90,10 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
+          6: STEA
         '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -81,9 +81,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'
@@ -113,9 +115,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'

--- a/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -81,9 +81,11 @@ elements: |
       issuer:
         '#options':
           1: Stat
+          3: EU
           4: Övrig
           5: Fundament
-        '#title': ' Bidragsgivare'
+          6: STEA
+        '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
         '#help': 'Vilket organ har beviljat bidraget (t.ex. namnet p&aring; departementet)'


### PR DESCRIPTION
# [AU-2039](https://helsinkisolutionoffice.atlassian.net/browse/AU-2039)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* English and swedish translations for dropdowns fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2039-translation-additions`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to your config ignore, remove the webform line, save config ignore
* [ ] `make drush-cim`
* [ ] `make drush-forms`
* [ ] `make drush-cr`
* [ ] Go to a [swedish form that used to have fundaments on the second page twice](https://hel-fi-drupal-grant-applications.docker.so/sv/hakemus/kaupunginkanslia_tyollisyysavust/1153/muokkaa)
* [ ] Go to the second page, select "Ja" for "Vi har ansökt om understöd från annanstans än Helsingfors stad."
* [ ] On the opening composite, see that "Bidragsgivare" has STEA and EU as options
* [ ] Repeat on the english page
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2039]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ