### PR TITLE
fix: AU-2454: Boolean values in the place of operations component

### DIFF
--- a/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
@@ -102,6 +102,8 @@ class PlaceOfOperationComposite extends WebformCompositeBase {
   protected function formatTextItemValue(array $element, WebformSubmissionInterface $webform_submission, array $options = []): array {
     $value = $this->getValue($element, $webform_submission, $options);
     $lines = [];
+    $tOpts = ['context' => 'grants_place_of_operation'];
+
     foreach ($value as $fieldName => $fieldValue) {
       if (isset($element["#webform_composite_elements"][$fieldName])) {
         $webformElement = $element["#webform_composite_elements"][$fieldName];
@@ -112,6 +114,16 @@ class PlaceOfOperationComposite extends WebformCompositeBase {
           if ($fieldValue) {
             $dateTime = new DrupalDateTime($fieldValue);
             $fieldValue = $dateTime->format('j.n.Y');
+          }
+        }
+
+        // Convert boolean value.
+        if ($fieldName === 'free') {
+          if ($fieldValue === 'false') {
+            $fieldValue = $this->t('No', [], $tOpts);
+          }
+          if ($fieldValue === 'true') {
+            $fieldValue = $this->t('Yes', [], $tOpts);
           }
         }
 


### PR DESCRIPTION
# [AU-2454](https://helsinkisolutionoffice.atlassian.net/browse/AU-2454)

## What was done

The `Place of operation` components has the field `Toimintaa järjestetään kaupungin opetus-, sosiaali- tai nuorisotoimelta saaduissa maksuttomissa tiloissa`. This field was displaying the value "false/true" when viewing a submitted application on the "/katso" page. This issue has been fixed.

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/ef252901-2176-4784-bb56-9f5e63afea19)


## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2454-place-of-operation-bu`
* `make fresh`
* `make drush-cr`

## How to test

Run `make test-pw-p PROJECT=forms-52` and make sure it passes. 

You can also test a [form](https://hel-fi-drupal-grant-applications.docker.so/fi/form/kasvatus-ja-koulutus-toiminta-av) manually if you feel like it. Submit the form and make sure either Yes or No is displayed on the "/katso" page after submitting the form.

[AU-2454]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ