### PR TITLE
fix: AU-2090: change confirmation page text

### DIFF
--- a/public/modules/custom/grants_handler/templates/grants-handler-completion.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-handler-completion.html.twig
@@ -45,7 +45,7 @@
           {{ "Make sure that the status of the application changes from “Submitted” to “Received”. The application is only fully received when the status reads “Received”."|t({}, {'context': 'grants_handler'})}}
         </p>
         <p>
-          {{ "The status change can take from seconds to few minutes."|t({}, {'context': 'grants_handler'})}}
+          {{ "There may be a delay in changing the status. For example, due to maintenance breaks, the delay can be longer than normal."|t({}, {'context': 'grants_handler'})}}
         </p>
       </div>
       <div class="grants-handler__completion__button-row">

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -364,8 +364,8 @@ msgid "Make sure that the status of the application changes from “Submitted”
 msgstr "Muistathan varmistaa, että hakemuksen tila vaihtuu “Lähetetty - odotetaan vahvistusta” -tilasta “Vastaanotettu” -tilaan. Hakemus on vastaanotettu vasta, kun tila on muodossa: “Vastaanotettu”."
 
 msgctxt "grants_handler"
-msgid "The status change can take from seconds to few minutes."
-msgstr "Tilan vaihtuminen voi kestää sekunneista muutamaan minuuttiin."
+msgid "There may be a delay in changing the status. For example, due to maintenance breaks, the delay can be longer than normal."
+msgstr "Tilan vaihtumisessa voi olla viivettä. Esimerkiksi huoltokatkoista johtuen viive voi olla normaaliakin pidempi."
 
 msgctxt "grants_handler"
 msgid "Application period is closed, no further editing is allowed."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -364,8 +364,8 @@ msgid "Make sure that the status of the application changes from “Submitted”
 msgstr "Se till att statusen för ansökan ändras från 'Lämnats' till 'Mottagits'. Ansökan är helt mottagen först när statusen lyder 'Mottagits'."
 
 msgctxt "grants_handler"
-msgid "The status change can take from seconds to few minutes."
-msgstr "Statusändringen kan ta från sekunder till några minuter."
+msgid "There may be a delay in changing the status. For example, due to maintenance breaks, the delay can be longer than normal."
+msgstr "Det kan finnas en fördröjning vid ändring av läge. Till exempel, på grund av underhållsuppehåll, kan förseningen vara längre än normalt."
 
 msgctxt "grants_handler"
 msgid "Application period is closed, no further editing is allowed."


### PR DESCRIPTION
# [AU-2090](https://helsinkisolutionoffice.atlassian.net/browse/AU-2090)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change confirmation page text

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2090-confirmation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Fill out and send any application
* [ ] Check that the text in confirmation page is correct
* [ ] Check translations

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/e99d834d-6963-4903-af79-30658da7475c)



[AU-2090]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ