### PR TITLE
fix :AU-2151 Fix budget field from duplicating after copying an application.

### DIFF
--- a/docker/openshift/entrypoints/90-deploy.sh
+++ b/docker/openshift/entrypoints/90-deploy.sh
@@ -34,14 +34,17 @@ if [ "$DRUSH_GET_VAR" != "$PREFIXED_OC_BUILD_NAME" ]; then
   fi
 
   # Put site in maintenance mode
-  echo "Site to mainenance"
+  echo "Site to maintenance"
   drush state:set system.maintenance_mode 1 --input-format=integer
+  echo "DONE: Site to maintenance"
 
   APP_ENV=${APP_ENV:-default}
 
   echo "Import configs"
   # import configs & overrides.
+  echo "DONE: Import configs"
 
+  echo "Import webform configs"
   if [ "$APP_ENV" == 'staging' ] || [ "$APP_ENV" == 'development' ] || [ "$APP_ENV" == 'testing' ]; then
     drush gwi --force
   fi
@@ -49,14 +52,16 @@ if [ "$DRUSH_GET_VAR" != "$PREFIXED_OC_BUILD_NAME" ]; then
   if [ "$APP_ENV" == 'production' ] || [ "$APP_ENV" == 'default' ]; then
     drush gwi
   fi
-
+  echo "DONE: Import webform configs"
 
   echo "Import overrides."
   drush gwco
+  echo "DONE: Import overrides."
 
   echo "Disable Maintenance"
   # Disable maintenance mode
   drush state:set system.maintenance_mode 0 --input-format=integer
+  echo "DONE: Disable maintenance."
 
   if [ $? -ne 0 ]; then
     output_error_message "Deployment failure: Failed to disable maintenance_mode"

--- a/public/modules/custom/grants_budget_components/src/TypedData/Definition/GrantsBudgetInfoDefinition.php
+++ b/public/modules/custom/grants_budget_components/src/TypedData/Definition/GrantsBudgetInfoDefinition.php
@@ -19,10 +19,10 @@ class GrantsBudgetInfoDefinition extends MapDataDefinition {
     if (!isset($this->propertyDefinitions)) {
       $info = &$this->propertyDefinitions;
 
-      // If you dont use these default other cost/income fields,
+      // If you dont use these default other cost/income field names,
       // but use differently named fields, you may want to define
       // ->setPropertyDefinition('budget_other_income')
-      // In the form definition class.
+      // In the form definition class to unset default fields.
       $info['budget_other_income'] = $this->getOtherIncomeDefinition();
       $info['budget_other_cost'] = $this->getOtherCostDefinition();
 

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoLeiriSelvitysDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoLeiriSelvitysDefinition.php
@@ -55,7 +55,11 @@ class NuorisoLeiriSelvitysDefinition extends ComplexDataDefinitionBase {
         ->setPropertyDefinition(
           'meno',
           GrantsBudgetInfoDefinition::getOtherCostDefinition()
-        );
+        )
+        // Remove default "other" budget components,
+        // as this form has 6 differently named ones.
+        ->setPropertyDefinition('budget_other_income')
+        ->setPropertyDefinition('budget_other_cost');
 
       // These default definitions from ApplicationDefintionTrait
       // are not required for this form, so let's unset them.


### PR DESCRIPTION
# [AU-2151](https://helsinkisolutionoffice.atlassian.net/browse/AU-2151)
<!-- What problem does this solve? -->

## What was done

* Remove default mappings, so the copy application function doesn't duplicate budget fields.
* Add little more logging to deployment script

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2151-duplicate-budget`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open a [Nuorisopalvelu, loma-aikojen leiriavustusselvitys](https://hel-fi-drupal-grant-applications.docker.so/fi/form/leiriselvitys)
* [ ] Fill the form and send through integration / save as draft
* [ ] Copy the application as a new one.
* [ ] Check the budget page and make sure that there is no extra/duplicated values.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2151]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ