### PR TITLE
fix: AU-2137: missing translations

### DIFF
--- a/conf/cmi/language/en/webform.webform.leiriselvitys.yml
+++ b/conf/cmi/language/en/webform.webform.leiriselvitys.yml
@@ -6,6 +6,8 @@ elements: |
     '#next_button_label': 'Next >'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">The indicated information has been retrieved from the register of the Finnish Patent and Registration Office (PRH), and changing the information is only possible in the online service in question.</div>'
+  hakemusprofiili:
+    '#title': 'Retrieved information'
   hakijan_tiedot:
     '#title': Applicant
   contact_person_email_section:

--- a/conf/cmi/language/sv/webform.webform.leiriselvitys.yml
+++ b/conf/cmi/language/sv/webform.webform.leiriselvitys.yml
@@ -6,6 +6,8 @@ elements: |
     '#next_button_label': 'Nästa >'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har hämtats från Patent- och registerstyrelsens register (PRH) och det är endast möjligt att ändra uppgifterna i nättjänsten i fråga.</div>'
+  hakemusprofiili:
+    '#title': 'Hämtade uppgifter'
   hakijan_tiedot:
     '#title': Sökande
   contact_person_email_section:


### PR DESCRIPTION
# [AU-2137](https://helsinkisolutionoffice.atlassian.net/browse/AU-2137)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2137-translation-leiriselvitys`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Leiriselvitys](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/leiriselvitys)
* [ ] Check that Haetut tiedot on page 1 is translated correctly in english and swedish
* [ ] When saving the document, see that the translation carries over to the preview and saved/sent data pages on both languages
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2137]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ