### PR TITLE
Feature/au 2150 skip tests on draft failure

### DIFF
--- a/e2e/utils/deletion_helpers.ts
+++ b/e2e/utils/deletion_helpers.ts
@@ -1,4 +1,4 @@
-import {expect, Page} from "@playwright/test";
+import {expect, Page, test} from "@playwright/test";
 import {FormData} from "./data/test_data";
 import {logger} from "./logger";
 
@@ -36,6 +36,11 @@ enum DeletionMethod {
  *   The env form data.
  */
 const deleteDraftApplication = async (formKey: string, page: Page, formDetails: FormData, storedata: any) => {
+  if (storedata === undefined || storedata[formKey] === undefined) {
+    logger(`Skipping deletion test: No env data stored after the "${formDetails.title}" test.`);
+    test.skip(true, 'Skip deletion test');
+  }
+
   const thisStoreData = storedata[formKey];
   if (thisStoreData.status !== 'DRAFT') {
     return;

--- a/e2e/utils/form_helpers.ts
+++ b/e2e/utils/form_helpers.ts
@@ -99,25 +99,12 @@ const fillGrantsFormPage = async (
   const expectedPattern = new RegExp(`^${formDetails.expectedDestination}`);
   expect(initialPathname).toMatch(expectedPattern);
 
+  // Store submissionUrl.
   const applicationId = await getApplicationNumberFromBreadCrumb(page);
   const submissionUrl = await extractUrl(page);
 
   // Hide the sliding popup once.
   await hideSlidePopup(page);
-
-  /**
-   * Save info about this application to env. This way they can be deleted
-   * via normal DRAFT deleting tests.
-   */
-  const storeName = `${profileType}_${formID}`;
-  const newData = {
-    [formKey]: {
-      submissionUrl: submissionUrl,
-      applicationId,
-      status: 'DRAFT'
-    }
-  }
-  saveObjectToEnv(storeName, newData);
 
   // Loop form pages
   for (const [formPageKey, formPageObject]

--- a/e2e/utils/validation_helpers.ts
+++ b/e2e/utils/validation_helpers.ts
@@ -1,4 +1,4 @@
-import {Page, expect} from "@playwright/test";
+import {Page, expect, test} from "@playwright/test";
 import {logger} from "./logger";
 import {
   FormField,
@@ -29,9 +29,12 @@ const validateSubmission = async (
   formDetails: FormData,
   storedata: any
 ) => {
+  if (storedata === undefined || storedata[formKey] === undefined) {
+    logger(`Skipping validation test: No env data stored after the "${formDetails.title}" test.`);
+    test.skip(true, 'Skip validation test');
+  }
 
   const thisStoreData = storedata[formKey];
-
   if (thisStoreData.status === 'DRAFT') {
     await validateDraft(page, formDetails, thisStoreData);
   } else {


### PR DESCRIPTION
# [AU-2226](https://helsinkisolutionoffice.atlassian.net/browse/AU-2226)

## What was done

This pull request implements "skip checks" for the "validation" and "deletion" tests. This means that neither of these tests will run if there is a problem with "draft" (or other variant) form test.

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2150-skip-tests-on-draft-failure`
* `make fresh`
* `make drush-cr`

## How to test

Start by running the tests normally and make sure everything works as before:
- `make test-pw-p PROJECT=forms-48`

Now, introduce some kind of error to the code that will make the draft test fail. For example, I did this in `registered_community_48.ts` (added a wrong value to the selector):


```
if (items['edit-budget-static-income-plannedothercompensations']) {
  await fillInputField(
    items['edit-budget-static-income-plannedothercompensations'].value ?? '',
    items['edit-budget-static-income-plannedothercompensations'].selector ?? {
      type: 'data-drupal-selector-sequential',
      name: 'data-drupal-selector',
      value: 'edit-budget-static-income-plannedothercompensationsssssssssssssss',
    },
    page,
    'edit-budget-static-income-plannedothercompensations'
  );
}
```
 
Now run the tests again. Make sure that the test for private persons and unregistered communities all work fine, but that the validation and deletion tests for registered communities are skipped:
- `make test-pw-p PROJECT=forms-48`