### PR TITLE
fix: AU-2462: Remove unnecessary metdata generation

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
+++ b/public/modules/custom/grants_metadata/src/TypedDataToDocumentContentWithWebform.php
@@ -244,7 +244,6 @@ class TypedDataToDocumentContentWithWebform {
 
         // Handle a json structure of the size 2.
         if ($numberOfItems == 2) {
-          $metaData = AtvSchema::getMetaData($page, $section, $element);
           if (is_array($itemValue) && AtvSchema::numericKeys($itemValue) && $propertyType == 'list') {
             self::handlePropertyItems($reference, $elementName, $property, $webformMainElement, $defaultValue, $hiddenFields, $metaData);
             self::handlePossibleEmptyArray($documentStructure, $reference, $jsonPath);
@@ -269,7 +268,6 @@ class TypedDataToDocumentContentWithWebform {
         }
       }
     }
-
     // Handle cases when no attachments info has been added.
     if (!array_key_exists('attachmentsInfo', $documentStructure)) {
       $documentStructure['attachmentsInfo'] = [];


### PR DESCRIPTION
# [AU-2462](https://helsinkisolutionoffice.atlassian.net/browse/AU-2462)
<!-- What problem does this solve? -->

Hakemuksesta vastaavat henkilöt -kentän metadatan generoinnin.

## What was done
<!-- Describe what was done -->

* Poista turha metadatan generointi rivi

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2462-metadata-field-issueh`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Mainittuun kenttään tulee metadatat oikein.
* [ ] Ainakin liitteet (attachments), community_officials ja additional_information ovat kenttiä jotka menevät muokatun if-lausekkeen sisään. Metadata joko generoidaan aiemmin tai sitten se tyhjä array. En keksi tapausta jossa tämä rikkoisi mitään koska sama logiikka toimii if-lausekkeessa jossa jsonPathin koko on 3-5.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2462]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ