### PR TITLE
fix: AU-2228: Make javascript load after content has loaded

### DIFF
--- a/public/modules/custom/grants_handler/templates/grants-handler-print-atv-document.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-handler-print-atv-document.html.twig
@@ -12,7 +12,7 @@
  * @ingroup themeable
  */
 #}
-<table class="webform-print-wrapper-table">
+<table aria-label="{{ "Print table"|t({}, {'langcode' : document_langcode}, {'context': 'grants_handler'}) }}" class="webform-print-wrapper-table">
   <thead><tr><th>
       <div class="webform-print-header-space">&nbsp;</div>
     </th></tr></thead>

--- a/public/modules/custom/grants_handler/templates/grants-handler-print-atv-document.html.twig
+++ b/public/modules/custom/grants_handler/templates/grants-handler-print-atv-document.html.twig
@@ -12,17 +12,6 @@
  * @ingroup themeable
  */
 #}
-<script>
-  var body = document.body;
-  body.classList.add("webform-submission-data-preview-page");
-  body.classList.add('webform-print');
-  (function() {
-    window.print();
-    setTimeout(() => {
-      history.back();
-    }, 500);
-  })();
-</script>
 <table class="webform-print-wrapper-table">
   <thead><tr><th>
       <div class="webform-print-header-space">&nbsp;</div>
@@ -97,3 +86,16 @@
     {{ atv_document.transaction_id }}
   </div>
 </header>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var body = document.body;
+    body.classList.add("webform-submission-data-preview-page");
+    body.classList.add('webform-print');
+    (function() {
+      window.print();
+      setTimeout(() => {
+        history.back();
+      }, 500);
+    })();
+  }, false);
+</script>

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -14,6 +14,10 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgctxt "grants_handler"
+msgid "Print table"
+msgstr "Tulostetta ohjaava taulukko"
+
+msgctxt "grants_handler"
 msgid "My message"
 msgstr "Oma viesti"
 

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -14,8 +14,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 msgctxt "grants_handler"
+msgid "Print table"
+msgstr "Tabell som styr utgången"
+
+msgctxt "grants_handler"
 msgid "My message"
-msgstr "Oma viesti"
+msgstr "Mitt meddelande"
 
 msgctxt "grants_handler"
 msgid "If checked, every handler method invoked will be displayed onscreen to all users."


### PR DESCRIPTION
# [AU-2228](https://helsinkisolutionoffice.atlassian.net/browse/AU-2228)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2228-print-issues`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Oma Asiointi](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi) and click print on one of the applications (not drafts)
* [ ] See that the page prints out fine.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2228]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ