### PR TITLE
fix: AU-2345 Add translations for file name

### DIFF
--- a/public/modules/custom/grants_metadata/translations/fi.po
+++ b/public/modules/custom/grants_metadata/translations/fi.po
@@ -80,3 +80,6 @@ msgctxt "grants_metadata"
 msgid 'Subvention type'
 msgstr 'Avustuslajin koodi'
 
+msgctxt "grants_metadata"
+msgid "File name"
+msgstr "Tiedostonimi"

--- a/public/modules/custom/grants_metadata/translations/sv.po
+++ b/public/modules/custom/grants_metadata/translations/sv.po
@@ -79,3 +79,7 @@ msgstr "Bilaga"
 msgctxt "grants_handler"
 msgid "Subvention type"
 msgstr "Typ av bidrag"
+
+msgctxt "grants_metadata"
+msgid "File name"
+msgstr "Filnamn"


### PR DESCRIPTION
# [AU-2345](https://helsinkisolutionoffice.atlassian.net/browse/AU-2345)
<!-- What problem does this solve? -->

Tulostusnäkymässä on File name aina englanniksi.

## What was done
<!-- Describe what was done -->

* Lisää merkkijonolle käännös oikealla kontekstilla.

ATVScheman uudelleenkirjoituksessa koodiin on lisätty konteksti ilman lisättyä käännöstä.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2345-translation-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Mene lomakkeelle jolla on liitetiedosto
* [ ] Jos se on tallennettu ennen tässä PR:ssä tulleiden käännösten tuomista, file name on englanniksi tulostusnäkymässä.
* [ ] Tallenna lomake kun käännökset on päivitetty (joko suomi- tai ruotsi-puolella)
* [ ] Nyt merkkijono käännetään oikein.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [x] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2345]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ