### PR TITLE
fix: AU-2130: news item title

### DIFF
--- a/conf/cmi/block.block.sivunotsikko.yml
+++ b/conf/cmi/block.block.sivunotsikko.yml
@@ -21,4 +21,4 @@ visibility:
   request_path:
     id: request_path
     negate: true
-    pages: "/hakemus/*/katso\r\n/news\r\n/news/*\r\n/tietoa-avustuksista/ukk\r\n/tietoa-avustuksista/ukk/*\r\n/etsi-avustusta\r\n/etsi-avustusta/*\r\n/hakemus/*\r\n/user/login\r\n/oma-asiointi\r\n/oma-asiointi/*"
+    pages: "/hakemus/*/katso\r\n/news\r\n/tietoa-avustuksista/ukk\r\n/tietoa-avustuksista/ukk/*\r\n/etsi-avustusta\r\n/etsi-avustusta/*\r\n/hakemus/*\r\n/user/login\r\n/oma-asiointi\r\n/oma-asiointi/*"


### PR DESCRIPTION
# [AU-2130](https://helsinkisolutionoffice.atlassian.net/browse/AU-2130)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* news_item title in english was restored

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2130-english-new-title`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to an [english language news item](https://hel-fi-drupal-grant-applications.docker.so/en/news/news-grants-application-renewed)
* [ ] See that there is a title.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2130]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ