### PR TITLE
feat: AU-2384: E2E, Implemented soft assertion for verifySubmit

### DIFF
--- a/e2e/utils/form_helpers.ts
+++ b/e2e/utils/form_helpers.ts
@@ -1,5 +1,5 @@
 import {logger} from "./logger";
-import {hideSlidePopup, extractPath} from "./helpers";
+import {hideSlidePopup, extractPath, waitForTextWithInterval} from "./helpers";
 import {validateFormErrors} from "./error_validation_helpers";
 import {validateHiddenFields} from "./validation_helpers";
 import {saveObjectToEnv} from "./env_helpers";
@@ -263,8 +263,15 @@ const verifySubmit = async (
 ) => {
 
   await expect(page.getByRole('heading', {name: 'Avustushakemus lähetetty onnistuneesti'})).toBeVisible();
-  await expect(page.getByText('Lähetetty - odotetaan vahvistusta').first()).toBeVisible()
-  await expect(page.getByText('Vastaanotettu', {exact: true})).toBeVisible({timeout: 90 * 1000})
+  await expect(page.getByText('Lähetetty - odotetaan vahvistusta').first()).toBeVisible();
+
+  // Attempt to locate the "Vastaanotettu" text on the page. Keep polling for 60000ms (1 minute).
+  // Note: We do this instead of using Playwrights "expect" method so that test execution isn't interrupted if this fails.
+  const applicationReceived = await waitForTextWithInterval(page, 'Vastaanotettu', 60000, 5000);
+  if (!applicationReceived) {
+    logger('WARNING: Failed to validate that the application was received.');
+    return;
+  }
 
   let applicationId = await page.locator(".grants-handler__completion__item--number").innerText();
   applicationId = applicationId.replace('Hakemusnumero\n', '')

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -95,10 +95,52 @@ const getApplicationNumberFromBreadCrumb = async (page: Page) => {
   return await breadcrumbLinks[breadcrumbLinks.length - 1].textContent();
 }
 
+/**
+ * The waitForTextWithInterval function.
+ *
+ * This function waits for text to be visible on the page,
+ * retrying every interval until a timeout. Can be used to implement soft
+ * assertion-like behavior by not throwing an error if it fails.
+ *
+ * @param page
+ *   The Playwright page object.
+ * @param text
+ *   The text to look for on the page.
+ * @param timeout
+ *   Maximum time in milliseconds to retry.
+ * @param interval
+ *   Time in milliseconds between retries.
+ */
+const waitForTextWithInterval = async (
+  page: Page,
+  text: string,
+  timeout: number,
+  interval: number
+): Promise<boolean> => {
+  logger(`Attempting to locate text: "${text}"...`);
+  const startTime = Date.now();
+
+  while (true) {
+    try {
+      await page.getByText(text, {exact: true}).waitFor({state: 'visible', timeout : interval})
+      logger('Text found!');
+      return true;
+    } catch (error) {
+      const currentTime = Date.now();
+      if ((currentTime - startTime) > timeout) {
+        logger(`Failed to find text. Timeout: ${timeout}ms. Interval: ${interval}ms.`);
+        return false;
+      }
+      logger('Timeout passed. Retrying...');
+    }
+  }
+}
+
 export {
   slowLocator,
   extractPath,
   hideSlidePopup,
   getApplicationNumberFromBreadCrumb,
+  waitForTextWithInterval,
 };
 

--- a/e2e/utils/validation_helpers.ts
+++ b/e2e/utils/validation_helpers.ts
@@ -33,30 +33,10 @@ const validateSubmission = async (
   }
 
   const thisStoreData = storedata[formKey];
-  if (thisStoreData.status === 'DRAFT') {
+  if (thisStoreData.status === 'DRAFT' || thisStoreData.status === 'RECEIVED') {
     await navigateAndValidateViewPage(page, thisStoreData);
     await validateFormData(page, formDetails);
-  } else {
-    await validateSent(page, formDetails, thisStoreData);
   }
-}
-
-/**
- * The validateSent function.
- *
- * @param page
- *   Page object from Playwright.
- * @param formDetails
- *   The form data.
- * @param thisStoreData
- *   The env form data.
- */
-const validateSent = async (
-  page: Page,
-  formDetails: FormData,
-  thisStoreData: any
-) => {
-  logger('Validate RECEIVED', thisStoreData);
 }
 
 /**


### PR DESCRIPTION
# [AU-2384](https://helsinkisolutionoffice.atlassian.net/browse/AU-2384)

## What was done

This pull request implements soft assertion for the `verifySubmit` function that is called right after an application has been submitted.

When an application is submitted, the tests start waiting for a "Vastaanotettu" text to appear on the page, which indicates that an application has been received by Avustus2. Sometimes this text doesn't show up, which would cause our old test implementation to fail and skip other tests inside the same test file.

Now, the `verifySubmit` function calls `waitForTextWithInterval`, which looks for the "Vastaanotettu" text for a total of 60 seconds. If the text is never found, we simply return instead of throwing and error. A warning text is also displayed.

## Other small changes

- `validation_helpers.ts:` Added validation to submitted applications.

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2384-e2e-submit-form-timeout`
* `make fresh`
* `make drush-cr`

## How to test

- Start by setting `ENABLED_FORM_VARIANTS="success,draft"` in your `.env` file.

- Find the `verifySubmit` function inside `form_helpers.ts` and edit the `Vastaanotettu` text to `Vastaanotettuuuu` inside the `waitForTextWithInterval` call. We do this to mimic a situation where the `Vastaanotettu` text never appears on the page.

- Run `make test-pw-p PROJECT=forms-48-registered`. Note that the deletion and validation parts of the "draft" test work normally even though we failed to validate that the application was received in the "success" test. With our old code, none of these tests would have executed. Make sure your output looks something like this:

![Screenshot 2024-04-17 at 15 13 42](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/7d3c8dbd-d12c-4181-bea5-0dd7981fd686)

- Change the text back to `Vastaanotettu` and run `make test-pw-p PROJECT=forms-48-registered` again. Your output should look something like this:

![Screenshot 2024-04-17 at 15 14 09](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/e364f05f-b82d-4918-b588-7e721ddf6345)


[AU-2384]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ