### PR TITLE
fix: AU-2428: Fix empty asiointirooli link

### DIFF
--- a/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
+++ b/public/modules/custom/grants_oma_asiointi/src/Plugin/Block/AsiointirooliBlock.php
@@ -99,8 +99,10 @@ class AsiointirooliBlock extends BlockBase implements ContainerFactoryPluginInte
         'class' => ['link--switch-role'],
       ],
     ]);
-
-    $asiointiLink = Link::createFromRoute($companyName, 'grants_profile.show');
+    $asiointiLink = '';
+    if ($companyName) {
+      $asiointiLink = Link::createFromRoute($companyName, 'grants_profile.show');
+    }
 
     $build = [
       '#theme' => 'grants_oma_asiointi_asiointirooli_block',


### PR DESCRIPTION
# [AU-2428](https://helsinkisolutionoffice.atlassian.net/browse/AU-2428)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove empty link from asiointiroolin valinta page

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2428-empty-asiointirooli-link`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in and before selecting asiointirooli, go to [Asiointiroolin valtuutus](https://hel-fi-drupal-grant-applications.docker.so/fi/asiointirooli-valtuutus)
* [ ] Check that there is no link between "Asiointirooli:" and "Vaihda asiointiroolia"
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2428]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ