### PR TITLE
fix: AU-2126: change service page block text when logged out

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -224,6 +224,7 @@ function grants_handler_theme(): array {
         'link' => NULL,
         'text' => NULL,
         'auth' => NULL,
+        'title' => NULL,
       ],
     ],
     'application_timeout_message' => [

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -197,7 +197,7 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
     );
     $loginText = [
       '#theme' => 'edit-label-with-icon',
-      '#icon' => 'user',
+      '#icon' => 'signin',
       '#text_label' => $this->t('Log in'),
     ];
 

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -206,10 +206,12 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
     if ($this->currentUser->isAuthenticated()) {
       $link = Link::fromTextAndUrl($mandateText, $mandateUrl);
       $text = $this->t('You do not have the necessary authorizations to make an application.', [], $tOpts);
+      $title = $this->t('Missing authorization', [], $tOpts);
     }
     else {
       $link = Link::fromTextAndUrl($loginText, $loginUrl);
-      $text = $this->t('You do not have the necessary authorizations to make an application. Log in to grants service.', [], $tOpts);
+      $text = $this->t('Log in to the service and do the identification.', [], $tOpts);
+      $title = $this->t('Identification', [], $tOpts);
     }
 
     $node = $this->routeMatch->getParameter('node');
@@ -231,6 +233,7 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
       '#theme' => 'grants_service_page_block',
       '#applicantType' => $isCorrectApplicantType,
       '#link' => $link,
+      '#title' => $title,
       '#text' => $text,
       '#webformLink' => $webformLink,
       '#auth' => 'anon',

--- a/public/modules/custom/grants_handler/templates/grants-service-page-block.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-service-page-block.html.twig
@@ -4,7 +4,6 @@
   {% set icon = 'info' %}
 {% else %}
   {% set authClass = 'grants-service-page-block--anon' %}
-  {% set title = 'Missing authorization'|t({}, {'context': 'grants_handler'}) %}
   {% set icon = 'alert' %}
 {% endif %}
 <div class="grants-service-page-block {{ authClass }}">

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -468,6 +468,14 @@ msgid "Missing authorization"
 msgstr "Puuttuva valtuutus"
 
 msgctxt "grants_handler"
+msgid "Identification"
+msgstr "Tunnistaudu"
+
+msgctxt "grants_handler"
+msgid "Log in to the service and do the identification."
+msgstr "Kirjaudu palveluun ja tee tunnistautuminen."
+
+msgctxt "grants_handler"
 msgid "Please familiarize yourself with the instructions on this page before proceeding to the application."
 msgstr "Tutustuthan ohjeistukseen tällä sivulla ennen hakemukselle siirtymistä."
 

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -468,6 +468,14 @@ msgid "Missing authorization"
 msgstr "Saknade behörighet"
 
 msgctxt "grants_handler"
+msgid "Identification"
+msgstr "Identifiera dig"
+
+msgctxt "grants_handler"
+msgid "Log in to the service and do the identification."
+msgstr "Logga in på tjänsten och gör identifieringen."
+
+msgctxt "grants_handler"
 msgid "Please familiarize yourself with the instructions on this page before proceeding to the application."
 msgstr "Bekanta dig med instruktionerna på den här sidan innan du går vidare till ansökan."
 


### PR DESCRIPTION
# [AU-2126](https://helsinkisolutionoffice.atlassian.net/browse/AU-2126)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change service page block text when logged out

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2126-service-page`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Be logged out and go to any service page, [for example](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/liikunnan-avustukset/liikunnan-laitosavustus)
* [ ] Check that yellow box looks as such
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/4e2b7be6-6027-4599-9f40-11fe9d5f6635)
* [ ] Login as private person or unregistered community and go to any service page that you do not have authorization, [for example](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/liikunnan-avustukset/liikunnan-laitosavustus)
* [ ] Check that yellow box looks as such
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/5e826d19-dcee-4d69-ae67-5571b836e63f)
* [ ] Go to any service page that you do have authorization, [for example](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/kulttuurin-avustukset/taide-ja-kulttuuriavustukset-projektiavustukset)
* [ ] Check that the box is now blue and looks as such
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/c6f1a356-f4ae-4203-821c-cff36d5cd98b)
* [ ] Check translations

[AU-2126]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ