### PR TITLE
fix: AU-2330: fix dates in Place of operations

### DIFF
--- a/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
@@ -5,6 +5,7 @@ namespace Drupal\grants_place_of_operation\Plugin\WebformElement;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\webform\WebformSubmissionInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
 
 /**
  * Provides a 'place_of_operation_composite' element.
@@ -109,7 +110,8 @@ class PlaceOfOperationComposite extends WebformCompositeBase {
         // Convert date strings.
         if ($fieldName === 'rentTimeBegin' || $fieldName === 'rentTimeEnd') {
           if ($fieldValue) {
-            $fieldValue = date("j.n.Y", strtotime(date($fieldValue)));
+            $dateTime = new DrupalDateTime($fieldValue);
+            $fieldValue = $dateTime->format('j.n.Y');
           }
         }
 


### PR DESCRIPTION
# [AU-2330](https://helsinkisolutionoffice.atlassian.net/browse/AU-2330)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Dates were shown wrong if dates added were before turning clocks
* Simplified date formatting, works now as expected

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2330-dates`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [KASKOIPTOIM](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-toiminta-av)
* [ ] Go to page 3
* [ ] Go to "Toimintapaikkojen perustiedot", select Ei in "Toimintaa järjestetään kaupungin opetus-, sosiaali- tai nuorisotoimelta saaduissa maksuttomissa tiloissa"
* [ ] Add dates after turning clocks, for example in april
* [ ] Save as draft, check that dates shown in preview are the same that you chose
* [ ] Go to edit draft
* [ ] Change dates to before turning clocks, for example last year
* [ ] Save as draft, check that dates shown in preview are the same that you chose

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-2330]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ