### PR TITLE
fix: AU-2221: translate Hakija in SV applications

### DIFF
--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': 'Informationen har h&auml;mtats fr&aring;n din s&ouml;kprofil.'
   hakijan_tiedot:
-    '#title': 'Den sökandes uppgifter'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': 'Informationen har h&auml;mtats fr&aring;n din s&ouml;kprofil.'
   hakijan_tiedot:
-    '#title': 'Den sökandes uppgifter'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.kasko_ip_lisa.yml
+++ b/conf/cmi/language/sv/webform.webform.kasko_ip_lisa.yml
@@ -8,6 +8,8 @@ elements: |
     '#title': 'Hämtade uppgifter'
   prh_markup:
     '#markup': 'Informationen har h&auml;mtats fr&aring;n din profil.'
+  hakijan_tiedot:
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   hakijan_tiedot:
-    '#title': 'Den sökandes uppgifter'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   hakijan_tiedot:
-    '#title': 'Sökande'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   hakijan_tiedot:
-    '#title': 'Den sökandes uppgifter'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   hakijan_tiedot:
-    '#title': 'Sökande'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.liikunta_suunnistuskartta_avustu.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_suunnistuskartta_avustu.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   hakijan_tiedot:
-    '#title': 'Den sökandes uppgifter'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_tapahtuma.yml
@@ -11,7 +11,7 @@ elements: |
   prh_markup:
     '#markup': 'Uppgifterna har h&auml;mtats fr&aring;n Patent- och registreringsverkets register (PRH) och kan d&auml;rf&ouml;r inte &auml;ndras.'
   hakijan_tiedot:
-    '#title': 'Sökande'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -8,6 +8,8 @@ elements: |
     '#title': 'Samfund för vilket understödet ansöks'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
+  hakijan_tiedot:
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_yleisavustushakemus.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   hakijan_tiedot:
-    '#title': 'Sökande'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': 'Informationen har h&auml;mtats fr&aring;n din profil.'
   hakijan_tiedot:
-    '#title': 'Sökande'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': 'Informationen har h&auml;mtats fr&aring;n din profil.'
   hakijan_tiedot:
-    '#title': 'Sökande'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.nuorlomaleir.yml
+++ b/conf/cmi/language/sv/webform.webform.nuorlomaleir.yml
@@ -9,7 +9,7 @@ elements: |
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
   hakijan_tiedot:
-    '#title': 'Sökande'
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -8,6 +8,8 @@ elements: |
     '#title': 'Samfund för vilket understödet ansöks'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
+  hakijan_tiedot:
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:

--- a/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -8,6 +8,8 @@ elements: |
     '#title': 'Samfund för vilket understödet ansöks'
   prh_markup:
     '#markup': '<div class="grants-profile-prh-info">De markerade uppgifterna har h&auml;mtats fr&aring;n Patent- och registerstyrelsens register (PRH) och det &auml;r endast m&ouml;jligt att &auml;ndra uppgifterna i n&auml;ttj&auml;nsten i fr&aring;ga.</div>'
+  hakijan_tiedot:
+    '#title': Sökande
   contact_person_email_section:
     '#title': E-post
   contact_markup:


### PR DESCRIPTION
# [AU-2221](https://helsinkisolutionoffice.atlassian.net/browse/AU-2221)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Translate Hakija in SV applications

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2221-hakija`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go through all the applications in SV, check that Preview-page has the word Hakija translated

[AU-2221]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ