### PR TITLE
fix: AU-2355: Copying applications with empty date fields

### DIFF
--- a/public/modules/custom/grants_metadata/src/GrantsConverterService.php
+++ b/public/modules/custom/grants_metadata/src/GrantsConverterService.php
@@ -17,7 +17,7 @@ class GrantsConverterService {
   /**
    * Format dates to a given or default format.
    *
-   * @param string $value
+   * @param mixed $value
    *   Input value.
    * @param array $arguments
    *   Arguments, dateFormat is used.
@@ -25,7 +25,7 @@ class GrantsConverterService {
    * @return string
    *   Formatted datetime string.
    */
-  public function convertDates(string $value, array $arguments): string {
+  public function convertDates(mixed $value, array $arguments): string {
 
     try {
       if ($value === NULL || $value === '' || !isset($value)) {


### PR DESCRIPTION
# [AU-2355](https://helsinkisolutionoffice.atlassian.net/browse/AU-2355)

## What was done
This pull request fixes an issue where copying an application with an empty date field would cause an ajax error:

![Screenshot 2024-04-09 at 15 21 34](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/4327a55a-2778-4bb7-bd27-be756bacef67)

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2355-application-copy-fix`
* `make fresh`
* `make drush-cr`

## How to test

- Login with a registered community role and start a new application. Make sure the application has a date field somewhere, for example, [Taide- ja kulttuuriavustukset: projektiavustukset](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kuva-projekti).

- Save the application as a draft and copy it by clicking "Kopioi hakemus". Make sure the application is copied.

- If you want to, you can run `make test-pw-p PROJECT=forms-48-registered` to make sure the application still works normally.

[AU-2355]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ