### PR TITLE
fix: AU-2135: Fixed sport name translations in the Club section composite element

### DIFF
--- a/public/modules/custom/grants_club_section/src/TypedData/Definition/GrantsClubSectionDefinition.php
+++ b/public/modules/custom/grants_club_section/src/TypedData/Definition/GrantsClubSectionDefinition.php
@@ -20,6 +20,10 @@ class GrantsClubSectionDefinition extends ComplexDataDefinitionBase {
       $info['sectionName'] = DataDefinition::create('string')
         ->setSetting('jsonPath', [
           'sectionName',
+        ])
+        ->setSetting('webformValueExtracter', [
+          'service' => 'grants_metadata.converter',
+          'method' => 'convertSportName',
         ]);
 
       $info['sectionOther'] = DataDefinition::create('string')

--- a/public/modules/custom/grants_metadata/src/GrantsConverterService.php
+++ b/public/modules/custom/grants_metadata/src/GrantsConverterService.php
@@ -86,10 +86,12 @@ class GrantsConverterService {
    * 3. Return the value 'Football' back through the t() function.
    *
    * @param array|string $value
-   *   The sport name or an array containing the 'value' key with the sport name.
+   *   The sport name or an array containing the 'value'
+   *   key with the sport name.
    *
    * @return string
-   *   English (source string) version of a sports name, passed through the t() function.
+   *   English (source string) version of a sports name,
+   *   passed through the t() function.
    */
   public function convertSportName(array|string $value): string {
     /** @var \Drupal\locale\StringDatabaseStorage $storage */
@@ -103,19 +105,20 @@ class GrantsConverterService {
 
     $translationEntry = $storage->getTranslations([
       'translation' => $original,
-      ...$tOpts,
+      'context' => 'grants_club_section',
       'translated' => TRUE,
     ]);
 
     if (!empty($translationEntry)) {
       /** @var \Drupal\locale\TranslationString $translationEntry */
       $translationEntry = reset($translationEntry);
+
       if ($translationEntry instanceof TranslationString) {
-        return $this->t($translationEntry->source, [], $tOpts);
+        return $this->t($translationEntry->source, [], $tOpts); // phpcs:ignore
       }
     }
 
-    return $this->t($original, [], $tOpts);
+    return $this->t($original, [], $tOpts); // phpcs:ignore
   }
 
   /**

--- a/public/modules/custom/grants_metadata/src/GrantsConverterService.php
+++ b/public/modules/custom/grants_metadata/src/GrantsConverterService.php
@@ -2,10 +2,15 @@
 
 namespace Drupal\grants_metadata;
 
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\locale\TranslationString;
+
 /**
  * Provide useful helper for converting values.
  */
 class GrantsConverterService {
+
+  use StringTranslationTrait;
 
   const DEFAULT_DATETIME_FORMAT = 'c';
 
@@ -58,6 +63,59 @@ class GrantsConverterService {
     }
 
     return str_replace('.', ',', $value);
+  }
+
+  /**
+   * The convertSportName method.
+   *
+   * This method attempts to convert any translated sport names
+   * (Finnish or Swedish) back to the original English
+   * name. If a translation is found, the translations source
+   * string (the English version) is returned through
+   * the t() function. Otherwise, the passed in value is just
+   * returned through the t() function.
+   *
+   * Ex. 1,  $value = 'Käsipallo'.
+   * 1. Look for a translation entry for the string 'Käsipallo'.
+   * 2. If one is found, get the source string, which is 'Handball'.
+   * 3. Return the value 'Handball' back through the t() function.
+   *
+   * Ex. 2,  $value = 'Football'.
+   * 1. Look for a translation entry for the string 'Football'.
+   * 2. A translation won't be found since it is the source translation.
+   * 3. Return the value 'Football' back through the t() function.
+   *
+   * @param array|string $value
+   *   The sport name or an array containing the 'value' key with the sport name.
+   *
+   * @return string
+   *   English (source string) version of a sports name, passed through the t() function.
+   */
+  public function convertSportName(array|string $value): string {
+    /** @var \Drupal\locale\StringDatabaseStorage $storage */
+    $storage = \Drupal::service('locale.storage');
+    $tOpts = ['context' => 'grants_club_section'];
+    $original = $value['value'] ?? $value;
+
+    if (empty($original)) {
+      return '';
+    }
+
+    $translationEntry = $storage->getTranslations([
+      'translation' => $original,
+      ...$tOpts,
+      'translated' => TRUE,
+    ]);
+
+    if (!empty($translationEntry)) {
+      /** @var \Drupal\locale\TranslationString $translationEntry */
+      $translationEntry = reset($translationEntry);
+      if ($translationEntry instanceof TranslationString) {
+        return $this->t($translationEntry->source, [], $tOpts);
+      }
+    }
+
+    return $this->t($original, [], $tOpts);
   }
 
   /**


### PR DESCRIPTION
# [AU-2135](https://helsinkisolutionoffice.atlassian.net/browse/AU-2135)

## What was done
This pull request fixes an issue with the `Sport dropdown` selector in the `Club section composite element`. The element saves the translated version of a selected sport name in ATV. If a user goes back to an application that was previously saved as a draft and then changes languages, then the previously selected value won't work, since the stored value is in the wrong language.

After this change, the stored ATV value is converted back to the original, English version, and then returned to the select dropdown through the t() function, which translates the selected sport to the correct value.

![Screenshot 2024-02-08 at 15 33 54](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/c3e9c8c9-0967-4e91-b3c0-ce7605cf49ea)

## How to install
Make sure your instance is up and running on the correct branch.
  * `git checkout feature/AU-2135-club-section-composite-bug`
  * `make fresh`
  * `make drush-cr`

## How to test
- Start filling in the form `Liikunta, toiminta- ja tilankäyttöavustushakemus` since it has the composite element in question. I had to add the from to a `Service page`, since one didn't exist from before. Do this in the `Finnish` language.

- Go to page 3 of the application and select a value from the `Sport dropdown`. Now save the application as a draft.

- Edit the same application and change the language to `Swedish`. Check that the value in the `Sport dropdown` menu has changed according to the sport that you selected on the Finnish version of the application.

- Repeat these steps with a few sports and various languages. Make sure that the selected sport stays as the desired value.

- Review the code.


[AU-2135]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ