### PR TITLE
fix: AU-2455 Draft setting in webforms

### DIFF
--- a/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -706,7 +706,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -834,7 +834,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.grants_handler.yml
+++ b/conf/cmi/webform.webform.grants_handler.yml
@@ -138,7 +138,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/webform.webform.hyte_yleisavustus.yml
@@ -742,7 +742,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.kasko_ip_lisa.yml
+++ b/conf/cmi/webform.webform.kasko_ip_lisa.yml
@@ -474,7 +474,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -1068,7 +1068,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -785,7 +785,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -885,7 +885,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -1307,7 +1307,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -1608,7 +1608,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.leiriselvitys.yml
+++ b/conf/cmi/webform.webform.leiriselvitys.yml
@@ -522,7 +522,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
@@ -756,7 +756,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.liikunta_suunnistuskartta_avustu.yml
+++ b/conf/cmi/webform.webform.liikunta_suunnistuskartta_avustu.yml
@@ -419,7 +419,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.liikunta_tapahtuma.yml
+++ b/conf/cmi/webform.webform.liikunta_tapahtuma.yml
@@ -677,7 +677,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -1106,7 +1106,7 @@ settings:
     joista_helsinkilaisia_muut_20: joista_helsinkilaisia_muut_20
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_yleisavustushakemus.yml
@@ -453,7 +453,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/conf/cmi/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -640,7 +640,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -928,7 +928,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.nuorlomaleir.yml
+++ b/conf/cmi/webform.webform.nuorlomaleir.yml
@@ -522,7 +522,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -1109,7 +1109,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.performance_test_webform.yml
+++ b/conf/cmi/webform.webform.performance_test_webform.yml
@@ -658,7 +658,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -1041,7 +1041,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1271,7 +1271,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -872,7 +872,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -788,7 +788,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/public/modules/custom/config/install/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -703,7 +703,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -838,7 +838,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.grants_handler.yml
+++ b/public/modules/custom/config/install/webform.webform.grants_handler.yml
@@ -138,7 +138,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/config/install/webform.webform.hyte_yleisavustus.yml
@@ -743,7 +743,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.kasko_ip_lisa.yml
+++ b/public/modules/custom/config/install/webform.webform.kasko_ip_lisa.yml
@@ -475,7 +475,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -1067,7 +1067,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -788,7 +788,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -881,7 +881,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.kuva_projekti.yml
+++ b/public/modules/custom/config/install/webform.webform.kuva_projekti.yml
@@ -1303,7 +1303,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.kuva_toiminta.yml
+++ b/public/modules/custom/config/install/webform.webform.kuva_toiminta.yml
@@ -1598,7 +1598,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -748,7 +748,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.liikunta_suunnistuskartta_avustu.yml
+++ b/public/modules/custom/config/install/webform.webform.liikunta_suunnistuskartta_avustu.yml
@@ -419,7 +419,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.liikunta_tapahtuma.yml
+++ b/public/modules/custom/config/install/webform.webform.liikunta_tapahtuma.yml
@@ -677,7 +677,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/public/modules/custom/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -1112,7 +1112,7 @@ settings:
     joista_helsinkilaisia_muut_20: joista_helsinkilaisia_muut_20
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/public/modules/custom/config/install/webform.webform.liikunta_yleisavustushakemus.yml
@@ -453,7 +453,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/public/modules/custom/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -637,7 +637,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/public/modules/custom/config/install/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -928,7 +928,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.nuorlomaleir.yml
+++ b/public/modules/custom/config/install/webform.webform.nuorlomaleir.yml
@@ -518,7 +518,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/config/install/webform.webform.nuortoimpalkka.yml
@@ -1101,7 +1101,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/public/modules/custom/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -1025,7 +1025,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/public/modules/custom/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1270,7 +1270,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/config/install/webform.webform.yleisavustushakemus.yml
@@ -878,7 +878,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/public/modules/custom/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -795,7 +795,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.grants_handler.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.grants_handler.yml
@@ -137,7 +137,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kasko_ip_lisa.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kasko_ip_lisa.yml
@@ -476,7 +476,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -780,7 +780,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kuva_projekti.yml
@@ -1249,7 +1249,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kuva_toiminta.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kuva_toiminta.yml
@@ -1532,7 +1532,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_tapahtuma.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_tapahtuma.yml
@@ -648,7 +648,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_yleisavustushakemus.yml
@@ -484,7 +484,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -601,7 +601,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuorlomaleir.yml
@@ -498,7 +498,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -1010,7 +1010,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1179,7 +1179,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.yleisavustushakemus.yml
@@ -869,7 +869,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1199,8 +1199,8 @@ function grants_handler_webform_presave(WebformInterface $webform) {
   }
   // Enable the draft save if not already set.
   $draft_setting = $webform->getSetting('draft');
-  if ($draft_setting !== WebformInterface::DRAFT_ALL) {
-    $webform->setSetting('draft', WebformInterface::DRAFT_ALL);
+  if ($draft_setting !== WebformInterface::DRAFT_AUTHENTICATED) {
+    $webform->setSetting('draft', WebformInterface::DRAFT_AUTHENTICATED);
   }
   // Set purge status to prevent clutter in the db.
   if ($purge_setting !== WebformSubmissionStorageInterface::PURGE_ALL

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -705,7 +705,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -837,7 +837,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.hyte_yleisavustus.yml
@@ -745,7 +745,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasko_ip_lisa.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasko_ip_lisa.yml
@@ -474,7 +474,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -1066,7 +1066,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -751,7 +751,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -884,7 +884,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kuva_projekti.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kuva_projekti.yml
@@ -851,7 +851,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kuva_toiminta.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kuva_toiminta.yml
@@ -1527,7 +1527,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -750,7 +750,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_suunnistuskartta_avustu.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_suunnistuskartta_avustu.yml
@@ -420,7 +420,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_tapahtuma.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_tapahtuma.yml
@@ -664,7 +664,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -1114,7 +1114,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_yleisavustushakemus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_yleisavustushakemus.yml
@@ -453,7 +453,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuorisopalvelut_toiminta_ja_palk.yml
@@ -637,7 +637,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -928,7 +928,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuorlomaleir.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuorlomaleir.yml
@@ -517,7 +517,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuortoimpalkka.yml
@@ -1082,7 +1082,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -1027,7 +1027,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -1272,7 +1272,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.yleisavustushakemus.yml
@@ -849,7 +849,7 @@ settings:
   preview_excluded_elements: {  }
   preview_exclude_empty: false
   preview_exclude_empty_checkbox: false
-  draft: all
+  draft: authenticated
   draft_multiple: false
   draft_auto_save: false
   draft_saved_message: ''


### PR DESCRIPTION
# [AU-2455](https://helsinkisolutionoffice.atlassian.net/browse/AU-2455)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Käytä authenticated arvo presave hookissa
* Muuta arvo kaikkiin webform-config tiedoistoihin

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2455-draft-setting`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Tallenna webformin asetukset. Draft asetuksen tulee aina asettua arvoon 'authenticated'
* [ ] Arvo asettuu oikein kun webformit tuodaan drush komennolla

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2455]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ