### PR TITLE
AU-2307: Fix navigation handler bug

### DIFF
--- a/public/modules/custom/grants_handler/src/GrantsHandlerNavigationHelper.php
+++ b/public/modules/custom/grants_handler/src/GrantsHandlerNavigationHelper.php
@@ -128,8 +128,12 @@ class GrantsHandlerNavigationHelper {
    */
   public function hasVisitedPage(WebformSubmissionInterface $webformSubmission, ?string $page): bool {
     // Get outta here if the submission hasn't been saved yet.
-    if (empty($webformSubmission->id()) || empty($page)) {
+    if (empty($webformSubmission->id())) {
       return FALSE;
+    }
+    // Set the page to the current page if it is empty.
+    if (empty($page)) {
+      $page = $this->getCurrentPage($webformSubmission);
     }
     $submissionLog = $this->getPageVisits($webformSubmission);
     $hasVisited = FALSE;
@@ -260,12 +264,12 @@ class GrantsHandlerNavigationHelper {
    *
    * @param \Drupal\webform\WebformSubmissionInterface $webformSubmission
    *   A webform submission entity.
-   * @param string $page
+   * @param ?string $page
    *   The page to log.
    *
    * @throws \Exception
    */
-  public function logPageVisit(WebformSubmissionInterface $webformSubmission, $page) {
+  public function logPageVisit(WebformSubmissionInterface $webformSubmission, ?string $page) {
 
     // Set the page to the current page if it is empty.
     if (empty($page)) {
@@ -458,7 +462,6 @@ class GrantsHandlerNavigationHelper {
         $paged_errors[$current_page][$element] = $error;
       }
     }
-
     return $paged_errors;
   }
 

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -864,6 +864,7 @@ class GrantsHandler extends WebformHandlerBase {
    */
   public function alterFormNavigation(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
     // Log the current page.
+    // This is null on initial form load but navigationhelper handles that.
     $current_page = $webform_submission->getCurrentPage();
     $webform = $webform_submission->getWebform();
     // Actions to perform if there are pages.


### PR DESCRIPTION
# [AU-2307](https://helsinkisolutionoffice.atlassian.net/browse/AU-2307)
<!-- What problem does this solve? -->

Virheiden puutteellinen näkyminen lomaketta täytettäessä.

## What was done
<!-- Describe what was done -->

* Käytä ensimmäistä sivua oletuksena

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2307-navigation-helper-bug`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Mene lomakkeelle
* [x] Siirry lomakkeen navigaation avulla toiselle sivulle
* [x] Tyhjäksi jätetyt ensimmäisen sivun virheet tulevat näkyville

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-2307]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ