### PR TITLE
fix: AU-2331: Place of operation "free" state fix

### DIFF
--- a/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Element/PlaceOfOperationComposite.php
@@ -216,10 +216,10 @@ class PlaceOfOperationComposite extends WebformCompositeBase {
     $element = parent::processWebformComposite($element, $form_state, $complete_form);
     $elementValue = $element['#value'];
 
-    if (isset($element["free"]) && $elementValue["free"] === "false") {
+    if (isset($element["free"]) && ($elementValue["free"] === "false" || $elementValue["free"] === false)) {
       $element["free"]["#default_value"] = 0;
     }
-    if (isset($element["free"]) && $elementValue["free"] === "true") {
+    if (isset($element["free"]) && ($elementValue["free"] === "true" || $elementValue["free"] === true)) {
       $element["free"]["#default_value"] = 1;
     }
 


### PR DESCRIPTION
# [AU-2331](https://helsinkisolutionoffice.atlassian.net/browse/AU-2331)

## What was done
This pull request fixes an issue with the "Place of operation" components "free" field. Previously, a selected value of "No" would be de-selected when editing an application that was previously saved as a "draft". Now, the value stays selected.

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2331-component-state-bug`
* `make fresh`
* `make drush-cr`

## How to test
- Login with a registered community role and go to a [form](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-toiminta-av) that has the component.
- Go to page three (3), Fill in the section "Toimintapaikkojen perustiedot" and select "Ei" in the field "Toimintaa järjestetään kaupungin opetus-, sosiaali- tai nuorisotoimelta saaduissa maksuttomissa tiloissa".
![Screenshot 2024-04-04 at 11 50 13](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/61b6ab73-cc9c-4235-b81a-1bd0db57137e)
- Save the form as a draft.
- Edit the form, go back to the same page, and make sure the "Ei" value is still selected.
- Perform the same check with the "Kyllä" value.


[AU-2331]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ