### PR TITLE
AU-2257: Allow grants_admins to access resend page and submitted applications page

### DIFF
--- a/conf/cmi/user.role.grants_admin.yml
+++ b/conf/cmi/user.role.grants_admin.yml
@@ -28,6 +28,7 @@ dependencies:
     - content_translation
     - entity_usage
     - external_entities
+    - grants_admin_applications
     - helfi_tpr
     - locale
     - media
@@ -65,6 +66,9 @@ permissions:
   - 'access webform overview'
   - 'access webform submission log'
   - 'access webform submission user'
+  - 'administer grants_admin_applications configuration'
+  - 'administer grants_admin_resend_applications configuration'
+  - 'administer grants_admin_submitted_applications configuration'
   - 'administer menu'
   - 'administer nodes'
   - 'administer taxonomy'


### PR DESCRIPTION
# [AU-2257](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done

* Permission changes to allow grants_admins to access resend- & submitted applications pages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2257-resend-permissions`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `make shell`
* [ ] `drush uli --uid 1413`
* [ ] Check that you are logged in as Tero
* [ ] Check that you can see page links and access the pages (Reports -> ATV Data -> Resend Application Data / Submitted Applications Status)
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/43133397/e6ebbc09-0751-4eed-8244-5857a87697e7)



## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2257]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ