### PR TITLE
fix: AU-2254: change swedish transation

### DIFF
--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -160,7 +160,7 @@ msgstr "Syftet med verksamheten"
 
 msgctxt "grants_profile"
 msgid "Description of the purpose of the activity of the registered association (max. 500 characters)"
-msgstr "Beskrivning av syftet med den registrerade gemenskapens verksamhet (500 merkkiä)"
+msgstr "Beskrivning av syftet med den registrerade gemenskapens verksamhet (max. 500 tecken)"
 
 msgctxt "grants_profile"
 msgid "Addresses"

--- a/public/modules/custom/grants_profile/translations/sv.po
+++ b/public/modules/custom/grants_profile/translations/sv.po
@@ -37,7 +37,7 @@ msgstr "grantsProfileContent hittades inte!"
 
 msgctxt "grants_profile"
 msgid "Briefly describe the purpose for which the community is working and how the community is\nfulfilling its purpose. For example, you can use the text \"Community purpose and\nforms of action\" in the Community rules. Please do not describe the purpose of the grant here, it will be asked\nlater when completing the grant application."
-msgstr "Beskriv kortfattat syftet med vilket communityn arbetar och hur communityn uppfyller sitt syfte. Du kan till exempel använda texten \"Community purpose and forms of action\" i gemenskapens regler. Vänligen beskriv inte syftet av bidraget här kommer det att efterfrågas senare vid ifyllande av bidragsansökan."
+msgstr "Beskriv kortfattat syftet med vilket communityn arbetar och hur communityn uppfyller sitt syfte. Du kan till exempel använda texten \"Gemenskapens syfte och handlingsformer\" i gemenskapens regler. Vänligen beskriv inte syftet av bidraget här kommer det att efterfrågas senare vid ifyllande av bidragsansökan."
 
 msgctxt "grants_profile"
 msgid "@fieldname field is required"


### PR DESCRIPTION
# [AU-2254](https://helsinkisolutionoffice.atlassian.net/browse/AU-2254)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Omissa tiedoissa tooltipissa Community purpose and forms of action - tämä on ruotsipuolella. Vaihdettiin tämä muotoon Gemenskapens syfte och handlingsformer  
* In omat tiedot edit, fixed the max 500 characters text for swedish

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2254-change-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to swedish [edit omat tiedot](https://hel-fi-drupal-grant-applications.docker.so/sv/oma-asiointi/hakuprofiili/muokkaa)
* [ ] Check that the tooltip text in "Beskrivning av syftet med den registrerade gemenskapens verksamhet (max. 500 tecken)" is correct
* [ ] And that it says "max. 500 tecken", not "500 merkkiä"
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2254]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ