### PR TITLE
fix: AU-2210: add context to email translations

### DIFF
--- a/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
+++ b/public/modules/custom/grants_applicant_info/src/Element/ApplicantInfoComposite.php
@@ -127,6 +127,8 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     $helsinkiProfiiliDataService = \Drupal::service('helfi_helsinki_profiili.userdata');
     $userData = $helsinkiProfiiliDataService->getUserProfileData();
 
+    $tOpts = ['context' => 'grants_handler'];
+
     $suffix = array_key_exists('phone_number', $profileContent) ? '' : '</div>';
 
     $elements['firstname'] = [
@@ -162,7 +164,7 @@ class ApplicantInfoComposite extends WebformCompositeBase {
     ];
     $elements['email'] = [
       '#type' => 'textfield',
-      '#title' => t('Email'),
+      '#title' => t('Email', [], $tOpts),
       '#readonly' => TRUE,
       '#required' => TRUE,
       '#value' => $userData["myProfile"]["primaryEmail"]["email"] ?? '',

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -610,3 +610,7 @@ msgstr "Ei lähetettyjä hakemuksia."
 msgctxt "grants_handler"
 msgid "Service page not found!"
 msgstr "Palvelusivua ei löytynyt!"
+
+msgctxt "grants_handler"
+msgid "Email"
+msgstr "Sähköposti"

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -610,3 +610,7 @@ msgstr "Inga skickade ansökningar."
 msgctxt "grants_handler"
 msgid "Service page not found!"
 msgstr "Servicesidan hittades inte!"
+
+msgctxt "grants_handler"
+msgid "Email"
+msgstr "E-post"

--- a/public/modules/custom/grants_profile/templates/grants-profile--basic-info--private-person.html.twig
+++ b/public/modules/custom/grants_profile/templates/grants-profile--basic-info--private-person.html.twig
@@ -21,7 +21,7 @@
         <dd class="grants-profile-item">{{ myProfile.verifiedPersonalInformation.nationalIdentificationNumber }}</dd>
       </div>
       <div class="grants-profile--wrapper-item">
-        <dt><strong>{{ "Email"|t }}</strong></dt>
+        <dt><strong>{{ "Email"|t({}, {'context': 'Yksityishenkilön asiointi'}) }}</strong></dt>
         <dd class="grants-profile-item">{{ myProfile.primaryEmail.email }}</dd>
       </div>
     </dl>

--- a/public/modules/custom/grants_profile/translations/fi.po
+++ b/public/modules/custom/grants_profile/translations/fi.po
@@ -477,6 +477,10 @@ msgctxt "Yksityishenkilön asiointi"
 msgid "Own contact information"
 msgstr "Omat yhteystiedot"
 
+msgctxt "Yksityishenkilön asiointi"
+msgid "Email"
+msgstr "Sähköposti"
+
 msgctxt "grants_profile"
 msgid "The information has been retrieved from your Helsinki profile. You need to go to your Helsinki profile to edit this information. When you have edited your information in the Helsinki profile, remember to update this field."
 msgstr "Tiedot on haettu Helsinki-profiilistasi. Sinun pitää siirtyä Helsinki-profiiliin muokataksesi näitä tietoja. Kun olet muokannut tietojasi Helsinki-profiilissa, muista päivittää tämä kenttä."

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -434,6 +434,10 @@ msgctxt "Yksityishenkilön asiointi"
 msgid "Own contact information"
 msgstr "Egna kontaktuppgifter"
 
+msgctxt "Yksityishenkilön asiointi"
+msgid "Email"
+msgstr "E-post"
+
 msgctxt "grants_profile"
 msgid "The information has been retrieved from your Helsinki profile. You need to go to your Helsinki profile to edit this information. When you have edited your information in the Helsinki profile, remember to update this field."
 msgstr "Informationen har hämtats från din Helsingfors-profil. Du måste gå till din Helsingforsprofil för att redigera denna information. När du har redigerat din information i Helsingforsprofilen, kom ihåg att uppdatera detta fält."


### PR DESCRIPTION
# [AU-2210](https://helsinkisolutionoffice.atlassian.net/browse/AU-2210)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add context to email translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2210-email-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as private person
* [ ] Go to Oma asiointi and check that Email-field is translated correctly
* [ ] Go to any application, and check that Email-field is translated correctly in first page, in preview-page and in draft page
* [ ] Login as unregistered community
* [ ] Repeat steps 2-3
