### PR TITLE
fix: AU-2281: remove empty UL from messages list in /katso page

### DIFF
--- a/public/modules/custom/grants_handler/templates/message-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/message-list.html.twig
@@ -1,7 +1,9 @@
-<ul class="webform-submission-messages__messages-list">
- {% for item in items %}
-        <li data-message-id="{{item["#message"].messageId}}" class="webform-submission-messages__message">
-          {{ item }}
-        </li>
-  {% endfor %}
-</ul>
+{% if items %}
+  <ul class="webform-submission-messages__messages-list">
+    {% for item in items %}
+      <li data-message-id="{{item["#message"].messageId}}" class="webform-submission-messages__message">
+        {{ item }}
+      </li>
+    {% endfor %}
+  </ul>
+{% endif %}


### PR DESCRIPTION
# [AU-2281](https://helsinkisolutionoffice.atlassian.net/browse/AU-2281)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed an empty `<ul>` element from application view page ("/katso") if message list is empty.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2281-empty-ul`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to view an application you've sent but have not sent/received messages on (this is the /katso -page)
* [ ] check source code that there is no `<ul>` element with the class `webform-submission-messages__messages-list`
* [ ] Send a message on the page.
* [ ] Refresh and check source code that there is an `<ul>` element with the class `webform-submission-messages__messages-list`
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2281]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ