### PR TITLE
fix: AU-2414: Change log in button to have role=link

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -562,6 +562,7 @@ function hdbt_subtheme_preprocess_html(&$variables): void {
 function hdbt_subtheme_form_alter(&$form, FormStateInterface $form_state, $form_id): void {
   if ($form_id == 'openid_connect_login_form') {
     $form['openid_connect_client_tunnistamo_login']['#value'] = t('Log in');
+    $form['openid_connect_client_tunnistamo_login']['#attributes']['role'] = "link";
   }
 
   // Attach the restricted-datepicker library to the various forms.


### PR DESCRIPTION
# [AU-2414](https://helsinkisolutionoffice.atlassian.net/browse/AU-2414)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Log in buttons have role="link" to identify it as link that directs to another page instead of a button that stays there.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2414-login-button-type`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Be not logged in. Go to a page you don't have [permission to visit](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti).
* [ ] Inspect the element of the login button. See that it has `role="link"`
* [ ] Go to the [login page](https://hel-fi-drupal-grant-applications.docker.so/fi/user/login). Check the same.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
