### PR TITLE
fix: AU-2147: add checks to remove error messages

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
+++ b/public/modules/custom/grants_applicant_info/src/ApplicantInfoService.php
@@ -320,25 +320,25 @@ class ApplicantInfoService {
       $addressElement = [
         [
           'ID' => 'street',
-          'value' => $profile["addresses"][0]["street"],
+          'value' => $profile["addresses"][0]["street"] ?? '',
           'valueType' => 'string',
           'label' => 'Katuosoite',
         ],
         [
           'ID' => 'city',
-          'value' => $profile["addresses"][0]["city"],
+          'value' => $profile["addresses"][0]["city"] ?? '',
           'valueType' => 'string',
           'label' => 'Postitoimipaikka',
         ],
         [
           'ID' => 'postCode',
-          'value' => $profile["addresses"][0]["postCode"],
+          'value' => $profile["addresses"][0]["postCode"] ?? '',
           'valueType' => 'string',
           'label' => 'Postinumero',
         ],
         [
           'ID' => 'country',
-          'value' => $profile["addresses"][0]["country"],
+          'value' => $profile["addresses"][0]["country"] ?? '',
           'valueType' => 'string',
           'label' => 'Postinumero',
         ],

--- a/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
+++ b/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
@@ -125,7 +125,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       '#title' => t('First name'),
       '#readonly' => TRUE,
       '#required' => TRUE,
-      '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["firstName"],
+      '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["firstName"] ?? '',
       '#wrapper_attributes' => [
         'class' => ['grants-handler--prefilled-field'],
       ],
@@ -136,7 +136,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       '#title' => t('Last name'),
       '#readonly' => TRUE,
       '#required' => TRUE,
-      '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["lastName"],
+      '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["lastName"] ?? '',
       '#wrapper_attributes' => [
         'class' => ['grants-handler--prefilled-field'],
       ],
@@ -146,7 +146,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       '#title' => t('Social security number'),
       '#readonly' => TRUE,
       '#required' => TRUE,
-      '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["nationalIdentificationNumber"],
+      '#value' => $userData["myProfile"]["verifiedPersonalInformation"]["nationalIdentificationNumber"] ?? '',
       '#wrapper_attributes' => [
         'class' => ['grants-handler--prefilled-field'],
       ],
@@ -156,7 +156,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       '#title' => t('Email'),
       '#readonly' => TRUE,
       '#required' => TRUE,
-      '#value' => $userData["myProfile"]["primaryEmail"]["email"],
+      '#value' => $userData["myProfile"]["primaryEmail"]["email"] ?? '',
       '#wrapper_attributes' => [
         'class' => ['grants-handler--prefilled-field'],
       ],
@@ -167,7 +167,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       '#title' => t('Street address'),
       '#readonly' => TRUE,
       '#required' => TRUE,
-      '#value' => $profileContent["addresses"][0]["street"],
+      '#value' => $profileContent["addresses"][0]["street"] ?? '',
       '#wrapper_attributes' => [
         'class' => ['grants-handler--prefilled-field'],
       ],
@@ -177,7 +177,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       '#title' => t('City'),
       '#readonly' => TRUE,
       '#required' => TRUE,
-      '#value' => $profileContent["addresses"][0]["city"],
+      '#value' => $profileContent["addresses"][0]["city"] ?? '',
       '#wrapper_attributes' => [
         'class' => ['grants-handler--prefilled-field'],
       ],
@@ -187,7 +187,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
       '#title' => t('Postal code'),
       '#readonly' => TRUE,
       '#required' => TRUE,
-      '#value' => $profileContent["addresses"][0]["postCode"],
+      '#value' => $profileContent["addresses"][0]["postCode"] ?? '',
       '#wrapper_attributes' => [
         'class' => ['grants-handler--prefilled-field'],
       ],

--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1283,12 +1283,12 @@ class ApplicationHandler {
         'applicant_type' => $selectedCompany["type"],
         'firstname' => $userData["given_name"],
         'lastname' => $userData["family_name"],
-        'socialSecurityNumber' => $userProfileData["myProfile"]["verifiedPersonalInformation"]["nationalIdentificationNumber"],
+        'socialSecurityNumber' => $userProfileData["myProfile"]["verifiedPersonalInformation"]["nationalIdentificationNumber"] ?? '',
         'email' => $userData["email"],
-        'street' => $companyData["addresses"][0]["street"],
-        'city' => $companyData["addresses"][0]["city"],
-        'postCode' => $companyData["addresses"][0]["postCode"],
-        'country' => $companyData["addresses"][0]["country"],
+        'street' => $companyData["addresses"][0]["street"] ?? '',
+        'city' => $companyData["addresses"][0]["city"] ?? '',
+        'postCode' => $companyData["addresses"][0]["postCode"] ?? '',
+        'country' => $companyData["addresses"][0]["country"] ?? '',
       ];
     }
     // Data must match the format of typed data, not the webform format.

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -203,7 +203,7 @@ you can do that by going to the Helsinki-profile from this link.', [], $this->tO
 
     $form['#basic_info'] = [
       '#theme' => 'grants_profile__basic_info__private_person',
-      '#myProfile' => $helsinkiProfileContent['myProfile'],
+      '#myProfile' => $helsinkiProfileContent['myProfile'] ?? '',
       '#editHelsinkiProfileLink' => $editHelsinkiProfileLink,
     ];
 


### PR DESCRIPTION
# [AU-2147](https://helsinkisolutionoffice.atlassian.net/browse/AU-2147)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add checks to remove warnings in private person profile

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2147-private-person-errors`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login with an user you have not created a private person profile
* [ ] Try to open an application with private person access ([for example](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_pienavustushake))
* [ ] Check that no warnings show up when redirected to Omat tiedot


[AU-2147]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ