### PR TITLE
fix: AU-2081: ajax settings cache issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,8 @@
         "patches": {
             "drupal/core": {
                 "Fix missing wrapper from core form": "patches/fix-form-wrapper.patch",
-                "#3023228: Status messages show up twice": "https://www.drupal.org/files/issues/2023-07-19/3023228-39.patch"
+                "#3023228: Status messages show up twice": "https://www.drupal.org/files/issues/2023-07-19/3023228-39.patch",
+                "Asset resolver empty settings cache issue": "patches/assetresolver-settings.patch"
             },
             "drupal/content_lock": {
                 "Fix missing types": "https://www.drupal.org/files/issues/2021-10-15/array_filter_issue-3243486-a.patch"

--- a/patches/assetresolver-settings.patch
+++ b/patches/assetresolver-settings.patch
@@ -1,0 +1,59 @@
+diff --git a/core/lib/Drupal/Core/Asset/AssetResolver.php b/core/lib/Drupal/Core/Asset/AssetResolver.php
+index 251b9036f3..c20a7a8d4a 100644
+--- a/core/lib/Drupal/Core/Asset/AssetResolver.php
++++ b/core/lib/Drupal/Core/Asset/AssetResolver.php
+@@ -328,6 +328,11 @@ public function getJsAssets(AttachedAssetsInterface $assets, $optimize, Language
+       $this->cache->set($cid, [$js_assets_header, $js_assets_footer, $settings, $settings_in_header], CacheBackendInterface::CACHE_PERMANENT, ['library_info']);
+     }
+
++    // Double check settings, as Drupal might've cached empty settings.
++    if (empty($settings) && \Drupal::requestStack()->getCurrentRequest()->getMethod() == 'POST') {
++      $settings = $this->doubleCheckSettings($assets);
++    }
++
+     if ($settings !== FALSE) {
+       // Attached settings override both library definitions and
+       // hook_js_settings_build().
+@@ -365,6 +370,42 @@ public function getJsAssets(AttachedAssetsInterface $assets, $optimize, Language
+     ];
+   }
+
++  /*
++   * Double check settings (workaround for enpty settings cache).
++   * This function is a copy/paste of a portion of getJsAssets().
++   *
++   * @see AjaxResponseAttachmentsProcessor::buildAttachmentsCommands()
++   *
++   * @param \Drupal\Core\Asset\AttachedAssetsInterface $assets
++   *   The assets attached to the current response.
++   *   Note that this object is modified to reflect the final JavaScript
++   *   settings assets.
++   *
++   * @return array|bool
++   *   Return attached settings array or False.
++   */
++  public function doubleCheckSettings(AttachedAssetsInterface $assets) {
++    // If the core/drupalSettings library is being loaded or is already
++    // loaded, get the JavaScript settings assets, and convert them into a
++    // single "regular" JavaScript asset.
++    $libraries_to_load = $this->getLibrariesToLoad($assets);
++    $settings_required = in_array('core/drupalSettings', $libraries_to_load) || in_array('core/drupalSettings', $this->libraryDependencyResolver->getLibrariesWithDependencies($assets->getAlreadyLoadedLibraries()));
++    $settings_have_changed = count($libraries_to_load) > 0 || count($assets->getSettings()) > 0;
++
++    // Initialize settings to FALSE since they are not needed by default. This
++    // distinguishes between an empty array which must still allow
++    // hook_js_settings_alter() to be run.
++    $settings = FALSE;
++    if ($settings_required && $settings_have_changed) {
++      $settings = $this->getJsSettingsAssets($assets);
++      // Allow modules to add cached JavaScript settings.
++      $this->moduleHandler->invokeAllWith('js_settings_build', function (callable $hook, string $module) use (&$settings, $assets) {
++        $hook($settings, $assets);
++      });
++    }
++    return $settings;
++  }
++
+   /**
+    * Sorts CSS and JavaScript resources.
+    *

--- a/patches/assetresolver-settings.patch
+++ b/patches/assetresolver-settings.patch
@@ -1,59 +1,15 @@
 diff --git a/core/lib/Drupal/Core/Asset/AssetResolver.php b/core/lib/Drupal/Core/Asset/AssetResolver.php
-index 251b9036f3..c20a7a8d4a 100644
+index 251b9036f3..06ac3e41a4 100644
 --- a/core/lib/Drupal/Core/Asset/AssetResolver.php
 +++ b/core/lib/Drupal/Core/Asset/AssetResolver.php
-@@ -328,6 +328,11 @@ public function getJsAssets(AttachedAssetsInterface $assets, $optimize, Language
-       $this->cache->set($cid, [$js_assets_header, $js_assets_footer, $settings, $settings_in_header], CacheBackendInterface::CACHE_PERMANENT, ['library_info']);
+@@ -325,7 +325,9 @@ public function getJsAssets(AttachedAssetsInterface $assets, $optimize, Language
+         });
+       }
+       $settings_in_header = in_array('core/drupalSettings', $header_js_libraries);
+-      $this->cache->set($cid, [$js_assets_header, $js_assets_footer, $settings, $settings_in_header], CacheBackendInterface::CACHE_PERMANENT, ['library_info']);
++      if (!empty($libraries_to_load)) {
++        $this->cache->set($cid, [$js_assets_header, $js_assets_footer, $settings, $settings_in_header], CacheBackendInterface::CACHE_PERMANENT, ['library_info']);
++      }
      }
 
-+    // Double check settings, as Drupal might've cached empty settings.
-+    if (empty($settings) && \Drupal::requestStack()->getCurrentRequest()->getMethod() == 'POST') {
-+      $settings = $this->doubleCheckSettings($assets);
-+    }
-+
      if ($settings !== FALSE) {
-       // Attached settings override both library definitions and
-       // hook_js_settings_build().
-@@ -365,6 +370,42 @@ public function getJsAssets(AttachedAssetsInterface $assets, $optimize, Language
-     ];
-   }
-
-+  /*
-+   * Double check settings (workaround for enpty settings cache).
-+   * This function is a copy/paste of a portion of getJsAssets().
-+   *
-+   * @see AjaxResponseAttachmentsProcessor::buildAttachmentsCommands()
-+   *
-+   * @param \Drupal\Core\Asset\AttachedAssetsInterface $assets
-+   *   The assets attached to the current response.
-+   *   Note that this object is modified to reflect the final JavaScript
-+   *   settings assets.
-+   *
-+   * @return array|bool
-+   *   Return attached settings array or False.
-+   */
-+  public function doubleCheckSettings(AttachedAssetsInterface $assets) {
-+    // If the core/drupalSettings library is being loaded or is already
-+    // loaded, get the JavaScript settings assets, and convert them into a
-+    // single "regular" JavaScript asset.
-+    $libraries_to_load = $this->getLibrariesToLoad($assets);
-+    $settings_required = in_array('core/drupalSettings', $libraries_to_load) || in_array('core/drupalSettings', $this->libraryDependencyResolver->getLibrariesWithDependencies($assets->getAlreadyLoadedLibraries()));
-+    $settings_have_changed = count($libraries_to_load) > 0 || count($assets->getSettings()) > 0;
-+
-+    // Initialize settings to FALSE since they are not needed by default. This
-+    // distinguishes between an empty array which must still allow
-+    // hook_js_settings_alter() to be run.
-+    $settings = FALSE;
-+    if ($settings_required && $settings_have_changed) {
-+      $settings = $this->getJsSettingsAssets($assets);
-+      // Allow modules to add cached JavaScript settings.
-+      $this->moduleHandler->invokeAllWith('js_settings_build', function (callable $hook, string $module) use (&$settings, $assets) {
-+        $hook($settings, $assets);
-+      });
-+    }
-+    return $settings;
-+  }
-+
-   /**
-    * Sorts CSS and JavaScript resources.
-    *


### PR DESCRIPTION
# [AU-2081](https://helsinkisolutionoffice.atlassian.net/browse/AU-2081)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added patch which will make Drupal Core AssetResolver class to not cache js assets which has an empty libraries_to_load array

As the class generates cache key by hashing $libraries_to_load array, it causes some issues with webform ajax functionality and with the autologout module.

## Steps to reproduce to original problem

* [ ] Login as normal user and select company etc..
* { ] Clear your cache `make drush-cr`
* [ ] Edit your `local.settings.php` value `$config['autologout.settings']['timeout']` to shorter one (like 5 or 10).
* [ ] Refresh the page, and wait for few moments until you see the auto logout spinner (or check network tab for ajax requests)
* [ ] (You can now edit the timeout value back to higher one, so you don't need to click autologout dialog all the time)
* [ ] Open any webform application and check add / remove buttons, you should be use these only once. (This might be in FI or EN side randomly).

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2081-ajax-issues`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check the reproduce steps and make sure you cannot replicate this issue any more
* [ ] Check that autologout works as usual.
