### PR TITLE
fix: AU-2297 remove asiointikansio -text from site

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/translations/fi.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/fi.po
@@ -62,7 +62,7 @@ msgstr "Oma asiointi"
 
 msgctxt "grants_oma_asiointi"
 msgid "Go to My Services"
-msgstr "Siirry omaan asiointiin"
+msgstr "Siirry omaan asiointi -sivulle"
 
 msgid "Community applications"
 msgstr "Yhteisön hakemukset"

--- a/public/modules/custom/grants_oma_asiointi/translations/fi.po
+++ b/public/modules/custom/grants_oma_asiointi/translations/fi.po
@@ -62,7 +62,7 @@ msgstr "Oma asiointi"
 
 msgctxt "grants_oma_asiointi"
 msgid "Go to My Services"
-msgstr "Siirry omaan asiointikansioon"
+msgstr "Siirry omaan asiointiin"
 
 msgid "Community applications"
 msgstr "Yhteisön hakemukset"

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -95,7 +95,7 @@ msgid "My Services"
 msgstr "Oma asiointi"
 
 msgid "Go to My Services"
-msgstr "Siirry omaan asiointikansioon"
+msgstr "Siirry omaan asiontiin"
 
 msgid "Grants profile"
 msgstr "Omat tiedot"

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -95,7 +95,7 @@ msgid "My Services"
 msgstr "Oma asiointi"
 
 msgid "Go to My Services"
-msgstr "Siirry omaan asiontiin"
+msgstr "Siirry omaan asionti -sivulle"
 
 msgid "Grants profile"
 msgstr "Omat tiedot"


### PR DESCRIPTION
# [AU-2297](https://helsinkisolutionoffice.atlassian.net/browse/AU-2297)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove outdated asiointikansio text from site

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2297-remove-avustuskansio`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [front page](https://hel-fi-drupal-grant-applications.docker.so/fi/) see that the oma asiointi block no longer mentions asiontikansio.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2297]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ