### PR TITLE
fix: AU-2230: default language back to fi

### DIFF
--- a/conf/cmi/language.negotiation.yml
+++ b/conf/cmi/language.negotiation.yml
@@ -13,4 +13,4 @@ url:
     en: ''
     fi: ''
     sv: ''
-selected_langcode: site_default
+selected_langcode: fi

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -11,4 +11,4 @@ page:
   front: /avustukset
 admin_compact_mode: false
 weight_select_max: 100
-default_langcode: fi
+default_langcode: en

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -11,4 +11,4 @@ page:
   front: /avustukset
 admin_compact_mode: false
 weight_select_max: 100
-default_langcode: en
+default_langcode: fi


### PR DESCRIPTION
# [AU-2230](https://helsinkisolutionoffice.atlassian.net/browse/AU-2230)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2230-default-lang`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2230]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ