### PR TITLE
fix: AU-2082: fix typo and change description

### DIFF
--- a/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -175,6 +175,8 @@ elements: |
     '#title': 'Others (under 20 years of age)'
   joista_helsinkilaisia_muut_20:
     '#title': 'Number of Helsinki residents'
+  aktiiviharrastajat:
+    '#title': 'Active members'
   aktiiviharrastajat_fieldset:
     '#title': 'Active members'
     '#help': 'Active members are persons who have participated in regular guided activities at least 10 times over a period of 3 months during the previous operating year. A group must include at least 4 people and an instructor/coach.'
@@ -219,10 +221,10 @@ elements: |
   joista_valmentaja_ja_ohjaajakoulutuksen_vok_1_5_tason_koulutukse:
     '#title': 'Among them, the total number of persons who have completed levels 1–5  of the coach and instructor training is'
     '#help': 'In addition to the VOK 1 training arranged by regional sports organisations, the calculation accounts for the number of instructors and coaches who have completed a sports federation&rsquo;s coach and instructor training that are at least equal in terms of level and content, or who have completed a basic qualification in sports instruction (vocational college), a degree in sports instruction (university of applied sciences) or a master&rsquo;s degree in sports sciences (sports pedagogy or sports biology).'
-  lajijaostot_helsinkilaisille_aktiiviiharrastajille:
+  lajijaostot_helsinkilaisille_aktiiviharrastajille:
     '#title': 'Operating sport divisions for Helsinki residents'
   lajijaostot_info:
-    '#markup': "<p>List the regular guided sports activities organised by the club/association by sport. Indicate the actual practice hours completed last year.</p>\r\n\r\n<p>For example, if the same practice group has boys (1 person) and men (9 persons), the total hours (100 h) must be divided as follows: 10 hours is listed for boys and 90 hours listed is for men.</p>\r\n"
+    '#markup': "<p>List the regular guided sports activities organised by the club/association by sport. Enter here the number of active members from Helsinki in the previous year, by sport, as well as their realized training hours.</p>\r\n"
   lisatiedot_ja_liitteet:
     '#title': '4. Additional information and attachments'
   lisatietoja_hakemukseen_liittyen:

--- a/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -224,10 +224,10 @@ elements: |
   joista_valmentaja_ja_ohjaajakoulutuksen_vok_1_5_tason_koulutukse:
     '#title': 'Antalet personer bland dessa som har avlagt nivå 1–5 inom den nationella tränar- och instruktörsutbildningen'
     '#help': 'Ut&ouml;ver de VOK 1-utbildningar som ordnas av regionala idrottsorganisationer beaktas i ber&auml;kningen antalet handledare och tr&auml;nare som har genomg&aring;tt en utbildning f&ouml;r tr&auml;nare och handledare som ordnas av ett grenf&ouml;rbund p&aring; minst motsvarande niv&aring; och med motsvarande inneh&aring;ll eller som har avlagt grundexamen i idrott, idrottsinstrukt&ouml;r (YH) eller magisterexamen i idrottsvetenskaper (idrottspedagogik eller motionsbiologi).'
-  lajijaostot_helsinkilaisille_aktiiviiharrastajille:
+  lajijaostot_helsinkilaisille_aktiiviharrastajille:
     '#title': 'Aktiva grengsektioner för helsingforsare'
   lajijaostot_info:
-    '#markup': "<p>Regelbunden handledd idrottsverksamhet som ordnas av föreningen, enligt gren. Ange här antalet träningstimmar som genomförts under det föregående året.</p>\r\n\r\n<p>Om det till exempel finns både pojkar (1 pers.) och män (9 pers.) i samma träningsgrupp, ska det totala antalet timmar (100 h) i detta fall delas på följande sätt: för pojkar markeras 10 och för män 90 timmar.</p>\r\n"
+    '#markup': "<p>Regelbunden handledd idrottsverksamhet som ordnas av föreningen, enligt gren. Ange här antalet aktiva idrottsutövare från Helsingfors under föregående år, per sport, samt deras realiserade träningstimmar.</p>\r\n"
   lisatiedot_ja_liitteet:
     '#title': '4. Ytterligare information och bilagor'
   lisatietoja_hakemukseen_liittyen:

--- a/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -810,15 +810,13 @@ elements: |-
         '#attributes':
           class:
             - webform--small
-    lajijaostot_helsinkilaisille_aktiiviiharrastajille:
+    lajijaostot_helsinkilaisille_aktiiviharrastajille:
       '#type': webform_section
-      '#title': 'Lajijaostot helsinkiläisille aktiiviiharrastajille'
+      '#title': 'Lajijaostot helsinkiläisille aktiiviharrastajille'
       lajijaostot_info:
         '#type': webform_markup
         '#markup': |
-          <p>Seuran/yhdistyksen järjestämä säännöllinen ohjattu liikuntatoiminta lajeittain. Ilmoita tähän edellisen vuoden toteutuneet harjoitustunnit.</p>
-
-          <p>Esimerkiksi jos samassa harjoitusryhmässä on sekä poikia (1hlö) että miehiä (9hlöä), niin tässä tapauksessa kokonaistunnit (100h) jaetaan seuraavasti: pojille merkataan 10 ja miehille 90 tuntia</p>
+          <p>Seuran/yhdistyksen järjestämä säännöllinen ohjattu liikuntatoiminta lajeittain. Ilmoita tähän lajeittain edellisen vuoden helsinkiläisten aktiiviharrastajien määrät sekä heidän toteutuneet harjoitustunnit.</p>
       club_section:
         '#type': club_section_composite
         '#title': '<empty>'


### PR DESCRIPTION
# [AU-2082](https://helsinkisolutionoffice.atlassian.net/browse/AU-2082)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed typo on title and changed description

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2082-tilankaytto`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] [Open application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/liikunta_toiminta_ja_tilankaytto)
* [x] Go to page 3
* [x] Check that title "Lajijaostot helsinkiläisille aktiiviharrastajille" is correct, and has no typo
* [x] Check that description next to this title matches ticket
* [x] Repeat in SV and EN



[AU-2082]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ