### PR TITLE
fix: AU-2065: Fix Swedish translation in grants_metadata

### DIFF
--- a/public/modules/custom/grants_metadata/translations/sv.po
+++ b/public/modules/custom/grants_metadata/translations/sv.po
@@ -11,19 +11,6 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-# Finnish translation of City of Helsinki Grants Metadata module
-#
-msgid ""
-msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2021-05-31 11:00+0300\n"
-"PO-Revision-Date: 2022-10-12 11:00+0300\n"
-"Last-Translator: NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgctxt "grants_metadata"
 msgid "Application details"
@@ -90,5 +77,5 @@ msgid "Attachment"
 msgstr "Bilaga"
 
 msgctxt "grants_handler"
-msgid 'Subvention type'
-msgstr 'Typ av bidrag'
+msgid "Subvention type"
+msgstr "Typ av bidrag"


### PR DESCRIPTION
# [AU-2065](https://helsinkisolutionoffice.atlassian.net/browse/AU-2065)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix malformed translation file in grants_metadata

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2065-grants_metadata-translation`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] run `make fresh` and see that there is no error about a malformed translation near the terminal logged line that says something like `>  [notice] Translations imported: 77 added, 15667 updated, 0 removed.` (numbers may vary)
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2065]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ