### PR TITLE
AU-2081: Add js_settings_build hook to force a setting to allways be available

### DIFF
--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -8,6 +8,7 @@
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Asset\AttachedAssetsInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -1977,4 +1978,15 @@ function grants_handler_user_login_form_submit(&$form, FormStateInterface $form_
     // Redirect the user after login.
     $form_state->setRedirect('system.admin_content');
   }
+}
+
+/**
+ * Implements hook_js_settings_build().
+ */
+function grants_handler_js_settings_build(&$settings, AttachedAssetsInterface $assets) {
+  // We set a dummy setting here for possibly fixing a problem with webform
+  // ajaxSettings being empty and breaking multivalue components
+  // and other components which are using ajax functions.
+  // See: AU-2081 https://helsinkisolutionoffice.atlassian.net/browse/AU-2081
+  $settings['grants_handler_dummy_setting'] = TRUE;
 }


### PR DESCRIPTION

# [AU-2081](https://helsinkisolutionoffice.atlassian.net/browse/AU-2081)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add dummy setting via alter hook,  this could we our AJAX problems by making settings object always available in the AJAX response. 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2081-ajax-settings-problem`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check with debugger that the value is set in /core/lib/Drupal/Core/Asset/AssetResolver.php after line 315

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2081]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ