### PR TITLE
feature: AU-2234: skip deployment script

### DIFF
--- a/docker/openshift/entrypoints/20-deploy.sh
+++ b/docker/openshift/entrypoints/20-deploy.sh
@@ -4,6 +4,12 @@ cd /var/www/html/public
 
 echo "******************************* START deploy20 ******************************************"
 
+# Skip deployment script if ENV var is true
+if [ "$SKIP_DEPLOY_SCRIPTS" = "true" ]; then
+    echo "SKIP_DEPLOY_SCRIPTS is true. Stopping script."
+    exit 1
+fi
+
  function output_error_message {
    echo ${1}
    php ../docker/openshift/notify.php "${1}" || true

--- a/docker/openshift/entrypoints/20-deploy.sh
+++ b/docker/openshift/entrypoints/20-deploy.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-cd /var/www/html/public
-
 echo "******************************* START deploy20 ******************************************"
 
 # Skip deployment script if ENV var is true
 if [ "$SKIP_DEPLOY_SCRIPTS" = "true" ]; then
     echo "SKIP_DEPLOY_SCRIPTS is true. Stopping script."
-    exit 1
+    exit 0
 fi
+
+cd /var/www/html/public
 
  function output_error_message {
    echo ${1}

--- a/docker/openshift/entrypoints/20-deploy.sh
+++ b/docker/openshift/entrypoints/20-deploy.sh
@@ -4,98 +4,97 @@ echo "******************************* START deploy20 ***************************
 
 # Skip deployment script if ENV var is true
 if [ "$SKIP_DEPLOY_SCRIPTS" = "true" ]; then
-    echo "SKIP_DEPLOY_SCRIPTS is true. Stopping script."
-    exit 0
+    echo "SKIP_DEPLOY_SCRIPTS is true. Skipping the steps."
+else
+  cd /var/www/html/public
+
+  function output_error_message {
+    echo ${1}
+    php ../docker/openshift/notify.php "${1}" || true
+  }
+
+  # Make sure we have active Drupal configuration.
+  if [ ! -f "../conf/cmi/system.site.yml" ]; then
+    output_error_message "Container start error: Codebase is not deployed properly. Exiting early."
+    exit 1
+  fi
+
+  if [ ! -n "$OPENSHIFT_BUILD_NAME" ]; then
+    output_error_message "Container start error: OPENSHIFT_BUILD_NAME is not defined. Exiting early."
+    exit 1
+  fi
+
+  function get_deploy_id {
+    echo $(drush state:get deploy_id)
+  }
+
+  # Populate twig caches.
+  if [ ! -d "/tmp/twig" ]; then
+    drush twig:compile || true
+  fi
+
+  # Attempt to set deploy ID in case this is the first deploy.
+  if [[ -z "$(get_deploy_id)" ]]; then
+    drush state:set deploy_id $OPENSHIFT_BUILD_NAME
+  fi
+
+  # Exit early if deploy ID is still not set. This usually means either Redis or
+  # something else is down.
+  if [[ -z "$(get_deploy_id)" ]]; then
+    output_error_message "Container start error: Could not fetch deploy ID. Exiting early."
+    exit 1
+  fi
+
+  # This script is run every time a container is spawned and certain environments might
+  # start more than one Drupal container. This is used to make sure we run deploy
+  # tasks only once per deploy.
+  if [ "$(get_deploy_id)" != "$OPENSHIFT_BUILD_NAME" ]; then
+    drush state:set deploy_id $OPENSHIFT_BUILD_NAME
+
+    if [ $? -ne 0 ]; then
+      output_error_message "Deployment failed: Failed set deploy_id"
+      exit 1
+    fi
+
+    echo "Enable maintenance mode:"
+    # Put site in maintenance mode
+    drush state:set system.maintenance_mode 1 --input-format=integer
+
+    if [ $? -ne 0 ]; then
+      output_error_message "Deployment failed: Failed to enable maintenance_mode"
+      exit 1
+    fi
+    # Run helfi specific pre-deploy tasks. Allow this to fail in case
+    # the environment is not using the 'helfi_api_base' module.
+    # @see https://github.com/City-of-Helsinki/drupal-module-helfi-api-base
+    drush helfi:pre-deploy || true
+
+    # Run maintenance tasks (config import, database updates etc)
+    #drush deploy
+
+    OUTPUT=$(sh -c '(drush deploy); exit $?' 2>&1)
+    if [ $? -ne 0 ]; then
+      output_error_message "Deployment failed: drush deploy failed with: ${OUTPUT}"
+      exit 1
+    fi
+
+    #  if [ $? -ne 0 ]; then
+    #    output_error_message "Deployment failed: drush deploy failed with {$?} exit code. See logs for more information."
+    #    exit 1
+    #  fi
+    # Run helfi specific post deploy tasks. Allow this to fail in case
+    # the environment is not using the 'helfi_api_base' module.
+    # @see https://github.com/City-of-Helsinki/drupal-module-helfi-api-base
+    drush helfi:post-deploy || true
+
+    echo "Disable maintenance mode:"
+    # Disable maintenance mode
+    drush state:set system.maintenance_mode 0 --input-format=integer
+
+    if [ $? -ne 0 ]; then
+      output_error_message "Deployment failure: Failed to disable maintenance_mode"
+    fi
+  fi
 fi
-
-cd /var/www/html/public
-
- function output_error_message {
-   echo ${1}
-   php ../docker/openshift/notify.php "${1}" || true
- }
-
- # Make sure we have active Drupal configuration.
- if [ ! -f "../conf/cmi/system.site.yml" ]; then
-   output_error_message "Container start error: Codebase is not deployed properly. Exiting early."
-   exit 1
- fi
-
- if [ ! -n "$OPENSHIFT_BUILD_NAME" ]; then
-   output_error_message "Container start error: OPENSHIFT_BUILD_NAME is not defined. Exiting early."
-   exit 1
- fi
-
- function get_deploy_id {
-   echo $(drush state:get deploy_id)
- }
-
- # Populate twig caches.
- if [ ! -d "/tmp/twig" ]; then
-   drush twig:compile || true
- fi
-
- # Attempt to set deploy ID in case this is the first deploy.
- if [[ -z "$(get_deploy_id)" ]]; then
-   drush state:set deploy_id $OPENSHIFT_BUILD_NAME
- fi
-
- # Exit early if deploy ID is still not set. This usually means either Redis or
- # something else is down.
- if [[ -z "$(get_deploy_id)" ]]; then
-   output_error_message "Container start error: Could not fetch deploy ID. Exiting early."
-   exit 1
- fi
-
- # This script is run every time a container is spawned and certain environments might
- # start more than one Drupal container. This is used to make sure we run deploy
- # tasks only once per deploy.
- if [ "$(get_deploy_id)" != "$OPENSHIFT_BUILD_NAME" ]; then
-   drush state:set deploy_id $OPENSHIFT_BUILD_NAME
-
-   if [ $? -ne 0 ]; then
-     output_error_message "Deployment failed: Failed set deploy_id"
-     exit 1
-   fi
-
-   echo "Enable maintenance mode:"
-   # Put site in maintenance mode
-   drush state:set system.maintenance_mode 1 --input-format=integer
-
-   if [ $? -ne 0 ]; then
-     output_error_message "Deployment failed: Failed to enable maintenance_mode"
-     exit 1
-   fi
-   # Run helfi specific pre-deploy tasks. Allow this to fail in case
-   # the environment is not using the 'helfi_api_base' module.
-   # @see https://github.com/City-of-Helsinki/drupal-module-helfi-api-base
-   drush helfi:pre-deploy || true
-
-   # Run maintenance tasks (config import, database updates etc)
-   #drush deploy
-
-   OUTPUT=$(sh -c '(drush deploy); exit $?' 2>&1)
-   if [ $? -ne 0 ]; then
-     output_error_message "Deployment failed: drush deploy failed with: ${OUTPUT}"
-     exit 1
-   fi
-
-   #  if [ $? -ne 0 ]; then
-   #    output_error_message "Deployment failed: drush deploy failed with {$?} exit code. See logs for more information."
-   #    exit 1
-   #  fi
-   # Run helfi specific post deploy tasks. Allow this to fail in case
-   # the environment is not using the 'helfi_api_base' module.
-   # @see https://github.com/City-of-Helsinki/drupal-module-helfi-api-base
-   drush helfi:post-deploy || true
-
-   echo "Disable maintenance mode:"
-   # Disable maintenance mode
-   drush state:set system.maintenance_mode 0 --input-format=integer
-
-   if [ $? -ne 0 ]; then
-     output_error_message "Deployment failure: Failed to disable maintenance_mode"
-   fi
- fi
 
 echo "******************************* EXIT FROM deploy20 ******************************************"

--- a/docker/openshift/entrypoints/90-deploy.sh
+++ b/docker/openshift/entrypoints/90-deploy.sh
@@ -2,8 +2,13 @@
 
 echo "================== RUN FORM CONFIGS ==================="
 
-cd /var/www/html/public
+# Skip deployment script if ENV var is true
+if [ "$SKIP_DEPLOY_SCRIPTS" = "true" ]; then
+    echo "SKIP_DEPLOY_SCRIPTS is true. Stopping script."
+    exit 1
+fi
 
+cd /var/www/html/public
 
 function output_error_message {
   echo ${1}

--- a/docker/openshift/entrypoints/90-deploy.sh
+++ b/docker/openshift/entrypoints/90-deploy.sh
@@ -5,7 +5,6 @@ echo "================== RUN FORM CONFIGS ==================="
 # Skip deployment script if ENV var is true
 if [ "$SKIP_DEPLOY_SCRIPTS" = "true" ]; then
     echo "SKIP_DEPLOY_SCRIPTS is true. Skipping the steps."
-fi
 else
   cd /var/www/html/public
 

--- a/docker/openshift/entrypoints/90-deploy.sh
+++ b/docker/openshift/entrypoints/90-deploy.sh
@@ -4,80 +4,80 @@ echo "================== RUN FORM CONFIGS ==================="
 
 # Skip deployment script if ENV var is true
 if [ "$SKIP_DEPLOY_SCRIPTS" = "true" ]; then
-    echo "SKIP_DEPLOY_SCRIPTS is true. Stopping script."
-    exit 0
+    echo "SKIP_DEPLOY_SCRIPTS is true. Skipping the steps."
 fi
+else
+  cd /var/www/html/public
 
-cd /var/www/html/public
+  function output_error_message {
+    echo ${1}
+    php ../docker/openshift/notify.php "${1}" || true
+  }
 
-function output_error_message {
-  echo ${1}
-  php ../docker/openshift/notify.php "${1}" || true
-}
+  function get_deploy_id {
+    echo $(drush state:get deploy_id_config)
+  }
 
-function get_deploy_id {
-  echo $(drush state:get deploy_id_config)
-}
+  PREFIXED_OC_BUILD_NAME="GRANTS-$OPENSHIFT_BUILD_NAME"
+  DRUSH_GET_VAR=$(get_deploy_id)
 
-PREFIXED_OC_BUILD_NAME="GRANTS-$OPENSHIFT_BUILD_NAME"
-DRUSH_GET_VAR=$(get_deploy_id)
+  echo "Drush variable: $DRUSH_GET_VAR"
+  echo "Prefixed build name: $PREFIXED_OC_BUILD_NAME"
 
-echo "Drush variable: $DRUSH_GET_VAR"
-echo "Prefixed build name: $PREFIXED_OC_BUILD_NAME"
+  # This script is run every time a container is spawned and certain environments might
+  # start more than one Drupal container. This is used to make sure we run deploy
+  # tasks only once per deploy.
+  if [ "$DRUSH_GET_VAR" != "$PREFIXED_OC_BUILD_NAME" ]; then
 
-# This script is run every time a container is spawned and certain environments might
-# start more than one Drupal container. This is used to make sure we run deploy
-# tasks only once per deploy.
-if [ "$DRUSH_GET_VAR" != "$PREFIXED_OC_BUILD_NAME" ]; then
-
-  echo "Skip deploy commands to allow manual commands."
+    echo "Skip deploy commands to allow manual commands."
 
 
-  echo "Set varible to state: $PREFIXED_OC_BUILD_NAME "
-  drush state:set deploy_id_config $PREFIXED_OC_BUILD_NAME
+    echo "Set varible to state: $PREFIXED_OC_BUILD_NAME "
+    drush state:set deploy_id_config $PREFIXED_OC_BUILD_NAME
 
-  if [ $? -ne 0 ]; then
-    output_error_message "Deployment failed: Failed set deploy_id_config"
-    exit 1
+    if [ $? -ne 0 ]; then
+      output_error_message "Deployment failed: Failed set deploy_id_config"
+      exit 1
+    fi
+
+    # Put site in maintenance mode
+    echo "Site to maintenance"
+    drush state:set system.maintenance_mode 1 --input-format=integer
+    echo "DONE: Site to maintenance"
+
+    APP_ENV=${APP_ENV:-default}
+
+    echo "Import configs"
+    # import configs & overrides.
+    echo "DONE: Import configs"
+
+    echo "Import webform configs"
+    if [ "$APP_ENV" == 'staging' ] || [ "$APP_ENV" == 'development' ] || [ "$APP_ENV" == 'testing' ]; then
+      drush gwi --force
+    fi
+
+    if [ "$APP_ENV" == 'production' ] || [ "$APP_ENV" == 'default' ]; then
+      drush gwi
+    fi
+    echo "DONE: Import webform configs"
+
+    echo "Import overrides."
+    drush gwco
+    echo "DONE: Import overrides."
+
+    echo "Disable Maintenance"
+    # Disable maintenance mode
+    drush state:set system.maintenance_mode 0 --input-format=integer
+    echo "DONE: Disable maintenance."
+
+    if [ $? -ne 0 ]; then
+      output_error_message "Deployment failure: Failed to disable maintenance_mode"
+    fi
   fi
 
-  # Put site in maintenance mode
-  echo "Site to maintenance"
-  drush state:set system.maintenance_mode 1 --input-format=integer
-  echo "DONE: Site to maintenance"
+  echo "================== END FORM CONFIGS ==================="
 
-  APP_ENV=${APP_ENV:-default}
-
-  echo "Import configs"
-  # import configs & overrides.
-  echo "DONE: Import configs"
-
-  echo "Import webform configs"
-  if [ "$APP_ENV" == 'staging' ] || [ "$APP_ENV" == 'development' ] || [ "$APP_ENV" == 'testing' ]; then
-    drush gwi --force
-  fi
-
-  if [ "$APP_ENV" == 'production' ] || [ "$APP_ENV" == 'default' ]; then
-    drush gwi
-  fi
-  echo "DONE: Import webform configs"
-
-  echo "Import overrides."
-  drush gwco
-  echo "DONE: Import overrides."
-
-  echo "Disable Maintenance"
-  # Disable maintenance mode
-  drush state:set system.maintenance_mode 0 --input-format=integer
-  echo "DONE: Disable maintenance."
-
-  if [ $? -ne 0 ]; then
-    output_error_message "Deployment failure: Failed to disable maintenance_mode"
-  fi
+  echo "================== RUN TRANSLATION IMPORT ==================="
+  #drush locale:check; drush locale:update; drush cr
+  echo "================== END TRANSLATION IMPORT ==================="
 fi
-
-echo "================== END FORM CONFIGS ==================="
-
-echo "================== RUN TRANSLATION IMPORT ==================="
-#drush locale:check; drush locale:update; drush cr
-echo "================== END TRANSLATION IMPORT ==================="

--- a/docker/openshift/entrypoints/90-deploy.sh
+++ b/docker/openshift/entrypoints/90-deploy.sh
@@ -5,7 +5,7 @@ echo "================== RUN FORM CONFIGS ==================="
 # Skip deployment script if ENV var is true
 if [ "$SKIP_DEPLOY_SCRIPTS" = "true" ]; then
     echo "SKIP_DEPLOY_SCRIPTS is true. Stopping script."
-    exit 1
+    exit 0
 fi
 
 cd /var/www/html/public


### PR DESCRIPTION
# [AU-2234](https://helsinkisolutionoffice.atlassian.net/browse/AU-2234)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added check for ENV variable which allows skipping the deployments scripts

## How to install

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Add / edit `SKIP_DEPLOY_SCRIPTS` variable in Azure Library
* [ ] Run the pipeline against this branch
* [ ] When the variable is `"true"` the deployment process should skip executing the usual drush deploy / cims
* [ ] When there is no such variable or it's not true, process should go through normally.


[AU-2234]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ