### PR TITLE
AU-2080: Remove constraint, as the postcode is not always required

### DIFF
--- a/public/modules/custom/grants_place_of_operation/src/TypedData/Definition/PlaceOfOperationDefinition.php
+++ b/public/modules/custom/grants_place_of_operation/src/TypedData/Definition/PlaceOfOperationDefinition.php
@@ -44,7 +44,6 @@ class PlaceOfOperationDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['postCode'] = DataDefinition::create('string')
-        ->addConstraint('NotBlank')
         ->addConstraint('ValidPostalCode')
         ->setSetting('jsonPath', [
           'postCode',

--- a/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCodeValidator.php
+++ b/public/modules/custom/grants_profile/src/Plugin/Validation/Constraint/ValidPostalCodeValidator.php
@@ -20,7 +20,7 @@ class ValidPostalCodeValidator extends ConstraintValidator {
    * {@inheritdoc}
    */
   public function validate($value, $constraint) {
-    if ($value !== NULL && !$this->isValidPostalCode($value)) {
+    if (($value !== NULL && $value !== '') && !$this->isValidPostalCode($value)) {
       $this->context->addViolation($constraint->notValidPostalCode, ['%value' => $value]);
     }
   }


### PR DESCRIPTION
# [AU-2080](https://helsinkisolutionoffice.atlassian.net/browse/AU-2080)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed NotBlank constraint, as this field is not marked as required always (Example: KASKO: Toiminta-avustushakemus koululaisten iltapäivätoiminnan järjestäjille).
* Added if case for `""` string, as webform values might be null or empty string

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2080-fix-postcode-validation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open a new https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-toiminta-av
* [ ] Fill the application as normal, but at page 3: leave `Postinumero `& `Euroa yhteensä lukuvuoden aikana (€)` (Behind the radio button selection) as empty / default values.
* [ ] Try to submit the application through integration.
* [ ] Validation should not fail due empty post code / 0,00 amount.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2080]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ