### PR TITLE
fix: AU-2376, AU-2377: fixes to KUVA toiminta SV translations

### DIFF
--- a/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
@@ -273,7 +273,7 @@ elements: |
     '#help': '<p>Med uruppförande avser vi ett verk, som uppförs för första gången, ett helt nytt verk. En nypremiär är t.ex. inte ett uruppförande.</p>'
   toteutuneet_ensi_iltojen_maara_helsingissa:
     '#title': 'Antal premiärer i Helsingfors'
-    '#help': '<p>Premiär betyder den första föreställningen av produktionen. Fyll i här premiärerna som äger rum i Helsingfors.</p>'
+    '#help': '<p>Med premiär avser vi den första föreställningen av en produktion. Fyll i de premiärer som sker i Helsingfors.</p>'
   toteutuneet_tila_markup:
     '#markup': "<h4>Öppen verksamhet för publik i Helsingfors</h4>\r\n\r\n<p>Med öppen verksamhet avser vi här t.ex. föreställningar, utställningar, verkstäder eller annan verksamhet, där publiken kan vara delaktig.</p>"
   toteutuneet_tila:
@@ -379,6 +379,7 @@ elements: |
     '#otherCompensations__help': 'Även stadens övriga understöd'
     '#totalIncome__help': 'Anteckna samtliga inkomster, även de understöd som uppgetts i tidigare punkter.'
     '#plannedStateOperativeSubvention__title': 'Statens verksamhetsunderstöd (€)'
+    '#stateOperativeSubvention__title': 'Statens verksamhetsunderstöd (€)'
     '#otherCompensationFromCity__title': 'Helsingfors stads kulturtjänsters verksamhetsstöd (€)'
     '#otherCompensations__title': 'Övriga understöd (€)'
     '#totalIncome__title': 'Inkomster sammanlagt (€)'


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Fixes to KUVA toiminta SV translations

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2376-kuva-toiminta`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [application](https://hel-fi-drupal-grant-applications.docker.so/sv/uusi-hakemus/kuva_toiminta)
* [ ] Go to page 4
* [ ] [AU-2376](https://helsinkisolutionoffice.atlassian.net/browse/AU-2376): Check that tooltip is fixed on Planerad verksamhet -> Om föreställningar
* [ ] Go to page 6
* [ ] [AU-2377](https://helsinkisolutionoffice.atlassian.net/browse/AU-2377): Check that field title is fixed in Förverkligade inkomster och utgifter -> Realiserade inkomster

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


[AU-2376]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-2377]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ