### PR TITLE
AU-2213: Allow budget explantion to be saved without a value

### DIFF
--- a/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
+++ b/public/modules/custom/grants_budget_components/src/GrantsBudgetComponentService.php
@@ -88,15 +88,22 @@ class GrantsBudgetComponentService {
       }
 
       $value = $values['value'];
+      $isEmptyValue = (is_null($value) || $value === "");
 
-      if (is_null($value) || $value === "") {
+      if ($isEmptyValue && empty(trim($values['label']))) {
         continue;
+      }
+      elseif ($isEmptyValue && $values['label']) {
+        $valueToSave = NULL;
+      }
+      else {
+        $valueToSave = (string) GrantsHandler::convertToFloat($value);
       }
 
       $itemValues = [
         'ID' => $property->getName() . '_' . $index,
         'label' => $values['label'] ?? NULL,
-        'value' => (string) GrantsHandler::convertToFloat($value),
+        'value' => $valueToSave,
         'valueType' => 'double',
       ];
 
@@ -137,14 +144,19 @@ class GrantsBudgetComponentService {
       if (!empty($parent) && isset($parent[$pathLast])) {
         $retVal[$groupName] = array_map(function ($e) {
           $value = GrantsHandler::convertToFloat($e['value']);
-          return [
-            'label' => $e['label'] ?? NULL,
-            'value' => number_format(
+
+          if ($value !== NULL) {
+            $value = number_format(
               $value,
               2,
               ',',
               ' ',
-            ) ?? NULL,
+            );
+          }
+
+          return [
+            'label' => $e['label'] ?? NULL,
+            'value' => $value,
           ];
         }, $parent[$pathLast]);
       }

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoLomaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisoLomaDefinition.php
@@ -47,7 +47,9 @@ class NuorisoLomaDefinition extends ComplexDataDefinitionBase {
         ->setPropertyDefinition(
           'meno',
           GrantsBudgetInfoDefinition::getOtherCostDefinition()
-        );
+        )
+        ->setPropertyDefinition('budget_other_income')
+        ->setPropertyDefinition('budget_other_cost');
 
       $info['lisakysymys_1'] = DataDefinition::create('string')
         ->setSetting('jsonPath', [


### PR DESCRIPTION
# [AU-2213](https://helsinkisolutionoffice.atlassian.net/browse/AU-2213)
<!-- What problem does this solve? -->

## What was done

* Allow multivalue budget components to be saved without a value if explanation / label is filled.


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2213-budget-component-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any application with multi-value budget components (like: https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/nuorlomaleir)
* [ ] Fill only the explanation / label
* [ ] Save as draft
* [ ] See that the explanation is saved but the euro values is empty.
* [ ] Check that multi-value works as they should.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2213]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ