### PR TITLE
feat: AU-2367: E2E, Skip application copying test if copying is disabled

### DIFF
--- a/e2e/utils/copying_helpers.ts
+++ b/e2e/utils/copying_helpers.ts
@@ -131,7 +131,7 @@ const makeApplicationCopy = async (
   logger(`Copying application: ${originalApplicationId}...`);
 
   await page.locator('#copy-application-modal-form-link').click();
-  await page.locator('span', { hasText: 'Käytä hakemusta pohjana' }).click();
+  await page.locator('#copy-application-modal-form-submit').click();
 
   // Wait for a redirect to the new application and store the new application ID and submission URL.
   await page.waitForURL('**/muokkaa');

--- a/e2e/utils/copying_helpers.ts
+++ b/e2e/utils/copying_helpers.ts
@@ -120,9 +120,16 @@ const makeApplicationCopy = async (
   const applicationIdContainerText = await applicationIdContainer.textContent();
   expect(applicationIdContainerText).toContain(originalApplicationId);
 
+  // Make sure the application can be copied. If not, skip this test.
+  const isCopyApplicationButtonVisible = await page.locator('#copy-application-modal-form-link').isVisible();
+  if (!isCopyApplicationButtonVisible) {
+    logger(`Copying disabled for application: ${originalApplicationId}. Skipping test.`);
+    test.skip(true, 'Skip copy test');
+  }
+
   // Copy the original application.
   logger(`Copying application: ${originalApplicationId}...`);
-  // Use #id as selector since the button text is not unique
+
   await page.locator('#copy-application-modal-form-link').click();
   await page.locator('span', { hasText: 'Käytä hakemusta pohjana' }).click();
 

--- a/public/modules/custom/grants_handler/src/Form/CopyApplicationModalForm.php
+++ b/public/modules/custom/grants_handler/src/Form/CopyApplicationModalForm.php
@@ -163,6 +163,9 @@ class CopyApplicationModalForm extends FormBase {
         'callback' => '::ajaxSubmitForm',
         'event' => 'click',
       ],
+      '#attributes' => [
+        'id' => 'copy-application-modal-form-submit',
+      ],
     ];
 
     // Set the form to not use AJAX if we're on a nojs path. When this form is


### PR DESCRIPTION
# [AU-2347](https://helsinkisolutionoffice.atlassian.net/browse/AU-2347)

## What was done

This pull request fixes an issue where copying an application that has disabled copying would make the tests fail. Now, the copying test is skipped if an application has disabled copying.

## Other smaller changes

- Added an ID to the copy application modal button.
  
## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2367-e2e-copy-test-open-application`
* `make fresh`
* `make drush-cr`

## How to test

- Go to the [settings page](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/kuva_projekti/settings) of the **Taide- ja kulttuuriavustukset: projektiavustukset** form and `disable copying` at the bottom of the page.

- Set `ENABLED_FORM_VARIANTSS="copy"` in your `.env` file. 

- Run `make test-pw-p PROJECT=forms-48-registered` and make sure you get an output like this:

![Screenshot 2024-04-12 at 8 19 15](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/2960f947-da8d-4adc-ae8b-4540966d4a6c)

- Go back to the [settings page](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/kuva_projekti/settings) of the of the form and `enable copying` of the application.

- Run `make test-pw-p PROJECT=forms-48-registered` again. Make sure you get an output like this:

![Screenshot 2024-04-12 at 8 40 28](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/d3c3ccbd-6df4-43b3-bcfd-35a2a98280f6)




[AU-2347]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ