### PR TITLE
fix: AU-2348: fix vastuuhenkilo in tyollisyyshakemus

### DIFF
--- a/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -189,8 +189,8 @@ elements: |-
         '#title': 'Valitse toiminnasta vastaavat henkilöt'
         '#multiple': true
         '#multiple__item_label': henkilö
-        '#multiple__min_items': 0
-        '#multiple__empty_items': 1
+        '#multiple__min_items': 1
+        '#multiple__empty_items': 0
         '#multiple__sorting': false
         '#multiple__add': false
         '#multiple__add_more_input': false


### PR DESCRIPTION
# [AU-2348](https://helsinkisolutionoffice.atlassian.net/browse/AU-2348)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed people responsible for operations -fields logic

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2348-vastuuhenkilo`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [KANSLIATYO](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kaupunginkanslia_tyollisyysavust)
* [ ] Check that in the first page there is one select-field for persons responsible for operations, and it cant be fully deleted

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [x] This PR passes regression tests. (`make test-pw`)


[AU-2348]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ