### PR TITLE
feat: AU-2052: submisison notes field helper

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -877,9 +877,11 @@ class ApplicationHandler {
         // Lets mark that we don't want to generate new application
         // number, as we just assigned the serial from ATV application id.
         // check GrantsHandler@preSave.
-        // @todo https://helsinkisolutionoffice.atlassian.net/browse/AU-2052
-        $customSettings = ['skip_available_number_check' => TRUE];
-        $submissionObject->set('notes', JSON::encode($customSettings));
+        WebformSubmissionNotesHelper::setValue(
+          $submissionObject,
+          'skip_available_number_check',
+          TRUE
+        );
         if ($document->getStatus() == 'DRAFT') {
           $submissionObject->set('in_draft', TRUE);
         }
@@ -1974,8 +1976,11 @@ class ApplicationHandler {
     // Mark that we don't want to generate new application
     // number, as we just assigned the serial from ATV application id.
     // Check GrantsHandler@preSave.
-    $customSettings = ['skip_available_number_check' => TRUE];
-    $submissionObject->set('notes', JSON::encode($customSettings));
+    WebformSubmissionNotesHelper::setValue(
+      $submissionObject,
+      'skip_available_number_check',
+      TRUE
+    );
     if ($document->getStatus() == 'DRAFT') {
       $submissionObject->set('in_draft', TRUE);
     }

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -18,6 +18,7 @@ use Drupal\grants_handler\FormLockService;
 use Drupal\grants_handler\GrantsErrorStorage;
 use Drupal\grants_handler\GrantsException;
 use Drupal\grants_handler\GrantsHandlerNavigationHelper;
+use Drupal\grants_handler\WebformSubmissionNotesHelper;
 use Drupal\grants_mandate\CompanySelectException;
 use Drupal\grants_profile\GrantsProfileService;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
@@ -1211,12 +1212,13 @@ class GrantsHandler extends WebformHandlerBase {
       // submissionObjectFromApplicationNumber@ApplicationHandler sets already
       // a correct serial id from ATV document. But
       // initApplication@ApplicationHandler needs a new unused application id.
-      // @todo notes field handling to separate service etc.
-      $notes = $webform_submission->get('notes')->value;
-      $customSettings = Json::decode($notes);
 
-      if (isset($customSettings['skip_available_number_check']) &&
-        $customSettings['skip_available_number_check'] === TRUE) {
+      $skipCheck = WebformSubmissionNotesHelper::getValue(
+        $webform_submission,
+        'skip_available_number_check',
+      );
+
+      if ($skipCheck === TRUE) {
         $this->applicationNumber = ApplicationHandler::createApplicationNumber($webform_submission);
       }
       else {

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\grants_handler\Plugin\WebformHandler;
 
-use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Datetime\DrupalDateTime;
@@ -1212,7 +1211,6 @@ class GrantsHandler extends WebformHandlerBase {
       // submissionObjectFromApplicationNumber@ApplicationHandler sets already
       // a correct serial id from ATV document. But
       // initApplication@ApplicationHandler needs a new unused application id.
-
       $skipCheck = WebformSubmissionNotesHelper::getValue(
         $webform_submission,
         'skip_available_number_check',

--- a/public/modules/custom/grants_handler/src/WebformSubmissionNotesHelper.php
+++ b/public/modules/custom/grants_handler/src/WebformSubmissionNotesHelper.php
@@ -18,8 +18,7 @@ class WebformSubmissionNotesHelper {
    */
   private static function getCustomData(WebformSubmissionInterface $submission) {
     $data = $submission->get('notes')->value;
-    $values = Json::decode($data);
-    return $values;
+    return Json::decode($data);
   }
 
   /**
@@ -30,7 +29,7 @@ class WebformSubmissionNotesHelper {
    * @param array|null $values
    *   Values to be saved. This will be Json encoded, unless the value is null.
    */
-  private static function setValues(WebformSubmissionInterface $submission, $values) {
+  private static function setValues(WebformSubmissionInterface $submission, ?array $values): void {
     if (empty($values)) {
       $submission->set('notes', NULL);
       return;
@@ -49,7 +48,7 @@ class WebformSubmissionNotesHelper {
    * @param mixed $value
    *   Value to be saved, needs to be json serializable.
    */
-  public static function setValue(WebformSubmissionInterface $submission, $key, $value) {
+  public static function setValue(WebformSubmissionInterface $submission, string $key, mixed $value): void {
     $values = self::getCustomData($submission);
     $values[$key] = $value;
     self::setValues($submission, $values);
@@ -63,7 +62,7 @@ class WebformSubmissionNotesHelper {
    * @param string $key
    *   Key to remove.
    */
-  public static function removeValue(WebformSubmissionInterface $submission, $key) {
+  public static function removeValue(WebformSubmissionInterface $submission, string $key): void {
     $values = self::getCustomData($submission);
     unset($values[$key]);
     self::setValues($submission, $values);
@@ -80,7 +79,7 @@ class WebformSubmissionNotesHelper {
    * @return mixed
    *   Value from the notes field or NULL if not found.
    */
-  public static function getValue(WebformSubmissionInterface $submission, $key) {
+  public static function getValue(WebformSubmissionInterface $submission, string $key): mixed {
     $customValues = self::getCustomData($submission);
     if (!isset($customValues[$key])) {
       return NULL;

--- a/public/modules/custom/grants_handler/src/WebformSubmissionNotesHelper.php
+++ b/public/modules/custom/grants_handler/src/WebformSubmissionNotesHelper.php
@@ -6,22 +6,29 @@ use Drupal\Component\Serialization\Json;
 use Drupal\webform\WebformSubmissionInterface;
 
 /**
- *
+ * Helper class to handle custom data saved in submissions notes field.
  */
 class WebformSubmissionNotesHelper {
 
   /**
+   * Get all custom values from the notes field.
    *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission object.
    */
   private static function getCustomData(WebformSubmissionInterface $submission) {
     $data = $submission->get('notes')->value;
     $values = Json::decode($data);
-    $error = json_last_error();
     return $values;
   }
 
   /**
+   * Updates custom data to the submission object.
    *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission object.
+   * @param array|null $values
+   *   Values to be saved. This will be Json encoded, unless the value is null.
    */
   private static function setValues(WebformSubmissionInterface $submission, $values) {
     if (empty($values)) {
@@ -33,7 +40,14 @@ class WebformSubmissionNotesHelper {
   }
 
   /**
+   * Sets value to specific key.
    *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission object.
+   * @param string $key
+   *   Key where the value is stored.
+   * @param mixed $value
+   *   Value to be saved, needs to be json serializable.
    */
   public static function setValue(WebformSubmissionInterface $submission, $key, $value) {
     $values = self::getCustomData($submission);
@@ -42,7 +56,12 @@ class WebformSubmissionNotesHelper {
   }
 
   /**
+   * Remove a value by key.
    *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission object.
+   * @param string $key
+   *   Key to remove.
    */
   public static function removeValue(WebformSubmissionInterface $submission, $key) {
     $values = self::getCustomData($submission);
@@ -51,7 +70,15 @@ class WebformSubmissionNotesHelper {
   }
 
   /**
+   * Get a value by key.
    *
+   * @param \Drupal\webform\WebformSubmissionInterface $submission
+   *   The submission object.
+   * @param string $key
+   *   Key to return.
+   *
+   * @return mixed
+   *   Value from the notes field or NULL if not found.
    */
   public static function getValue(WebformSubmissionInterface $submission, $key) {
     $customValues = self::getCustomData($submission);

--- a/public/modules/custom/grants_handler/src/WebformSubmissionNotesHelper.php
+++ b/public/modules/custom/grants_handler/src/WebformSubmissionNotesHelper.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\grants_handler;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ *
+ */
+class WebformSubmissionNotesHelper {
+
+  /**
+   *
+   */
+  private static function getCustomData(WebformSubmissionInterface $submission) {
+    $data = $submission->get('notes')->value;
+    $values = Json::decode($data);
+    $error = json_last_error();
+    return $values;
+  }
+
+  /**
+   *
+   */
+  private static function setValues(WebformSubmissionInterface $submission, $values) {
+    if (empty($values)) {
+      $submission->set('notes', NULL);
+      return;
+    }
+
+    $submission->set('notes', Json::encode($values));
+  }
+
+  /**
+   *
+   */
+  public static function setValue(WebformSubmissionInterface $submission, $key, $value) {
+    $values = self::getCustomData($submission);
+    $values[$key] = $value;
+    self::setValues($submission, $values);
+  }
+
+  /**
+   *
+   */
+  public static function removeValue(WebformSubmissionInterface $submission, $key) {
+    $values = self::getCustomData($submission);
+    unset($values[$key]);
+    self::setValues($submission, $values);
+  }
+
+  /**
+   *
+   */
+  public static function getValue(WebformSubmissionInterface $submission, $key) {
+    $customValues = self::getCustomData($submission);
+    if (!isset($customValues[$key])) {
+      return NULL;
+    }
+
+    return $customValues[$key];
+  }
+
+}

--- a/public/modules/custom/grants_handler/tests/src/Kernel/DataConversionTest.php
+++ b/public/modules/custom/grants_handler/tests/src/Kernel/DataConversionTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\grants_handler\Kernel\TestDataConversion;
 
-use Drupal\Component\Serialization\Json;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 use Drupal\grants_handler\ApplicationHandler;

--- a/public/modules/custom/grants_handler/tests/src/Kernel/DataConversionTest.php
+++ b/public/modules/custom/grants_handler/tests/src/Kernel/DataConversionTest.php
@@ -7,6 +7,7 @@ use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 use Drupal\grants_handler\ApplicationHandler;
 use Drupal\grants_handler\GrantsHandlerSubmissionStorage;
+use Drupal\grants_handler\WebformSubmissionNotesHelper;
 use Drupal\grants_test_base\Kernel\GrantsKernelTestBase;
 use Drupal\helfi_atv\AtvDocument;
 use Drupal\webform\Entity\WebformSubmission;
@@ -69,8 +70,11 @@ class DataConversionTest extends GrantsKernelTestBase implements ServiceModifier
     $this->initSession();
     $submissionObject = WebformSubmission::create(['webform_id' => 'kuva_projekti']);
     $submissionObject->set('serial', 'TEST-1234');
-    $customSettings = ['skip_available_number_check' => TRUE];
-    $submissionObject->set('notes', JSON::encode($customSettings));
+    WebformSubmissionNotesHelper::setValue(
+      $submissionObject,
+      'skip_available_number_check',
+      TRUE
+    );
     $submissionObject->set('in_draft', TRUE);
     $applicationTypes = [
       'KUVAPROJ' => [

--- a/public/modules/custom/grants_handler/tests/src/Kernel/WebformSubmissionNotesHelperTest.php
+++ b/public/modules/custom/grants_handler/tests/src/Kernel/WebformSubmissionNotesHelperTest.php
@@ -4,20 +4,15 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\grants_handler\Kernel;
 
-use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
-use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
-use Drupal\Core\Entity\EntityStorageException;
-use Drupal\Core\Entity\Exception\AmbiguousBundleClassException;
 use Drupal\grants_handler\WebformSubmissionNotesHelper;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform\WebformSubmissionInterface;
-use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
-/** @package Drupal\Tests\grants_handler\Kernel */
+/**
+ * Test WebformSubmissionNotesHelper class.
+ */
 class WebformSubmissionNotesHelperTest extends KernelTestBase {
 
   /**
@@ -40,7 +35,10 @@ class WebformSubmissionNotesHelperTest extends KernelTestBase {
   }
 
   /**
-   * @return WebformSubmissionInterface
+   * Get an empty submission object.
+   *
+   * @return \Drupal\webform\WebformSubmissionInterface
+   *   Empty submission object.
    */
   private function getSubmissionObject(): WebformSubmissionInterface {
     $webform = Webform::create(['id' => 'webform_test', 'title' => 'Test']);
@@ -56,6 +54,9 @@ class WebformSubmissionNotesHelperTest extends KernelTestBase {
     return WebformSubmission::create($values);
   }
 
+  /**
+   * Test for getting values.
+   */
   public function testSetSingleValue() {
     $submission = $this->getSubmissionObject();
     WebformSubmissionNotesHelper::setValue($submission, 'test_value', 'foo');
@@ -66,6 +67,9 @@ class WebformSubmissionNotesHelperTest extends KernelTestBase {
     $this->assertEquals($testValue, 'foo');
   }
 
+  /**
+   * Tests for value removals.
+   */
   public function testRemoveValue() {
     $submission = $this->getSubmissionObject();
     WebformSubmissionNotesHelper::setValue($submission, 'foo', 'bar');
@@ -86,16 +90,6 @@ class WebformSubmissionNotesHelperTest extends KernelTestBase {
     $this->assertEquals($userValue, NULL);
     // Removing the last custom value should change field value to null.
     $this->assertEquals($rawField, NULL);
-
   }
-
-  public function testNonJsonValue() {
-    $submission = $this->getSubmissionObject();
-    $submission->set('notes', 'foobar');
-    WebformSubmissionNotesHelper::getValue($submission, 'test');
-
-  }
-
 
 }
-

--- a/public/modules/custom/grants_handler/tests/src/Kernel/WebformSubmissionNotesHelperTest.php
+++ b/public/modules/custom/grants_handler/tests/src/Kernel/WebformSubmissionNotesHelperTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\grants_handler\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\Entity\Exception\AmbiguousBundleClassException;
+use Drupal\grants_handler\WebformSubmissionNotesHelper;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\webform\Entity\Webform;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\webform\WebformSubmissionInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/** @package Drupal\Tests\grants_handler\Kernel */
+class WebformSubmissionNotesHelperTest extends KernelTestBase {
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = ['system', 'webform', 'user', 'field'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installSchema('webform', ['webform']);
+    $this->installConfig('webform');
+    $this->installEntitySchema('webform_submission');
+    $this->installEntitySchema('user');
+  }
+
+  /**
+   * @return WebformSubmissionInterface
+   */
+  private function getSubmissionObject(): WebformSubmissionInterface {
+    $webform = Webform::create(['id' => 'webform_test', 'title' => 'Test']);
+    $webform->save();
+
+    // Create webform submission.
+    $values = [
+      'id' => 'webform_submission_test',
+      'webform_id' => $webform->id(),
+      'data' => ['name' => 'John Smith'],
+    ];
+    /** @var \Drupal\webform\WebformSubmissionInterface $webform_submission */
+    return WebformSubmission::create($values);
+  }
+
+  public function testSetSingleValue() {
+    $submission = $this->getSubmissionObject();
+    WebformSubmissionNotesHelper::setValue($submission, 'test_value', 'foo');
+    $rawField = $submission->get('notes')->value;
+    $testValue = WebformSubmissionNotesHelper::getValue($submission, 'test_value');
+
+    $this->assertEquals($rawField, '{"test_value":"foo"}');
+    $this->assertEquals($testValue, 'foo');
+  }
+
+  public function testRemoveValue() {
+    $submission = $this->getSubmissionObject();
+    WebformSubmissionNotesHelper::setValue($submission, 'foo', 'bar');
+    WebformSubmissionNotesHelper::setValue($submission, 'user', 'testuser');
+
+    WebformSubmissionNotesHelper::removeValue($submission, 'foo');
+
+    $fooValue = WebformSubmissionNotesHelper::getValue($submission, 'foo');
+    $rawField = $submission->get('notes')->value;
+
+    $this->assertEquals($fooValue, NULL);
+    $this->assertEquals($rawField, '{"user":"testuser"}');
+
+    WebformSubmissionNotesHelper::removeValue($submission, 'user');
+    $userValue = WebformSubmissionNotesHelper::getValue($submission, 'user');
+    $rawField = $submission->get('notes')->value;
+
+    $this->assertEquals($userValue, NULL);
+    // Removing the last custom value should change field value to null.
+    $this->assertEquals($rawField, NULL);
+
+  }
+
+  public function testNonJsonValue() {
+    $submission = $this->getSubmissionObject();
+    $submission->set('notes', 'foobar');
+    WebformSubmissionNotesHelper::getValue($submission, 'test');
+
+  }
+
+
+}
+


### PR DESCRIPTION
# [AU-2052](https://helsinkisolutionoffice.atlassian.net/browse/AU-2052)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* We have some custom data saved to submissions notes field. Change this data handling to it's own helper class.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2052-submisison-notes-field-helper`
  * `make fresh`
* Run `make drush-cr`

## How to test

Maybe bit hard to test: but


* [ ] You can purge all submissions with "drush webform:purge --all"
* [ ] Add debugger to ApplicationHandler where new class is called and check the flow.
* [ ] Visit https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi/hakuprofiili to trigger webmission creation where we want to do the application number skipping.
* [ ] Run test with `make shell` &&  `vendor/phpunit/phpunit/phpunit public/modules/custom/grants_handler/`



[AU-2052]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ