### PR TITLE
AU-2107: Filter submission saved message in EN forms

### DIFF
--- a/conf/cmi/disable_messages.settings.yml
+++ b/conf/cmi/disable_messages.settings.yml
@@ -6,7 +6,7 @@ disable_messages_filter_by_page: 1
 disable_messages_page_filter_paths: 'admin/*'
 disable_messages_enable_debug: '0'
 disable_messages_debug_visible_div: '0'
-disable_messages_ignore_patterns: "User logged in and data fetched\r\nTo log in to this site, your browser must accept cookies from the domain\r\nYou have already submitted this webform.+\r\nUnable to send email. Contact the site administrator if the problem persists.\r\nThere was a problem sending.+\r\nKunde inte skicka e-post. Kontakta webbplatsens administratör om problemet kvarstår. \r\nSähköpostin lähettäminen epäonnistui. Ota yhteyttä sivuston ylläpitäjään, jos ongelma toistuu.\r\nA partially-completed form was found. Please complete the remaining portions.\r\nTiedot tallennettu. Voit palata tähän lomakkeeseen myöhemmin ja palauttaa nykyiset tiedot.\r\nFormulär sparat. Du kan återvända till detta formulär senare och fortsätta inmatningen."
+disable_messages_ignore_patterns: "User logged in and data fetched\r\nTo log in to this site, your browser must accept cookies from the domain\r\nYou have already submitted this webform.+\r\nUnable to send email. Contact the site administrator if the problem persists.\r\nThere was a problem sending.+\r\nKunde inte skicka e-post. Kontakta webbplatsens administratör om problemet kvarstår. \r\nSähköpostin lähettäminen epäonnistui. Ota yhteyttä sivuston ylläpitäjään, jos ongelma toistuu.\r\nA partially-completed form was found. Please complete the remaining portions.\r\nTiedot tallennettu. Voit palata tähän lomakkeeseen myöhemmin ja palauttaa nykyiset tiedot.\r\nFormulär sparat. Du kan återvända till detta formulär senare och fortsätta inmatningen.\r\nSubmission saved. You may return to this form later and it will restore the current values."
 disable_messages_enable_permissions: '0'
 disable_messages_ignore_exclude: '0'
 disable_messages_ignore_case: '1'
@@ -22,3 +22,4 @@ disable_messages_ignore_regex:
   - '/^A partially-completed form was found. Please complete the remaining portions.$/i'
   - '/^Tiedot tallennettu. Voit palata tähän lomakkeeseen myöhemmin ja palauttaa nykyiset tiedot.$/i'
   - '/^Formulär sparat. Du kan återvända till detta formulär senare och fortsätta inmatningen.$/i'
+  - '/^Submission saved. You may return to this form later and it will restore the current values.$/i'


### PR DESCRIPTION
# [AU-2107](https://helsinkisolutionoffice.atlassian.net/browse/AU-2107)
<!-- What problem does this solve? -->

## What was done

* Filter out default webform submission saved message on EN forms.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2107-disable-webform-submission-message?`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any application: https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kasko_ip_lisa
* [ ] Change language to english.
* [ ] Change webform pages and make sure that no status message will be displayed with text: "Submission saved. You may return to this form later and it will restore the current values"


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2107]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ