### PR TITLE
AU-2325: Avoid function call without actual object

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormRegisteredCommunity.php
@@ -91,11 +91,11 @@ class GrantsProfileFormRegisteredCommunity extends GrantsProfileFormBase {
     $form = parent::buildForm($form, $form_state);
     $grantsProfile = $this->getGrantsProfileDocument();
 
-    $isNewGrantsProfile = $grantsProfile->getTransactionId();
-
     if ($grantsProfile == NULL) {
       return [];
     }
+
+    $isNewGrantsProfile = $grantsProfile->getTransactionId();
 
     // Handle multiple editors.
     $lockService = \DrupaL::service('grants_handler.form_lock_service');


### PR DESCRIPTION
# [AU-2325](https://helsinkisolutionoffice.atlassian.net/browse/AU-2325)
<!-- What problem does this solve? -->

Funktio-kutsu aiheuttaa booleanille virheen

## What was done
<!-- Describe what was done -->

* Siirrä funktiokutsu parempaan kohtaan koodissa.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2325-function-call-error`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* En keksinyt miten sentryssä nähdyn ongelman saisi toistettua oikeasti.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [x] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2325]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ