### PR TITLE
AU-789: Add remove_http_headers module and config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "drupal/purge_users": "^3.1",
         "drupal/radioactivity": "^4.0",
         "drupal/raven": "^4.0",
+        "drupal/remove_http_headers": "^2.0.1",
         "drupal/restui": "^1.21",
         "drupal/search_api": "^1.29",
         "drupal/select2": "^1.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a06d02b8a0ca8a0265c26792c74094dd",
+    "content-hash": "501015b0aad0452d4aea857f56bda7ac",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8520,6 +8520,69 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
+            }
+        },
+        {
+            "name": "drupal/remove_http_headers",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/remove_http_headers.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/remove_http_headers-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "797e6f9d368eb073b930e0f4ccb2a55c86a70666"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1699022260",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Orlando Thöny",
+                    "homepage": "https://www.drupal.org/user/3636010",
+                    "email": "orlando.thoeny@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "marco-s",
+                    "homepage": "https://www.drupal.org/user/3396620"
+                },
+                {
+                    "name": "milovan",
+                    "homepage": "https://www.drupal.org/user/2018332"
+                },
+                {
+                    "name": "rdamjanov",
+                    "homepage": "https://www.drupal.org/user/913518"
+                }
+            ],
+            "description": "Removes configured HTTP Response headers.",
+            "homepage": "https://drupal.org/project/remove_http_headers",
+            "keywords": [
+                "Drupal",
+                "HTTP headers",
+                "Security"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/remove_http_headers"
             }
         },
         {

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -158,6 +158,7 @@ module:
   raven: 0
   readonly_field_widget: 0
   redirect: 0
+  remove_http_headers: 0
   responsive_image: 0
   rest: 0
   restui: 0

--- a/conf/cmi/remove_http_headers.settings.yml
+++ b/conf/cmi/remove_http_headers.settings.yml
@@ -1,0 +1,11 @@
+_core:
+  default_config_hash: LNYrEZMNvotD7ZS_X0b59tq3Jyl-f5lNMUOZWTLuC9A
+headers_to_remove:
+  - X-Generator
+  - X-Drupal-Dynamic-Cache
+  - X-Drupal-Cache
+  - X-Powered-By
+dependencies:
+  enforced:
+    module:
+      - remove_http_headers


### PR DESCRIPTION
# [AU-789](https://helsinkisolutionoffice.atlassian.net/browse/AU-789)
<!-- What problem does this solve? -->

## What was done

* Added and configure `remove_http_headers` module

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-789-remove-http-headers`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open the front page of the application and with your browsers inspector: Check network tab and see that there is no x-powered-by & x-generator headers in response.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-789]: https://helsinkisolutionoffice.atlassian.net/browse/AU-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ