### PR TITLE
fix: AU-2057: Application attachment purging fix

### DIFF
--- a/public/modules/custom/grants_attachments/src/AttachmentRemover.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentRemover.php
@@ -234,7 +234,7 @@ class AttachmentRemover {
     $query = $database->query("SELECT sid FROM {sessions}");
     $result = $query->fetchAll();
 
-    $activeSessions = array_map(fn($item) => sha1($item->sid), $result);
+    $activeSessions = array_map(fn($item) => $item->sid, $result);
 
     $pathsToClear = [
       "private://grants_attachments",

--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\grants_attachments\Element;
 
+use Drupal\Component\Utility\Crypt;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Component\Utility\Xss;
@@ -218,7 +219,7 @@ class GrantsAttachments extends WebformCompositeBase {
   public static function getCompositeElements(array $element): array {
     $tOpts = ['context' => 'grants_attachments'];
 
-    $sessionHash = sha1(\Drupal::service('session')->getId());
+    $sessionHash = Crypt::hashBase64(\Drupal::service('session')->getId());
     $uploadLocation = 'private://grants_attachments/' . $sessionHash;
     $maxFileSizeInBytes = (1024 * 1024) * 20;
 

--- a/public/modules/custom/grants_handler/src/Form/MessageForm.php
+++ b/public/modules/custom/grants_handler/src/Form/MessageForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\grants_handler\Form;
 
+use Drupal\Component\Utility\Crypt;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\AppendCommand;
@@ -188,7 +189,7 @@ class MessageForm extends FormBase {
         '#required' => TRUE,
       ];
 
-      $sessionHash = sha1($this->session->getId());
+      $sessionHash = Crypt::hashBase64($this->session->getId());
       $upload_location = 'private://grants_messages/' . $sessionHash;
 
       $maxFileSizeInBytes = (1024 * 1024) * 20;

--- a/public/modules/custom/grants_profile/grants_profile.module
+++ b/public/modules/custom/grants_profile/grants_profile.module
@@ -118,35 +118,6 @@ function grants_profile_theme(): array {
 }
 
 /**
- * Implements hook_cron().
- */
-function grants_profile_cron(): void {
-
-  // Make sure no dangling files are left over from bank account confirmations.
-  /** @var \Drupal\Core\File\FileSystem $fileSystem */
-  $fileSystem = \Drupal::service('file_system');
-
-  $files = $fileSystem->scanDirectory(DRUPAL_ROOT . '/sites/default/files/private/grants_profile', '(.*?)');
-
-  foreach ($files as $uri => $file) {
-
-    /** @var \Drupal\file\FileInterface[] $loadedFiles */
-    $loadedFiles = \Drupal::entityTypeManager()
-      ->getStorage('file')
-      ->loadByProperties(['uri' => $uri]);
-    /** @var \Drupal\file\FileInterface|null $loadedFile */
-    $loadedFile = reset($loadedFiles) ?: NULL;
-
-    if ($loadedFile) {
-      $loadedFile->delete();
-    }
-    else {
-      @unlink($uri);
-    }
-  }
-}
-
-/**
  * Implements hook_form_alter().
  */
 function grants_profile_form_alter(&$form, FormStateInterface $form_state, $form_id): void {


### PR DESCRIPTION
# [AU-2057](https://helsinkisolutionoffice.atlassian.net/browse/AU-2057)

## What was done

The goal of this pull request was to:

**A)** Fix the code inside `purgeAllAttachments` that gets called every cron run.

**B)** Figure out why we're no longer deleting application attachments after an application has been saved/submitted.

## What has changed

**Fix for A):** The `purgeAllAttachments` function has been fixed an refactored. Previously, the function would always delete everything inside the `/private` directory whenever it was called, since session ID comparison was being done incorrectly. Changes also had to be made inside `GrantsAttachments.php` and `MessageForm.php`, since these were creating the attachment directories with the wrong hashing algorithm (sha1 instead of Crypt::hashBase64) in the first place. The code inside `grants_profile_cron` was also removed, since it is just duplicating the behaviour of `purgeAllAttachments`.

**Fix for B):** Nothing has been done, since we're actually already deleting the uploaded application attachments. This is being done in `getAttachmentByFieldValue`, which gets called inside `parseAttachments`, which gets called whenever we save or submit and application.

## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2057-fix-attachment-removing`
* `make fresh`
* `make drush-cr`

## How to test

If you have files and directories inside the `/private` directory, you can just run `make shell` -> `drush cron`. Check that any directories and files for any inactive sessions get deleted. The active sessions can be viewed from the DB table `sessions`.

If you don't, then just login with a test user and add a few attachments to the profile and a few applications. You can now run `drush cron `once while you're still logged in (which should delete nothing), and then once after you've logged out (which should delete everything).

[AU-2057]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ