### PR TITLE
feat: AU-2397, AU-2401, E2E, Screenshots, bug-fixes and URL logging

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -171,7 +171,7 @@ export default defineConfig({
     },
     /* Form 61 tests. */
     {
-      name: 'forms-61-registered',
+      name: 'forms-61',
       testMatch: '/forms/registered_community_61.ts',
       dependencies: ['profile-registered_community']
     },
@@ -193,7 +193,7 @@ export default defineConfig({
     },
     /* Form 63 tests. */
     {
-      name: 'forms-63-registered',
+      name: 'forms-63',
       testMatch: '/forms/registered_community_63.ts',
       dependencies: ['profile-registered_community']
     },

--- a/e2e/tests/forms/private_person_48.ts
+++ b/e2e/tests/forms/private_person_48.ts
@@ -564,6 +564,10 @@ test.describe('Private person KUVAPROJ(48)', () => {
     await selectRole(page, 'PRIVATE_PERSON');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/private_person_64.ts
+++ b/e2e/tests/forms/private_person_64.ts
@@ -177,6 +177,10 @@ test.describe('ASUKASPIEN(64)', () => {
     await selectRole(page, 'PRIVATE_PERSON');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_29.ts
+++ b/e2e/tests/forms/registered_community_29.ts
@@ -251,6 +251,10 @@ test.describe('ECONOMICGRANTAPPLICATION(29)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_48.ts
+++ b/e2e/tests/forms/registered_community_48.ts
@@ -561,6 +561,10 @@ test.describe('KUVAPROJ(48)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_51.ts
+++ b/e2e/tests/forms/registered_community_51.ts
@@ -243,6 +243,10 @@ test.describe('KASKOYLEIS(51)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_52.ts
+++ b/e2e/tests/forms/registered_community_52.ts
@@ -487,6 +487,10 @@ test.describe('KASKOIPTOIM(52)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_53.ts
+++ b/e2e/tests/forms/registered_community_53.ts
@@ -77,6 +77,10 @@ test.describe('KASKOIPLISA(53)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_54.ts
+++ b/e2e/tests/forms/registered_community_54.ts
@@ -238,6 +238,10 @@ test.describe('KANSLIATYO(54)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_56.ts
+++ b/e2e/tests/forms/registered_community_56.ts
@@ -72,6 +72,10 @@ test.describe('LIIKUNTAYLEIS(56)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_57.ts
+++ b/e2e/tests/forms/registered_community_57.ts
@@ -161,6 +161,10 @@ test.describe('LIIKUNTALAITOS(57)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_58.ts
+++ b/e2e/tests/forms/registered_community_58.ts
@@ -61,6 +61,10 @@ test.describe('LIIKUNTASUUNNISTUS(58)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_60.ts
+++ b/e2e/tests/forms/registered_community_60.ts
@@ -212,6 +212,10 @@ test.describe('LIIKUNTATILANKAYTTO(60)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_61.ts
+++ b/e2e/tests/forms/registered_community_61.ts
@@ -234,6 +234,10 @@ test.describe('YMPARISTOYLEIS(61)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_62.ts
+++ b/e2e/tests/forms/registered_community_62.ts
@@ -219,10 +219,6 @@ test.describe('NUORPROJ(62)', () => {
     await page.close();
   });
 
-  test.afterAll(async() => {
-    await page.close();
-  });
-
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_62.ts
+++ b/e2e/tests/forms/registered_community_62.ts
@@ -7,8 +7,8 @@ import {validateSubmission} from "../../utils/validation_helpers";
 import {deleteDraftApplication} from "../../utils/deletion_helpers";
 import {copyApplication} from "../../utils/copying_helpers";
 import {fillFormField, fillInputField, uploadFile} from "../../utils/input_helpers";
-import {registeredCommunityApplications as applicationData} from '../../utils/data/application_data';
 import {swapFieldValues} from "../../utils/field_swap_helpers";
+import {registeredCommunityApplications as applicationData} from '../../utils/data/application_data';
 
 const profileType = 'registered_community';
 const formId = '62';
@@ -213,6 +213,14 @@ test.describe('NUORPROJ(62)', () => {
   test.beforeAll(async ({browser}) => {
     page = await browser.newPage()
     await selectRole(page, 'REGISTERED_COMMUNITY');
+  });
+
+  test.afterAll(async() => {
+    await page.close();
+  });
+
+  test.afterAll(async() => {
+    await page.close();
   });
 
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);

--- a/e2e/tests/forms/registered_community_63.ts
+++ b/e2e/tests/forms/registered_community_63.ts
@@ -301,6 +301,10 @@ test.describe('NUORTOIMPALKKA(63)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_64.ts
+++ b/e2e/tests/forms/registered_community_64.ts
@@ -160,6 +160,10 @@ test.describe('ASUKASPIEN(64)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_65.ts
+++ b/e2e/tests/forms/registered_community_65.ts
@@ -109,6 +109,10 @@ test.describe('NUORLOMALEIR(65)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_66.ts
+++ b/e2e/tests/forms/registered_community_66.ts
@@ -148,10 +148,6 @@ test.describe('NUORTOIMPALKENNAKKO(66)', () => {
     await page.close();
   });
 
-  test.afterAll(async() => {
-    await page.close();
-  });
-
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_66.ts
+++ b/e2e/tests/forms/registered_community_66.ts
@@ -144,6 +144,14 @@ test.describe('NUORTOIMPALKENNAKKO(66)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_68.ts
+++ b/e2e/tests/forms/registered_community_68.ts
@@ -254,6 +254,10 @@ test.describe('HYVINYLEIS(68)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/registered_community_69.ts
+++ b/e2e/tests/forms/registered_community_69.ts
@@ -99,6 +99,10 @@ test.describe('LEIRISELVITYS(69)', () => {
     await selectRole(page, 'REGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/unregistered_community_48.ts
+++ b/e2e/tests/forms/unregistered_community_48.ts
@@ -565,6 +565,10 @@ test.describe('KUVAPROJ(48)', () => {
     await selectRole(page, 'UNREGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/unregistered_community_62.ts
+++ b/e2e/tests/forms/unregistered_community_62.ts
@@ -215,6 +215,10 @@ test.describe('NUORPROJ(62)', () => {
     await selectRole(page, 'UNREGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/unregistered_community_64.ts
+++ b/e2e/tests/forms/unregistered_community_64.ts
@@ -159,6 +159,10 @@ test.describe('ASUKASPIEN(64)', () => {
     await selectRole(page, 'UNREGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/unregistered_community_65.ts
+++ b/e2e/tests/forms/unregistered_community_65.ts
@@ -109,6 +109,10 @@ test.describe('NUORLOMALEIR(65)', () => {
     await selectRole(page, 'UNREGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/unregistered_community_66.ts
+++ b/e2e/tests/forms/unregistered_community_66.ts
@@ -144,6 +144,10 @@ test.describe('NUORTOIMPALKENNAKKO(66)', () => {
     await selectRole(page, 'UNREGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/forms/unregistered_community_69.ts
+++ b/e2e/tests/forms/unregistered_community_69.ts
@@ -99,6 +99,10 @@ test.describe('LEIRISELVITYS(69)', () => {
     await selectRole(page, 'UNREGISTERED_COMMUNITY');
   });
 
+  test.afterAll(async() => {
+    await page.close();
+  });
+
   const testDataArray: [string, FormData][] = Object.entries(applicationData[formId]);
 
   for (const [key, obj] of testDataArray) {

--- a/e2e/tests/profiles/private_person.ts
+++ b/e2e/tests/profiles/private_person.ts
@@ -18,9 +18,10 @@ test.describe('Private person - Grants Profile', () => {
     profileExists = await isProfileCreated(profileType);
   });
 
-  test.afterAll(() => {
+  test.afterAll(async() => {
     expect(process.env[`profile_exists_${profileType}`], `Profile does not exist for: ${profileType}`).toBe('TRUE');
     logger(`Profile exist for: ${profileType}`);
+    await page.close();
   });
 
   test('Profile form tests', async () => {

--- a/e2e/tests/profiles/registered_community.ts
+++ b/e2e/tests/profiles/registered_community.ts
@@ -18,9 +18,10 @@ test.describe('Registered Community - Grants Profile', () => {
     profileExists = await isProfileCreated(profileType);
   });
 
-  test.afterAll(() => {
+  test.afterAll(async() => {
     expect(process.env[`profile_exists_${profileType}`], `Profile does not exist for: ${profileType}`).toBe('TRUE');
     logger(`Profile exist for: ${profileType}`);
+    await page.close();
   });
 
   test('Profile form tests', async () => {

--- a/e2e/tests/profiles/unregistered_community.ts
+++ b/e2e/tests/profiles/unregistered_community.ts
@@ -23,9 +23,10 @@ test.describe('Unregistered Community - Grants Profile', () => {
     }
   });
 
-  test.afterAll(() => {
+  test.afterAll(async() => {
     expect(process.env[`profile_exists_${profileType}`], `Profile does not exist for: ${profileType}`).toBe('TRUE');
     logger(`Profile exist for: ${profileType}`);
+    await page.close();
   });
 
   test('Profile form tests', async () => {

--- a/e2e/utils/auth_helpers.ts
+++ b/e2e/utils/auth_helpers.ts
@@ -1,6 +1,7 @@
 import {Page} from '@playwright/test';
 import {logger} from "./logger";
 import {existsSync, readFileSync} from 'fs';
+import {logCurrentUrl} from "./helpers";
 
 type Role = "REGISTERED_COMMUNITY" | "UNREGISTERED_COMMUNITY" | "PRIVATE_PERSON";
 type Mode = "new" | "existing";
@@ -24,6 +25,7 @@ const AUTH_FILE_PATH = '.auth/user.json';
 const selectRole = async (page: Page, role: Role, mode: Mode = 'existing') => {
   await checkLoginStateAndLogin(page);
   await page.goto("/fi/asiointirooli-valtuutus");
+  await logCurrentUrl(page);
 
   const roleIsLoggedIn = await page.locator("body")
     .evaluate((el, role) => el.classList.contains(`grants-role-${role.toLowerCase()}`), role);
@@ -110,6 +112,7 @@ const selectPrivatePersonRole = async (page: Page) => {
 const login = async (page: Page, SSN?: string) => {
   logger('Logging in...');
   await page.goto('/fi/user/login');
+  await logCurrentUrl(page);
   await page.locator("#edit-openid-connect-client-tunnistamo-login").click();
   await page.locator("#fakevetuma2").click()
   await page.locator("#hetu_input").fill(SSN ?? process.env.TEST_USER_SSN ?? '');
@@ -202,6 +205,7 @@ const getSessionCookie = (): boolean | any => {
 const sessionIsValid = async (page: Page): Promise<boolean> => {
   logger('Visit user page to check session validity...');
   await page.goto('/fi/user');
+  await logCurrentUrl(page);
   const actualUrl = page.url();
 
   if (!actualUrl.includes('/asiointirooli-valtuutus') &&

--- a/e2e/utils/copying_helpers.ts
+++ b/e2e/utils/copying_helpers.ts
@@ -1,7 +1,7 @@
 import {expect, Page, test} from "@playwright/test";
 import {FormData} from "./data/test_data";
 import {logger} from "./logger";
-import {getApplicationNumberFromBreadCrumb} from "./helpers";
+import {getApplicationNumberFromBreadCrumb, logCurrentUrl} from "./helpers";
 import {extractPath} from "./helpers";
 import {getObjectFromEnv, saveObjectToEnv} from "./env_helpers";
 import {validateSubmission} from "./validation_helpers";
@@ -113,6 +113,7 @@ const makeApplicationCopy = async (
   // Go to the "Katso" page of the original application we are copying.
   const viewPageURL = `/fi/hakemus/${originalApplicationId}/katso`;
   await page.goto(viewPageURL);
+  await logCurrentUrl(page);
   logger(`Navigated to: ${viewPageURL}.`);
 
   // Make sure we get there.
@@ -134,12 +135,14 @@ const makeApplicationCopy = async (
   await page.locator('#copy-application-modal-form-submit').click();
 
   // Wait for a redirect to the new application and store the new application ID and submission URL.
+  await logCurrentUrl(page);
   await page.waitForURL('**/muokkaa');
   const newApplicationId = await getApplicationNumberFromBreadCrumb(page);
   const submissionUrl = await extractPath(page);
 
   // Save the new application as a draft.
   await page.locator('[data-drupal-selector="edit-actions-draft"]').click();
+  await logCurrentUrl(page);
   await page.waitForURL('**/katso');
 
   // Store the copied applications data to the env.

--- a/e2e/utils/data/application/application_data_54.ts
+++ b/e2e/utils/data/application/application_data_54.ts
@@ -713,7 +713,8 @@ const sendApplication: FormDataWithRemoveOptionalProps = {
             type: 'data-drupal-selector',
             name: 'data-drupal-selector',
             value: 'edit-actions-submit',
-          }
+          },
+          viewPageSkipValidation: true
         },
       },
       itemsToRemove: [],

--- a/e2e/utils/data/application/application_data_57.ts
+++ b/e2e/utils/data/application/application_data_57.ts
@@ -666,7 +666,8 @@ const sendApplication: FormDataWithRemoveOptionalProps = {
             type: 'data-drupal-selector',
             name: 'data-drupal-selector',
             value: 'edit-actions-submit',
-          }
+          },
+          viewPageSkipValidation: true
         },
       },
       itemsToRemove: [],

--- a/e2e/utils/data/application/application_data_58.ts
+++ b/e2e/utils/data/application/application_data_58.ts
@@ -424,7 +424,8 @@ const sendApplication: FormDataWithRemoveOptionalProps = {
             type: 'data-drupal-selector',
             name: 'data-drupal-selector',
             value: 'edit-actions-submit',
-          }
+          },
+          viewPageSkipValidation: true
         },
       },
       itemsToRemove: [],

--- a/e2e/utils/data/application/application_data_60.ts
+++ b/e2e/utils/data/application/application_data_60.ts
@@ -1133,7 +1133,8 @@ const sendApplication: FormDataWithRemoveOptionalProps = {
             type: 'data-drupal-selector',
             name: 'data-drupal-selector',
             value: 'edit-actions-submit',
-          }
+          },
+          viewPageSkipValidation: true
         },
       },
       itemsToRemove: [],

--- a/e2e/utils/data/application/application_data_62.ts
+++ b/e2e/utils/data/application/application_data_62.ts
@@ -939,7 +939,8 @@ const sendApplication: FormDataWithRemoveOptionalProps = {
             type: 'data-drupal-selector',
             name: 'data-drupal-selector',
             value: 'edit-actions-submit',
-          }
+          },
+          viewPageSkipValidation: true
         },
       },
       itemsToRemove: [],

--- a/e2e/utils/data/application/application_data_64.ts
+++ b/e2e/utils/data/application/application_data_64.ts
@@ -453,7 +453,7 @@ const registeredCommunityApplications_64 = {
   copy: createFormData(baseFormRegisteredCommunity_64, copyForm),
   missing_values: createFormData(baseFormRegisteredCommunity_64, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_64, wrongValues),
-  success: createFormData(baseFormRegisteredCommunity_64, sendApplication),
+  success: createFormData(baseFormPrivatePerson_64, sendApplication),
 }
 
 /**

--- a/e2e/utils/data/application/application_data_64.ts
+++ b/e2e/utils/data/application/application_data_64.ts
@@ -453,7 +453,7 @@ const registeredCommunityApplications_64 = {
   copy: createFormData(baseFormRegisteredCommunity_64, copyForm),
   missing_values: createFormData(baseFormRegisteredCommunity_64, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_64, wrongValues),
-  success: createFormData(baseFormPrivatePerson_64, sendApplication),
+  success: createFormData(baseFormRegisteredCommunity_64, sendApplication),
 }
 
 /**
@@ -464,7 +464,7 @@ const registeredCommunityApplications_64 = {
 const privatePersonApplications_64 = {
   draft: baseFormPrivatePerson_64,
   missing_values: createFormData(baseFormPrivatePerson_64, missingValuesPrivateUnregistered),
-  success: createFormData(baseFormRegisteredCommunity_64, sendApplication),
+  success: createFormData(baseFormPrivatePerson_64, sendApplication),
 }
 
 /**

--- a/e2e/utils/data/application/application_data_68.ts
+++ b/e2e/utils/data/application/application_data_68.ts
@@ -566,7 +566,8 @@ const sendApplication: FormDataWithRemoveOptionalProps = {
             type: 'data-drupal-selector',
             name: 'data-drupal-selector',
             value: 'edit-actions-submit',
-          }
+          },
+          viewPageSkipValidation: true
         },
       },
       itemsToRemove: [],

--- a/e2e/utils/deletion_helpers.ts
+++ b/e2e/utils/deletion_helpers.ts
@@ -1,6 +1,7 @@
 import {expect, Page, test} from "@playwright/test";
 import {FormData} from "./data/test_data";
 import {logger} from "./logger";
+import {logCurrentUrl} from "./helpers";
 
 /**
  * The DeletionMethod enum.
@@ -75,11 +76,13 @@ const deleteDraftApplication = async (formKey: string, page: Page, formDetails: 
  */
 const deleteUsingSubmissionUrl = async (page: Page, submissionUrl: string, applicationId: string) => {
   await page.goto(submissionUrl);
+  await logCurrentUrl(page);
   await page.waitForURL('**/muokkaa');
   await page.locator('#webform-button--delete-draft').click();
   page.once('dialog', async dialog => {
     await dialog.accept();
   });
+  await logCurrentUrl(page);
   await page.waitForURL('/fi/oma-asiointi');
   await validateDeletionNotification(page, 'Submission URL.', applicationId);
 }
@@ -101,9 +104,11 @@ const deleteUsingSubmissionUrl = async (page: Page, submissionUrl: string, appli
  */
 const deleteUsingApplicationId = async (page: Page, applicationId: string) => {
   await page.goto('/fi/oma-asiointi');
+  await logCurrentUrl(page);
   await page.waitForURL('**/oma-asiointi');
   await page.locator(`.application-delete-link-${applicationId}`).click();
   await page.waitForLoadState('load');
+  await logCurrentUrl(page);
   await validateDeletionNotification(page, 'Application ID on Oma asiointi page.', applicationId);
 }
 

--- a/e2e/utils/field_swap_helpers.ts
+++ b/e2e/utils/field_swap_helpers.ts
@@ -3,6 +3,7 @@ import {FieldSwapItemList, FormData, FormPage, Selector} from "./data/test_data"
 import {logger} from "./logger";
 import {clickButton, fillFormField} from "./input_helpers";
 import {validateFormData} from "./validation_helpers";
+import {logCurrentUrl} from "./helpers";
 
 /**
  * The swapFieldValues function.
@@ -105,6 +106,7 @@ const swapFieldValuesOnPage = async (
  */
 const goToSubmissionUrl = async (page: Page, submissionUrl: string) => {
   await page.goto(submissionUrl);
+  await logCurrentUrl(page);
   await page.waitForURL('**/muokkaa');
   logger(`Navigated to: ${submissionUrl}.`);
 };
@@ -128,6 +130,7 @@ const navigateToApplicationPage = async (page: Page, formPageKey: string) => {
   }
   await clickButton(page, applicantDetailsLink);
   await page.waitForLoadState('load');
+  await logCurrentUrl(page);
   logger(`Loaded page: ${formPageKey}.`);
 };
 
@@ -147,6 +150,7 @@ const saveAsDraft = async (page: Page) => {
     value: 'edit-actions-draft',
   }
   await clickButton(page, saveDraftLink);
+  await logCurrentUrl(page);
   await page.waitForURL('**/katso');
   logger('Form saved as draft.')
 };

--- a/e2e/utils/form_helpers.ts
+++ b/e2e/utils/form_helpers.ts
@@ -225,8 +225,9 @@ const verifyDraftSave = async (
   formKey: string
 ) => {
   logger(`Verifying draft save...`);
-  await expect(page.getByText('Luonnos')).toBeVisible()
-  await expect(page.getByRole('link', {name: 'Muokkaa hakemusta'})).toBeEnabled();
+  await page.waitForURL('**/katso');
+  await expect(await page.getByText('Luonnos')).toBeVisible()
+  await expect(await page.getByRole('link', {name: 'Muokkaa hakemusta'})).toBeEnabled();
   const applicationId = await page.locator(".webform-submission__application_id--body").innerText();
 
   const storeName = `${profileType}_${formId}`;
@@ -268,8 +269,9 @@ const verifySubmit = async (
   formKey: string
 ) => {
   logger(`Verifying submit...`);
-  await expect(page.getByRole('heading', {name: 'Avustushakemus lähetetty onnistuneesti'})).toBeVisible();
-  await expect(page.getByText('Lähetetty - odotetaan vahvistusta').first()).toBeVisible();
+  await page.waitForURL('**/completion');
+  await expect(await page.getByRole('heading', {name: 'Avustushakemus lähetetty onnistuneesti'})).toBeVisible();
+  await expect(await page.getByText('Lähetetty - odotetaan vahvistusta').first()).toBeVisible();
 
   // Attempt to locate the "Vastaanotettu" text on the page. Keep polling for 60000ms (1 minute).
   // Note: We do this instead of using Playwrights "expect" method so that test execution isn't interrupted if this fails.

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -136,11 +136,24 @@ const waitForTextWithInterval = async (
   }
 }
 
+/**
+ * The logCurrentUrl function.
+ *
+ * This functions logs the current URL of the page.
+ *
+ * @param page
+ *  Playwright page object.
+ */
+const logCurrentUrl = async (page: Page) => {
+  logger('On URL:', page.url());
+}
+
 export {
   slowLocator,
   extractPath,
   hideSlidePopup,
   getApplicationNumberFromBreadCrumb,
   waitForTextWithInterval,
+  logCurrentUrl,
 };
 

--- a/e2e/utils/validation_helpers.ts
+++ b/e2e/utils/validation_helpers.ts
@@ -3,6 +3,7 @@ import {logger} from "./logger";
 import {FormField, FormData, FormFieldWithRemove} from "./data/test_data"
 import {viewPageBuildSelectorForItem} from "./view_page_helpers";
 import {PROFILE_INPUT_DATA, ProfileInputData} from "./data/profile_input_data";
+import {logCurrentUrl} from "./helpers";
 
 /**
  * The validateSubmission function.
@@ -353,6 +354,7 @@ const navigateAndValidateViewPage = async (
   const applicationId = thisStoreData.applicationId;
   const viewPageURL = `/fi/hakemus/${applicationId}/katso`;
   await page.goto(viewPageURL);
+  await logCurrentUrl(page);
   await page.waitForURL('**/katso');
   const applicationIdContainer = await page.locator('.webform-submission__application_id');
   const applicationIdContainerText = await applicationIdContainer.textContent();
@@ -380,6 +382,7 @@ const navigateAndValidateProfilePage = async (
 
   const profilePageURL = '/fi/oma-asiointi/hakuprofiili';
   await page.goto(profilePageURL);
+  await logCurrentUrl(page);
 
   const headingMap: Record<string, string> = {
     registered_community: 'Yhteisön tiedot avustusasioinnissa',


### PR DESCRIPTION
# [AU-2397](https://helsinkisolutionoffice.atlassian.net/browse/AU-2397),  [AU-2401](https://helsinkisolutionoffice.atlassian.net/browse/AU-2401)

## What was done

This pull request implements bug-fixes, more URL logging and an attempt to fix the screenshots taken by Playwright in situations where an exception is thrown.

### Screenshots at exceptions

I ran into an [issue](https://github.com/microsoft/playwright/issues/27186) in Playwrights issue queue that described a similar problem to the one we're experiencing: Playwrights report would sometimes be populated by seemingly irrelevant screenshots that had nothing to do with the failure itself. A suggestion was made to close the testing browser after each test case, which I have now implemented to our tests as well.

```
  test.afterAll(async() => {
    await page.close();
  });
```

### URL logging

The `logCurrentUrl` function has been implemented in `helpers.ts`, which logs the current URL to the terminal. I've tried to add the function call to pretty much every relevant navigation that happens during the test run.
### Bugfixes

- Added `viewPageSkipValidation` to various `submitbuttons` in various test data files. Without this the validation tests would fail.

- The test data file containing `privatePersonApplications_64` was calling `createFormData` with the wrong parameters. This caused the validation test to fail.

- Added `waitForURL()` calls to both the `verifyDraftSave` and `verifySubmit` functions so that they don't execute before we arrive on the page. I also added checks that make sure we have an application ID before we store any environment data.

- Added a `page.waitForLoadState('load')` call to the `verifySubmit` function after the test has validated that the `Vastaanotettu` text is present on the page. The call was added because the page refreshes when the application is received, and the `applicationId` variable would sometimes be empty when we tried to retrieve it before the page had loaded.

### Other smaller changes
- Finished what was started in [AU-2274](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1323/files) regarding the test names in `playwright.config.ts`.

## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2397-e2e-screenshot-on-failure`
* `make fresh`
* `make drush-cr`

## How to test

Run a few test to make sure everything still works. Make sure you see URLs logged to the terminal: 
`make test-pw-p PROJECT=forms-48 forms-64`

I ran every test with only one failure, which was caused by a bug in the code. Fixing this in [this](https://helsinkisolutionoffice.atlassian.net/browse/AU-2454) issue.

![Screenshot 2024-04-24 at 13 18 55](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/7a0fcd4b-98d6-4be6-bae9-96f5a2283116)


[AU-2397]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-2401]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2274]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ