### PR TITLE
fix: AU-1175: edit festival-field in KUVA toiminta

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
@@ -216,6 +216,7 @@ elements: |
     '#markup': '<h4>The dates, in case of festivals and events</h4>'
   festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
     '#title': 'The dates, in case of festivals and events'
+    '#counter_maximum_message': '%d/100 characters remaining'
   toimintamuodot_markup:
     '#markup': "<h4>Other central forms of activities</h4>\r\n\r\n<p>If your activities include other central forms of activities, in addition to performances, screenings, exhibitions, workshops, or other participatory activities that are open to the public, please list them here.</p>"
   muut_keskeiset_toimintamuodot:

--- a/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
@@ -218,6 +218,7 @@ elements: |
     '#markup': '<h4>Evenemang eller festivaldatum</h4>'
   festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
     '#title': 'Evenemang eller festivaldatum'
+    '#counter_maximum_message': '%d/100 tecken kvar'
   toimintamuodot_markup:
     '#markup': "<h4>Andra nyckelfunktioner</h4>\r\n\r\n<p>Om aktiviteten inkluderar föreställningar öppna för allmänheten, utställningar och workshops eller andra former av inkluderande verksamhet, lista dem här.</p>"
   muut_keskeiset_toimintamuodot:

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -760,13 +760,16 @@ elements: |-
           '#help': 'Ensi-illalla tarkoitetaan tuotannon ensimmäistä esitystä. Täytä tähän ne ensi-illat, jotka tapahtuvat Helsingissä.'
       festivaali_paivanmaarat_maarasta_markup:
         '#type': webform_markup
-        '#markup': '<h4>Tapahtuman tai festivaalin päivämäärät</h4>'
+        '#markup': '<h4>Festivaalin tai tapahtuman päivämäärät</h4>'
       festivaalin_tai_tapahtuman_kohdalla_tapahtuman_paivamaarat:
-        '#type': textarea
+        '#type': textfield
+        '#counter_type': character
+        '#counter_maximum': 100
+        '#counter_maximum_message': '%d/100 merkkiä jäljellä'
         '#attributes':
           class:
             - webform--large
-        '#title': 'Tapahtuman tai festivaalin päivämäärät'
+        '#title': 'Festivaalin tai tapahtuman kohdalla tapahtuman päivämäärät'
       toimintamuodot_markup:
         '#type': webform_markup
         '#markup': |-


### PR DESCRIPTION
# [AU-1175](https://helsinkisolutionoffice.atlassian.net/browse/AU-1175)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Edit festival-field in KUVA toiminta

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-1175-toiminta-field`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [KUVA toiminta](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_toiminta)
* [ ] Go to page 4
* [ ] Check that "Festivaalin tai tapahtuman päivämäärät" title is correct
* [ ] Check that the field is textfield, not textarea
* [ ] Check that counter works
* [ ] Repeat in EN and SV



[AU-1175]: https://helsinkisolutionoffice.atlassian.net/browse/AU-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ