### PR TITLE
fix: AU-2459: fix broken translations

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/Block/ApplicationTimeoutMessageBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ApplicationTimeoutMessageBlock.php
@@ -57,7 +57,7 @@ class ApplicationTimeoutMessageBlock extends BlockBase {
       '#message_heading' => $this->t('The application period for this grant has closed.', [], ['context' => 'grants_handler']),
       '#message_body' =>
       $this->t('You can no longer submit an application because the
-        application period for this grant has closed.',
+application period for this grant has closed.',
           [],
           ['context' => 'grants_handler']),
       '#attached' => [

--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAnonBlock.php
@@ -192,7 +192,7 @@ class ServicePageAnonBlock extends BlockBase implements ContainerFactoryPluginIn
     if ($this->currentUser->isAuthenticated()) {
       $link = Link::fromTextAndUrl($mandateText, $mandateUrl);
       $text = $this->t('Change your role and return to make the
-       application with role which the application is instructed to be made.', [], $tOpts);
+application with role which the application is instructed to be made.', [], $tOpts);
       $title = $this->t('Change role', [], $tOpts);
     }
     else {

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -443,7 +443,7 @@ msgid "Print application"
 msgstr "Tulosta hakemus"
 
 msgctxt "grants_handler"
-msgid "Change your role and return to make the application with role which the application is instructed to be made."
+msgid "Change your role and return to make the\napplication with role which the application is instructed to be made."
 msgstr "Vaihda asiointiroolia ja palaa tekemään hakemus palvelukuvauksen ohjeistamalla asiointiroolilla."
 
 msgctxt "grants_handler"
@@ -572,7 +572,7 @@ msgid "The application period for this grant has closed."
 msgstr "Tämän avustuksen hakuaika on päättynyt."
 
 msgctxt "grants_handler"
-msgid "You can no longer submit an application because the application period for this grant has closed."
+msgid "You can no longer submit an application because the\napplication period for this grant has closed."
 msgstr "Et voi enää lähettää hakemusta, sillä avustuksen hakuaika on päättynyt."
 
 msgctxt "grants_handler"

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -443,7 +443,7 @@ msgid "Print application"
 msgstr "Skriv ut ansökan"
 
 msgctxt "grants_handler"
-msgid "Change your role and return to make the application with role which the application is instructed to be made."
+msgid "Change your role and return to make the\napplication with role which the application is instructed to be made."
 msgstr "Byt roll och gå tillbaka för att göra ansökan med roll som ansökan är instruerad att göra."
 
 msgctxt "grants_handler"
@@ -572,7 +572,7 @@ msgid "The application period for this grant has closed."
 msgstr "Ansökningstiden för detta bidrag har löpt ut."
 
 msgctxt "grants_handler"
-msgid "You can no longer submit an application because the application period for this grant has closed."
+msgid "You can no longer submit an application because the\napplication period for this grant has closed."
 msgstr "Du kan inte längre skicka in denna ansökan eftersom att ansökningstiden har löpt ut."
 
 msgctxt "grants_handler"

--- a/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
+++ b/public/modules/custom/grants_mandate/src/Form/ApplicantMandateForm.php
@@ -110,10 +110,10 @@ class ApplicantMandateForm extends FormBase {
     $form['info'] = [
       '#markup' => '<p>' .
       $this->t('Before proceeding to the grant application, you should
-         choose an applicant role. You can continue applying as an individual
-          or switch to applying on behalf of the community. When you choose to
-           apply on behalf of a registered community, you will be transferred
-            to Suomi.fi business authorization.', [], $tOpts) . '</p>',
+choose an applicant role. You can continue applying as an individual
+or switch to applying on behalf of the community. When you choose to
+apply on behalf of a registered community, you will be transferred
+to Suomi.fi business authorization.', [], $tOpts) . '</p>',
     ];
     $form['actions'] = [
       '#type' => 'actions',
@@ -129,8 +129,8 @@ class ApplicantMandateForm extends FormBase {
       '#icon' => 'company',
       '#role' => $this->t('Registered community', [], $tOpts),
       '#role_description' => $this->t('Registered community is,
-       for example, a company, non-profit organization,
-        organization or association', [], $tOpts),
+for example, a company, non-profit organization,
+organization or association', [], $tOpts),
     ];
     $form['actions']['registered_community']['submit'] = [
       '#type' => 'submit',

--- a/public/modules/custom/grants_mandate/translations/fi.po
+++ b/public/modules/custom/grants_mandate/translations/fi.po
@@ -64,11 +64,11 @@ msgid "Your mandate does not allow you to use this service."
 msgstr "Valtuutuksesi ei salli sinun käyttää tätä palvelua."
 
 msgctxt "grants_mandate"
-msgid "Before proceeding to the grant application, you should choose an applicant role. You can continue applying as an individual or switch to applying on behalf of the community. When you choose to apply on behalf of a registered community, you will be transferred to Suomi.fi business authorization."
+msgid "Before proceeding to the grant application, you should\nchoose an applicant role. You can continue applying as an individual\nor switch to applying on behalf of the community. When you choose to\napply on behalf of a registered community, you will be transferred\nto Suomi.fi business authorization."
 msgstr "Ennen kuin siirryt avustushakemukselle, sinun tulee valita asiointirooli. Voit jatkaa asiointia yksityishenkilönä tai vaihtaa yhteisön puolesta asiointiin. Valitessasi rekisteröidyn yhteisön puolesta asioinnin, sinut siirretään suomi.fi yritysvaltuutukseen."
 
 msgctxt "grants_mandate"
-msgid "Registered community is, for example, a company, non-profit organization, organization or association"
+msgid "Registered community is,\nfor example, a company, non-profit organization,\norganization or association"
 msgstr "Rekisteröity yhteisö on esimerkiksi yritys, voittoa tavoittelematon organisaatio, järjestö tai yhdistys"
 
 msgctxt "grants_mandate"

--- a/public/modules/custom/grants_mandate/translations/sv.po
+++ b/public/modules/custom/grants_mandate/translations/sv.po
@@ -64,11 +64,11 @@ msgid "Your mandate does not allow you to use this service."
 msgstr "Ditt medgivande tillåter dig inte att använda denna tjänst."
 
 msgctxt "grants_mandate"
-msgid "Before proceeding to the grant application, you should choose an applicant role. You can continue applying as an individual or switch to applying on behalf of the community. When you choose to apply on behalf of a registered community, you will be transferred to Suomi.fi business authorization."
+msgid "Before proceeding to the grant application, you should\nchoose an applicant role. You can continue applying as an individual\nor switch to applying on behalf of the community. When you choose to\napply on behalf of a registered community, you will be transferred\nto Suomi.fi business authorization."
 msgstr "Innan du går vidare till bidragsansökan bör du välja en sökanderoll. Du kan fortsätta att ansöka som privatperson eller byta till att ansöka på uppdrag av gemenskapen. När du väljer att ansöka på uppdrag av en registrerad gemenskap kommer du att överföras till Suomi.fi företagsauktorisering."
 
 msgctxt "grants_mandate"
-msgid "Registered community is, for example, a company, non-profit organization, organization or association"
+msgid "Registered community is,\nfor example, a company, non-profit organization,\norganization or association"
 msgstr "Registrerad gemenskap är till exempel ett företag, ideell organisation, organisation eller förening"
 
 msgctxt "grants_mandate"


### PR DESCRIPTION
# [AU-2459](https://helsinkisolutionoffice.atlassian.net/browse/AU-2459)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix translations that were broken after phpstan fixes

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2459-translations`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to [asiointirooli valtuutus](https://hel-fi-drupal-grant-applications.docker.so/fi/asiointirooli-valtuutus) and check that translations work in fin and sv
* [x] Be logged in as private person, go to [service page](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/muut-avustukset/tyollisyysavustus)
* [x] Check that yellow box is translated correctly

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-2459]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ