### PR TITLE
fix: AU-2203: update service page block text

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -205,8 +205,8 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
 
     if ($this->currentUser->isAuthenticated()) {
       $link = Link::fromTextAndUrl($mandateText, $mandateUrl);
-      $text = $this->t('You do not have the necessary authorizations to make an application.', [], $tOpts);
-      $title = $this->t('Missing authorization', [], $tOpts);
+      $text = $this->t('Change your role and return to make the application with role which the application is instructed to be made.', [], $tOpts);
+      $title = $this->t('Change role', [], $tOpts);
     }
     else {
       $link = Link::fromTextAndUrl($loginText, $loginUrl);

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -439,8 +439,8 @@ msgid "Print application"
 msgstr "Tulosta hakemus"
 
 msgctxt "grants_handler"
-msgid "You do not have the necessary authorizations to make an application."
-msgstr "Sinulla ei ole tarvittavia valtuuksia hakemuksen tekemiseen."
+msgid "Change your role and return to make the application with role which the application is instructed to be made."
+msgstr "Vaihda asiointiroolia ja palaa tekemään hakemus palvelukuvauksen ohjeistamalla asiointiroolilla."
 
 msgctxt "grants_handler"
 msgid "You do not have the necessary authorizations to make an application. Log in to grants service."
@@ -464,8 +464,8 @@ msgid "Create new application"
 msgstr "Luo uusi hakemus"
 
 msgctxt "grants_handler"
-msgid "Missing authorization"
-msgstr "Puuttuva valtuutus"
+msgid "Change role"
+msgstr "Vaihda asiointiroolia"
 
 msgctxt "grants_handler"
 msgid "Identification"

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -439,8 +439,8 @@ msgid "Print application"
 msgstr "Skriv ut ansökan"
 
 msgctxt "grants_handler"
-msgid "You do not have the necessary authorizations to make an application."
-msgstr "Du har inte de nödvändiga behörigheterna för att göra en ansökan."
+msgid "Change your role and return to make the application with role which the application is instructed to be made."
+msgstr "Byt roll och gå tillbaka för att göra ansökan med roll som ansökan är instruerad att göra."
 
 msgctxt "grants_handler"
 msgid "You do not have the necessary authorizations to make an application. Log in to grants service."
@@ -464,8 +464,8 @@ msgid "Create new application"
 msgstr "Skapa ny applikation"
 
 msgctxt "grants_handler"
-msgid "Missing authorization"
-msgstr "Saknade behörighet"
+msgid "Change role"
+msgstr "Byt roll"
 
 msgctxt "grants_handler"
 msgid "Identification"


### PR DESCRIPTION
# [AU-2203](https://helsinkisolutionoffice.atlassian.net/browse/AU-2203)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Update service page block text

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2203-servicepage`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as private person
* [ ] Go to any service page that you do not have authorization ([for example](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/muut-avustukset/tyollisyysavustus))
* [ ] Check that application block's text is correct
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/98c6f21a-861a-4a41-994e-a9b69c2c6279)
* [ ] Check translations