### PR TITLE
fix: AU-2457: Fix attachment selections disappearing

### DIFF
--- a/public/modules/custom/grants_attachments/src/AttachmentHandlerHelper.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentHandlerHelper.php
@@ -153,10 +153,10 @@ class AttachmentHandlerHelper {
       case '':
       case 'new':
         if (isset($field['isDeliveredLater'])) {
-          $retval['isDeliveredLater'] = $field['isDeliveredLater'] === "1";
+          $retval['isDeliveredLater'] = in_array($field['isDeliveredLater'], ['1', 'true']);
         }
         if (isset($field['isIncludedInOtherFile'])) {
-          $retval['isIncludedInOtherFile'] = $field['isIncludedInOtherFile'] === "1";
+          $retval['isIncludedInOtherFile'] = in_array($field['isIncludedInOtherFile'], ['1', 'true']);
         }
         $retval['isNewAttachment'] = TRUE;
         break;


### PR DESCRIPTION
# [AU-2457](https://helsinkisolutionoffice.atlassian.net/browse/AU-2457)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix an issue where isDeliveredLater / isIncludedInOtherFile checkbox values were disappearing if user doesn't visit attachment page after returning to edit mode.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2457-fix-attachment-selections-disappearing`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any application https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/liikunta_laitosavustushakemus
* [ ] Go to attachment page and check Delivered later / already delivered check boxes
* [ ] Go to preview page
* [ ] Save as draft - Check that the checkbox values are correct 
* [ ] Press "Edit application"
* [ ] Save application once again and check the values are still there.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2457]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ