### PR TITLE
feat: AU-2047: E2E - Added possibility to disable form variants

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,6 +7,7 @@ import 'dotenv/config';
  */
 export default defineConfig({
   globalTeardown: require.resolve('./tests/global.teardown.ts'),
+  globalSetup: require.resolve('./tests/init.setup.ts'),
   testDir: './tests',
   timeout: 180 * 1000,
   /* Run tests in files in parallel */

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -1,6 +1,5 @@
 import {test as setup, expect} from '@playwright/test';
 import {setDebugMode} from "../utils/debugging_helpers";
-import {setDisabledFormVariants} from "../utils/form_variant_helpers";
 import {logger} from "../utils/logger";
 import {
   ATV_BASE_URL,
@@ -19,7 +18,6 @@ setup('Setup environment', async () => {
   expect(APP_ENV).toBeTruthy()
   expect(APP_ENV.toUpperCase()).not.toContain("PROD");
   setDebugMode();
-  //setDisabledFormVariants();
 })
 
 

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -1,5 +1,4 @@
 import {test as setup, expect} from '@playwright/test';
-import {setDebugMode} from "../utils/debugging_helpers";
 import {logger} from "../utils/logger";
 import {
   ATV_BASE_URL,
@@ -17,7 +16,6 @@ setup('Setup environment', async () => {
   expect(ATV_BASE_URL).toBeTruthy()
   expect(APP_ENV).toBeTruthy()
   expect(APP_ENV.toUpperCase()).not.toContain("PROD");
-  setDebugMode();
 })
 
 

--- a/e2e/tests/global.setup.ts
+++ b/e2e/tests/global.setup.ts
@@ -1,5 +1,6 @@
 import {test as setup, expect} from '@playwright/test';
 import {setDebugMode} from "../utils/debugging_helpers";
+import {setDisabledFormVariants} from "../utils/form_variant_helpers";
 import {logger} from "../utils/logger";
 import {
   ATV_BASE_URL,
@@ -18,6 +19,7 @@ setup('Setup environment', async () => {
   expect(APP_ENV).toBeTruthy()
   expect(APP_ENV.toUpperCase()).not.toContain("PROD");
   setDebugMode();
+  //setDisabledFormVariants();
 })
 
 

--- a/e2e/tests/init.setup.ts
+++ b/e2e/tests/init.setup.ts
@@ -1,0 +1,22 @@
+import { chromium, type FullConfig } from '@playwright/test';
+import {setDebugMode} from "../utils/debugging_helpers";
+import {setDisabledFormVariants} from "../utils/form_variant_helpers";
+
+/**
+ * This function serves as the initial entry point when executing tests with Playwright.
+ * It is designed to perform preliminary operations such as reading environment variables
+ * or modifying test configurations before any test initialization occurs.
+ *
+ * While certain initializations can alternatively be managed through dependencies,
+ * modifying test configurations or similar tasks via dependencies may not work,
+ * as Playwright might consider it too late in the test lifecycle, leading to errors.
+ * This function ensures such preparatory tasks are executed at the appropriate time.
+ *
+ * @docs: https://playwright.dev/docs/test-global-setup-teardown.
+ *
+ * @param config The full configuration object provided by Playwright.
+ */
+module.exports = async (config: FullConfig) => {
+  setDebugMode();
+  setDisabledFormVariants();
+};

--- a/e2e/utils/data/application/application_data_29.ts
+++ b/e2e/utils/data/application/application_data_29.ts
@@ -553,7 +553,7 @@ const registeredCommunityApplications_29 = {
   draft: baseForm_29,
   missing_values: createFormData(baseForm_29, missingValues),
   wrong_values: createFormData(baseForm_29, wrongValues),
-  // success: createFormData(baseForm_29, sendApplication),
+  success: createFormData(baseForm_29, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_48.ts
+++ b/e2e/utils/data/application/application_data_48.ts
@@ -959,8 +959,7 @@ const registeredCommunityApplications_48 = {
   wrong_email_2: createFormData(baseForm_48, wrongEmail2),
   wrong_email_3: createFormData(baseForm_48, wrongEmail3),
   under5000: createFormData(baseForm_48, under5000),
-  // wrong_values: createFormData(baseForm_48, wrongValues),
-  // success: createFormData(baseForm_48, sendApplication),
+  success: createFormData(baseForm_48, sendApplication),
 }
 
 /**
@@ -971,8 +970,8 @@ const registeredCommunityApplications_48 = {
 const privatePersonApplications_48 = {
   draft: baseFormPrivatePerson_48,
   under5000: createFormData(baseForm_48, under5000),
-  // missing_values: createFormData(baseFormPrivatePerson_48, missingValues),
-  // success: createFormData(baseFormPrivatePerson_48, sendApplication),
+  missing_values: createFormData(baseFormPrivatePerson_48, missingValues),
+  success: createFormData(baseFormPrivatePerson_48, sendApplication),
 }
 
 /**
@@ -983,8 +982,8 @@ const privatePersonApplications_48 = {
 const unRegisteredCommunityApplications_48 = {
   draft: baseFormUnRegisteredCommunity_48,
   under5000: createFormData(baseForm_48, under5000),
-  // missing_values: createFormData(baseFormUnRegisteredCommunity_48, missingValues),
-  // success: createFormData(baseFormUnRegisteredCommunity_48, sendApplication),
+  missing_values: createFormData(baseFormUnRegisteredCommunity_48, missingValues),
+  success: createFormData(baseFormUnRegisteredCommunity_48, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_48.ts
+++ b/e2e/utils/data/application/application_data_48.ts
@@ -22,7 +22,7 @@ import {
  *
  */
 const baseForm_48: FormData = {
-  title: 'Form submit to avus2',
+  title: 'Save as draft',
   formSelector: 'webform-submission-kuva-projekti-form',
   formPath: '/fi/form/kuva-projekti',
   formPages: {

--- a/e2e/utils/data/application/application_data_52.ts
+++ b/e2e/utils/data/application/application_data_52.ts
@@ -838,7 +838,7 @@ const registeredCommunityApplications_52 = {
   draft: baseFormRegisteredCommunity_52,
   missing_values: createFormData(baseFormRegisteredCommunity_52, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_52, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_52, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_52, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_53.ts
+++ b/e2e/utils/data/application/application_data_53.ts
@@ -253,7 +253,7 @@ const registeredCommunityApplications_53 = {
   draft: baseFormRegisteredCommunity_53,
   missing_values: createFormData(baseFormRegisteredCommunity_53, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_53, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_53, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_53, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_54.ts
+++ b/e2e/utils/data/application/application_data_54.ts
@@ -717,7 +717,7 @@ const registeredCommunityApplications_54 = {
   draft: baseFormRegisteredCommunity_54,
   missing_values: createFormData(baseFormRegisteredCommunity_54, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_54, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_54, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_54, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_56.ts
+++ b/e2e/utils/data/application/application_data_56.ts
@@ -255,7 +255,7 @@ const registeredCommunityApplications_56 = {
   draft: baseFormRegisteredCommunity_56,
   missing_values: createFormData(baseFormRegisteredCommunity_56, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_56, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_56, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_56, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_57.ts
+++ b/e2e/utils/data/application/application_data_57.ts
@@ -409,7 +409,7 @@ const registeredCommunityApplications_57 = {
   draft: baseFormRegisteredCommunity_57,
   missing_values: createFormData(baseFormRegisteredCommunity_57, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_57, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_57, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_57, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_58.ts
+++ b/e2e/utils/data/application/application_data_58.ts
@@ -276,7 +276,7 @@ const registeredCommunityApplications_58 = {
   draft: baseFormRegisteredCommunity_58,
   missing_values: createFormData(baseFormRegisteredCommunity_58, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_58, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_58, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_58, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_60.ts
+++ b/e2e/utils/data/application/application_data_60.ts
@@ -837,7 +837,7 @@ const registeredCommunityApplications_60 = {
   draft: baseFormRegisteredCommunity_60,
   missing_values: createFormData(baseFormRegisteredCommunity_60, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_60, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_60, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_60, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_61.ts
+++ b/e2e/utils/data/application/application_data_61.ts
@@ -438,7 +438,7 @@ const registeredCommunityApplications_61 = {
   draft: baseFormRegisteredCommunity_61,
   missing_values: createFormData(baseFormRegisteredCommunity_61, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_61, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_61, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_61, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_62.ts
+++ b/e2e/utils/data/application/application_data_62.ts
@@ -575,7 +575,7 @@ const registeredCommunityApplications_62 = {
   draft: baseFormRegisteredCommunity_62,
   missing_values: createFormData(baseFormRegisteredCommunity_62, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_62, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_62, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_62, sendApplication),
 }
 
 /**
@@ -587,7 +587,7 @@ const unRegisteredCommunityApplications_62 = {
   draft: baseFormUnRegisteredCommunity_62,
   missing_values: createFormData(baseFormUnRegisteredCommunity_62, missingValuesUnregistered),
   wrong_values: createFormData(baseFormUnRegisteredCommunity_62, wrongValuesUnregistered),
-  // success: createFormData(baseFormUnRegisteredCommunity_62, sendApplication),
+  success: createFormData(baseFormUnRegisteredCommunity_62, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_63.ts
+++ b/e2e/utils/data/application/application_data_63.ts
@@ -633,7 +633,7 @@ const registeredCommunityApplications_63 = {
   draft: baseFormRegisteredCommunity_63,
   missing_values: createFormData(baseFormRegisteredCommunity_63, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_63, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_63, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_63, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_64.ts
+++ b/e2e/utils/data/application/application_data_64.ts
@@ -415,7 +415,7 @@ const registeredCommunityApplications_64 = {
   draft: baseFormRegisteredCommunity_64,
   missing_values: createFormData(baseFormRegisteredCommunity_64, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_64, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_64, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_64, sendApplication),
 }
 
 /**
@@ -426,7 +426,7 @@ const registeredCommunityApplications_64 = {
 const privatePersonApplications_64 = {
   draft: baseFormPrivatePerson_64,
   missing_values: createFormData(baseFormPrivatePerson_64, missingValuesPrivateUnregistered),
-  // success: createFormData(baseFormRegisteredCommunity_64, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_64, sendApplication),
 }
 
 /**
@@ -437,7 +437,7 @@ const privatePersonApplications_64 = {
 const unRegisteredCommunityApplications_64 = {
   draft: baseFormUnRegisteredCommunity_64,
   missing_values: createFormData(baseFormUnRegisteredCommunity_64, missingValuesPrivateUnregistered),
-  // success: createFormData(baseFormUnRegisteredCommunity_64, sendApplication),
+  success: createFormData(baseFormUnRegisteredCommunity_64, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_65.ts
+++ b/e2e/utils/data/application/application_data_65.ts
@@ -468,7 +468,7 @@ const registeredCommunityApplications_65 = {
   draft: baseForm_65,
   missing_values: createFormData(baseForm_65, missingValues),
   wrong_values: createFormData(baseForm_65, wrongValues),
-  // success: createFormData(baseForm_65, sendApplication),
+  success: createFormData(baseForm_65, sendApplication),
 }
 
 /**
@@ -480,7 +480,7 @@ const unRegisteredCommunityApplications_65 = {
   draft: baseFormUnRegisteredCommunity_65,
   missing_values: createFormData(baseFormUnRegisteredCommunity_65, missingValuesUnregistered),
   wrong_values: createFormData(baseFormUnRegisteredCommunity_65, wrongValuesUnregistered),
-  // success: createFormData(baseFormUnRegisteredCommunity_65, sendApplication),
+  success: createFormData(baseFormUnRegisteredCommunity_65, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_66.ts
+++ b/e2e/utils/data/application/application_data_66.ts
@@ -402,7 +402,7 @@ const registeredCommunityApplications_66 = {
   draft: baseFormRegisteredCommunity_66,
   missing_values: createFormData(baseFormRegisteredCommunity_66, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_66, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_66, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_66, sendApplication),
 }
 
 /**
@@ -413,7 +413,7 @@ const registeredCommunityApplications_66 = {
 const unRegisteredCommunityApplications_66 = {
   draft: baseFormUnRegisteredCommunity_66,
   missing_values: createFormData(baseFormUnRegisteredCommunity_66, missingValuesUnregistered),
-  // success: createFormData(baseFormUnRegisteredCommunity_66, sendApplication),
+  success: createFormData(baseFormUnRegisteredCommunity_66, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_68.ts
+++ b/e2e/utils/data/application/application_data_68.ts
@@ -439,7 +439,7 @@ const registeredCommunityApplications_68 = {
   draft: baseFormRegisteredCommunity_68,
   missing_values: createFormData(baseFormRegisteredCommunity_68, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_68, wrongValues),
-  // success: createFormData(baseFormRegisteredCommunity_68, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_68, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application/application_data_69.ts
+++ b/e2e/utils/data/application/application_data_69.ts
@@ -755,7 +755,7 @@ const registeredCommunityApplications_69 = {
   draft: baseForm_69,
   missing_values: createFormData(baseForm_69, missingValues),
   wrong_values: createFormData(baseForm_69, wrongValues),
-  // success: createFormData(baseForm_69, sendApplication),
+  success: createFormData(baseForm_69, sendApplication),
 }
 
 /**
@@ -767,7 +767,7 @@ const unRegisteredCommunityApplications_69 = {
   draft: baseFormUnRegisteredCommunity_69,
   missing_values: createFormData(baseFormUnRegisteredCommunity_69, missingValuesUnregistered),
   wrong_values: createFormData(baseFormUnRegisteredCommunity_69, wrongValuesUnregistered),
-  // success: createFormData(baseFormUnRegisteredCommunity_69, sendApplication),
+  success: createFormData(baseFormUnRegisteredCommunity_69, sendApplication),
 }
 
 export {

--- a/e2e/utils/data/application_data.ts
+++ b/e2e/utils/data/application_data.ts
@@ -7,20 +7,7 @@ import {
 import {
   unRegisteredCommunityApplications as originalUnRegisteredCommunityApplications
 } from "./application/application_data_unregistered_community";
-import {
-  setDisabledFormVariants,
-  filterOutDisabledFormVariants
-} from "../form_variant_helpers";
-
-/**
- * Call setDisabledFormVariants().
- *
- * This needs to be done here, since doing it in, for example,
- * global.setup.ts is considered to be "too late". We need to determine
- * what tests we are going to run before we give them to Playwrights test()
- * function. Otherwise, Playwright will complain about missing tests.
- */
-setDisabledFormVariants();
+import {filterOutDisabledFormVariants} from "../form_variant_helpers";
 
 const privatePersonApplications = filterOutDisabledFormVariants(originalPrivatePersonApplications);
 const registeredCommunityApplications = filterOutDisabledFormVariants(originalRegisteredCommunityApplications);

--- a/e2e/utils/data/application_data.ts
+++ b/e2e/utils/data/application_data.ts
@@ -7,7 +7,20 @@ import {
 import {
   unRegisteredCommunityApplications as originalUnRegisteredCommunityApplications
 } from "./application/application_data_unregistered_community";
-import {filterOutDisabledFormVariants} from "../form_variant_helpers";
+import {
+  setDisabledFormVariants,
+  filterOutDisabledFormVariants
+} from "../form_variant_helpers";
+
+/**
+ * Call setDisabledFormVariants().
+ *
+ * This needs to be done here, since doing it in, for example,
+ * global.setup.ts is considered to be "too late". We need to determine
+ * what tests we are going to run before we give them to Playwrights test()
+ * function. Otherwise, Playwright will complain about missing tests.
+ */
+setDisabledFormVariants();
 
 const privatePersonApplications = filterOutDisabledFormVariants(originalPrivatePersonApplications);
 const registeredCommunityApplications = filterOutDisabledFormVariants(originalRegisteredCommunityApplications);

--- a/e2e/utils/data/application_data.ts
+++ b/e2e/utils/data/application_data.ts
@@ -1,13 +1,17 @@
 import {
-  privatePersonApplications
+  privatePersonApplications as originalPrivatePersonApplications
 } from "./application/application_data_private_person";
 import {
-  registeredCommunityApplications
+  registeredCommunityApplications as originalRegisteredCommunityApplications
 } from "./application/application_data_registered_community";
 import {
-  unRegisteredCommunityApplications
+  unRegisteredCommunityApplications as originalUnRegisteredCommunityApplications
 } from "./application/application_data_unregistered_community";
+import {filterOutDisabledFormVariants} from "../form_variant_helpers";
 
+const privatePersonApplications = filterOutDisabledFormVariants(originalPrivatePersonApplications);
+const registeredCommunityApplications = filterOutDisabledFormVariants(originalRegisteredCommunityApplications);
+const unRegisteredCommunityApplications = filterOutDisabledFormVariants(originalUnRegisteredCommunityApplications);
 
 export {
   privatePersonApplications,

--- a/e2e/utils/debugging_helpers.ts
+++ b/e2e/utils/debugging_helpers.ts
@@ -1,28 +1,4 @@
-import path from "path";
-import fs from "fs";
-
-/**
- * The readEnvFile function.
- *
- * This function reads the content of the '.test_env' file
- * and returns an array of its lines.
- *
- * @returns string[]
- *   Array of lines from the '.test_env' file.
- *
- * TODO: This function should be moved to another file, since it
- *       is not strictly related to debugging.
- */
-const readEnvFile = (): string[] => {
-  try {
-    const envFilePath = path.resolve(__dirname, '../.test_env');
-    const envFile = fs.readFileSync(envFilePath, 'utf-8');
-    return envFile.split('\n');
-  } catch (error) {
-    console.error('[Error reading .test_env file]');
-    return [];
-  }
-};
+import { readEnvFile } from "./env_helpers";
 
 /**
  * The setDebugMode function.

--- a/e2e/utils/env_helpers.ts
+++ b/e2e/utils/env_helpers.ts
@@ -1,0 +1,27 @@
+import path from "path";
+import fs from "fs";
+
+/**
+ * The readEnvFile function.
+ *
+ * This function reads the content of the '.test_env' file
+ * and returns an array of its lines.
+ *
+ * @returns string[]
+ *   Array of lines from the '.test_env' file.
+ *
+ */
+const readEnvFile = (): string[] => {
+  try {
+    const envFilePath = path.resolve(__dirname, '../.test_env');
+    const envFile = fs.readFileSync(envFilePath, 'utf-8');
+    return envFile.split('\n');
+  } catch (error) {
+    console.error('[Error reading .test_env file]');
+    return [];
+  }
+};
+
+export {
+  readEnvFile,
+}

--- a/e2e/utils/form_variant_helpers.ts
+++ b/e2e/utils/form_variant_helpers.ts
@@ -1,0 +1,70 @@
+import {readEnvFile} from "./env_helpers";
+import {logger} from "./logger";
+
+/**
+ * The setAllowedFormVariants function.
+ *
+ * This function ...
+ */
+const setDisabledFormVariants = (): void => {
+  if (process.env.DISABLED_FORM_VARIANTS) return;
+
+  const envLines = readEnvFile();
+  const variantsLine = envLines.find(line => line.startsWith('DISABLED_FORM_VARIANTS='));
+
+  if (variantsLine) {
+
+    const variants = variantsLine
+      .substring(variantsLine.indexOf('=') + 1)
+      .split(',')
+      .map(variant => variant.trim().replace(/"/g, ''));
+
+    process.env.DISABLED_FORM_VARIANTS = JSON.stringify(variants);
+    console.log('DISABLED_FORM_VARIANTS in the .test_env file:', variants)
+    console.log('CALL', getDisabledFormVariants());
+
+  } else {
+    console.log('[DISABLED_FORM_VARIANTS has not been set in the .test_env file]')
+  }
+};
+
+/**
+ * The getDisabledFormVariants function.
+ *
+ * This function ...
+ */
+const getDisabledFormVariants = (): string[] => {
+  if (!process.env.DISABLED_FORM_VARIANTS) return [];
+  return JSON.parse(process.env.DISABLED_FORM_VARIANTS);
+};
+
+/**
+ *
+ * @param applications
+ */
+const filterOutDisabledFormVariants = (applications: any): any => {
+  // Parse the disabled form variants from the environment variable.
+  const disabledFormVariants = getDisabledFormVariants();
+
+  // Return unmodified applications if there are no disabled variants.
+  if (!disabledFormVariants) return applications;
+
+  Object.keys(applications).forEach(applicationId => {
+    // Iterate over each form variant within the current application.
+    Object.keys(applications[applicationId]).forEach(formVariant => {
+      // Check if the current variant is among the disabled variants.
+      if (disabledFormVariants.includes(formVariant)) {
+        // If so, delete this form variant from the application.
+        console.log('IN APPLICATION ID ', applicationId)
+        console.log('Deleted variant', formVariant)
+        delete applications[applicationId][formVariant];
+      }
+    });
+  });
+  return applications;
+}
+
+export {
+  setDisabledFormVariants,
+  filterOutDisabledFormVariants,
+}

--- a/e2e/utils/form_variant_helpers.ts
+++ b/e2e/utils/form_variant_helpers.ts
@@ -1,4 +1,5 @@
 import {readEnvFile} from "./env_helpers";
+import {logger} from "./logger";
 
 /**
  * The setDisabledFormVariants function.
@@ -18,7 +19,7 @@ const setDisabledFormVariants = (): void => {
 
   if (!variantsLine) {
     process.env.DISABLED_FORM_VARIANTS = 'FALSE';
-    console.log('[DISABLED_FORM_VARIANTS has not been set in .test_env]');
+    logger('DISABLED_FORM_VARIANTS has not been set in .test_env');
     return;
   }
 
@@ -28,7 +29,7 @@ const setDisabledFormVariants = (): void => {
     .map(variant => variant.trim().replace(/"/g, ''));
 
   process.env.DISABLED_FORM_VARIANTS = JSON.stringify(variants);
-  console.log(`[Disabled form variants: ${variants}]`)
+  logger(`Disabled form variants: ${variants}`);
 };
 
 /**
@@ -51,11 +52,9 @@ const getDisabledFormVariants = (): string[] => {
 /**
  * The filterOutDisabledFormVariants function.
  *
- * This function removes disabled form variants from the
- * application data. This functionality exists so that one
- * does not need to comment out the wanted tests from an
- * application_data_x.ts file, but instead define the disabled
- * form variants to a DISABLED_FORM_VARIANTS key in the .test_env file.
+ * The function filters out disabled form variants from the provided application data.
+ * This allows for dynamic exclusion of specific tests based on configurations set in the .test_env file,
+ * avoiding the need to manually comment out tests in the application data files.
  *
  * The function does the following:
  *

--- a/e2e/utils/form_variant_helpers.ts
+++ b/e2e/utils/form_variant_helpers.ts
@@ -19,7 +19,7 @@ const setDisabledFormVariants = (): void => {
 
   if (!variantsLine) {
     process.env.DISABLED_FORM_VARIANTS = 'FALSE';
-    logger('DISABLED_FORM_VARIANTS has not been set in .test_env');
+    logger('DISABLED_FORM_VARIANTS has not been set in .test_env. Running all form variant tests.');
     return;
   }
 


### PR DESCRIPTION
# [AU-2047](https://helsinkisolutionoffice.atlassian.net/browse/AU-2047)

## What was done

This pull request implements the possibility to _disable form variants_ (e.g. `success`, `draft`, `wrong_values`) in the `.test_env` file. This allows for dynamic exclusion of specific tests based on configuration, avoiding the need to manually comment out tests in the application data files.

No need for this anymore!

![Screenshot 2024-02-29 at 8 35 22](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/991eb7e1-7e58-47e0-b308-7cf659641411)


## What has changed

- A `globalSetup` key has been added to the `playwright.config.ts` file. The key points to a `init.setup.ts` file, which allows us to run code before initializing any tests.

- The `readEnvFile` function has been moved to its own `env_helpers.ts` file.

- The logic for filtering out disabled form variants has been implemented in `form_variant_helpers.ts`. All application data is being run through `filterOutDisabledFormVariants` in `application_data.ts` before it is passed on to any test.

- Removed any comments from commented out tests.

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2047-e2e-send-avustus2-logic`
* `make fresh`
* `make drush-cr`

## How to test
#### 1. Run any test, for example: `make test-pw-p PROJECT=forms-29`.

Notice that all the tests (form variants) get executed and tested:

<img width="1425" alt="Screenshot 2024-02-28 at 15 10 48" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/0ca61f0c-210e-46dd-95a7-0d8032130fab">

#### 2. Now, add this to the end of the `.test_env` file: 

```
// Set the disabled form variants.
DISABLED_FORM_VARIANTS="success", "wrong_values", "missing_values"
```

#### 3. Run any test, for example: `make test-pw-p PROJECT=forms-29`.

Notice that only the `draft` test is being run, and the others (`success`, `wrong_values`, `missing_values`) have been disabled.

<img width="1436" alt="Screenshot 2024-02-28 at 15 03 44" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/717fc5c8-b8c6-451f-81b2-de99d3798012">



[AU-2047]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ