### PR TITLE
fix: AU-2207-blue-search-page

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--application-search-search-api.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--application-search-search-api.html.twig
@@ -32,6 +32,7 @@
 #}
 {%
   set classes = [
+  'hdbt-theme--engel',
   'view',
   'view-' ~ id|clean_class,
   'view-id-' ~ id,


### PR DESCRIPTION
# [AU-2207](https://helsinkisolutionoffice.atlassian.net/browse/AU-2207)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add Engel theme to the search page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2207-blue-search-page`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Search page](https://hel-fi-drupal-grant-applications.docker.so/fi/etsi-avustusta)
* [ ] See that [it was all yellow](https://www.youtube.com/watch?v=yKNxeF4KMsY).
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2207]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ