### PR TITLE
fix: AU-2054 Budget page calculated subvention sum fix

### DIFF
--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -3,7 +3,6 @@
 namespace Drupal\grants_budget_components\Element;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\grants_handler\ApplicationHandler;
 
 /**
  * Provides a 'grants_budget_income_static'.

--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetIncomeStatic.php
@@ -3,6 +3,7 @@
 namespace Drupal\grants_budget_components\Element;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\grants_handler\ApplicationHandler;
 
 /**
  * Provides a 'grants_budget_income_static'.
@@ -84,8 +85,10 @@ class GrantsBudgetIncomeStatic extends GrantsBudgetStaticBase {
       $total += $floatVal;
     }
 
-    $element['#value'] = $total;
     $form_state->setValueForElement($element, $total);
+
+    // Convert value back to #inputMask format for the element.
+    $element['#value'] = str_replace('.', ',', $total);
 
     return $element;
   }


### PR DESCRIPTION
# [AU-2054](https://helsinkisolutionoffice.atlassian.net/browse/AU-2054)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Currently the budget subvention sum field will drop decimal point and the field will display wrong number. (eg. 343,22 becomes 34322)
* Format the form value to satisfy inputMask

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2054-calculated-sum-format-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-toiminta-av
* [ ] On page 2: Input subvention value with decimals (anything else than just zeroes)
* [ ] on page 4: Check that "Haettu avustus (€)" field displays the value correctly (decimals not dropping etc.)

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2054]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ