### PR TITLE
fix: AU-2366: Fix application search card lead-in text display

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/field/field--field-lead-in.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/field/field--field-lead-in.html.twig
@@ -1,0 +1,27 @@
+{% set content %}
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+{% endset %}
+
+{% if content|render %}
+  <section class="lead-in" aria-labelledby="lead-in__label">
+    {% embed "@hdbt/misc/component.twig" with
+      {
+        component_classes: [
+        'component--lead-in',
+        'component--hardcoded'
+      ],
+      }
+    %}
+      {% block component_content %}
+
+        {{ content }}
+
+      {% endblock component_content %}
+    {% endembed %}
+    <span id="lead-in__label" class="is-hidden" {{ alternative_language ? create_attribute(({ 'lang': lang_attributes.fallback_lang, 'dir': lang_attributes.fallback_dir })) }}>
+      {{ 'Lead-in paragraph'|t({}, {'context': 'Page lead-in section explanation for screen readers'}) }}
+    </span>
+  </section>
+{% endif %}


### PR DESCRIPTION
# [AU-2366](https://helsinkisolutionoffice.atlassian.net/browse/AU-2366)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Moved the hidden aria label to come after the text so that it won't get parsed in front of our text-only displays when the markup is stripped from the field.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2366-etsi-avustusta-johdanto`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Etsi avustusta](https://hel-fi-drupal-grant-applications.docker.so/fi/etsi-avustusta) page and see that the "johdanto" text has disappeared from the cards.
* [ ] Go to a [service page](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/liikunnan-avustukset) and see that the lead-in paragraph (ingress) isn't affected by the change.
* [ ] Bonus points: use a screen reader to hear that the lead-in paragraph is still labeled with the same text.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2366]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ