### PR TITLE
fix: AU-1056: Add translations for statuses

### DIFF
--- a/conf/cmi/grants_handler.settings.yml
+++ b/conf/cmi/grants_handler.settings.yml
@@ -4,6 +4,7 @@ statusStrings:
     SENT: Sent
     SUBMITTED: Submitted
     RECEIVED: Received
+    PREPARING: Preparing
     PENDING: Pending
     PROCESSING: 'In Progress'
     READY: Ready
@@ -13,11 +14,13 @@ statusStrings:
     CANCELED: Canceled
     CANCELLED: Canceled
     CLOSED: Closed
+    RESOLVED: Resolved
   fi:
     DRAFT: Luonnos
     SENT: Lähetetty
     SUBMITTED: 'Lähetetty - odotetaan vahvistusta'
     RECEIVED: Vastaanotettu
+    PREPARING: Avustusvalmistelussa
     PENDING: Odottaa
     PROCESSING: Käsittelyssä
     READY: Valmiina
@@ -27,11 +30,13 @@ statusStrings:
     CANCELED: Peruttu
     CANCELLED: Peruttu
     CLOSED: Suljettu
+    RESOLVED: Valmis
   sv:
     DRAFT: Utkast
     SENT: Skickas
     SUBMITTED: Lämnats
     RECEIVED: Mottagits
+    PREPARING: 'Beredning av understöd'
     PENDING: 'I väntan på'
     PROCESSING: Behandlas
     READY: Redo
@@ -41,4 +46,5 @@ statusStrings:
     CANCELED: Annulerad
     CANCELLED: Inställt
     CLOSED: Stängd
+    RESOLVED: Färdig
 langcode: fi

--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -256,6 +256,7 @@ third_party_options:
     CANCELED: CANCELED
     CANCELLED: CANCELLED
     CLOSED: CLOSED
+    RESOLVED: RESOLVED
   subvention_types:
     1: 'Operating grant'
     2: 'Wage subsidy'


### PR DESCRIPTION
# [AU-1056](https://helsinkisolutionoffice.atlassian.net/browse/AU-1056)
<!-- What problem does this solve? -->

Translations for new statuses were missing, this adds them.



[AU-1056]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ