### PR TITLE
feat: AU-2453, E2E, Test attachment checkboxes

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -210,3 +210,7 @@ BUSINESS_IDS="7009192-5"
 Execute the script
 make shell > e2e/clean-env.sh
 ```
+
+## Known problems
+
+- Sometimes the test fail because of a problem with uploading attachment to applications or profiles. This can usually be fixed by setting 777 permission on everything inside the /private directory.

--- a/e2e/tests/forms/registered_community_52.ts
+++ b/e2e/tests/forms/registered_community_52.ts
@@ -399,70 +399,35 @@ const formPages: PageHandlers = {
     }
 
     if (items['edit-yhteison-saannot-attachment-upload']) {
-      await uploadFile(
-        page,
-        items['edit-yhteison-saannot-attachment-upload'].selector?.value ?? '',
-        items['edit-yhteison-saannot-attachment-upload'].selector?.resultValue ?? '',
-        items['edit-yhteison-saannot-attachment-upload'].value
-      )
+      await fillFormField(page, items['edit-yhteison-saannot-attachment-upload'], 'edit-yhteison-saannot-attachment-upload');
     }
 
     if (items['edit-vahvistettu-tilinpaatos-attachment-upload']) {
-      await uploadFile(
-        page,
-        items['edit-vahvistettu-tilinpaatos-attachment-upload'].selector?.value ?? '',
-        items['edit-vahvistettu-tilinpaatos-attachment-upload'].selector?.resultValue ?? '',
-        items['edit-vahvistettu-tilinpaatos-attachment-upload'].value
-      )
+      await fillFormField(page, items['edit-vahvistettu-tilinpaatos-attachment-upload'], 'edit-vahvistettu-tilinpaatos-attachment-upload');
     }
 
     if (items['edit-vahvistettu-toimintakertomus-attachment-upload']) {
-      await uploadFile(
-        page,
-        items['edit-vahvistettu-toimintakertomus-attachment-upload'].selector?.value ?? '',
-        items['edit-vahvistettu-toimintakertomus-attachment-upload'].selector?.resultValue ?? '',
-        items['edit-vahvistettu-toimintakertomus-attachment-upload'].value
-      )
+      await fillFormField(page, items['edit-vahvistettu-toimintakertomus-attachment-upload'], 'edit-vahvistettu-toimintakertomus-attachment-upload');
     }
 
     if (items['edit-vahvistettu-tilin-tai-toiminnantarkastuskertomus-attachment-upload']) {
-      await uploadFile(
-        page,
-        items['edit-vahvistettu-tilin-tai-toiminnantarkastuskertomus-attachment-upload'].selector?.value ?? '',
-        items['edit-vahvistettu-tilin-tai-toiminnantarkastuskertomus-attachment-upload'].selector?.resultValue ?? '',
-        items['edit-vahvistettu-tilin-tai-toiminnantarkastuskertomus-attachment-upload'].value
-      )
+      await fillFormField(page, items['edit-vahvistettu-tilin-tai-toiminnantarkastuskertomus-attachment-upload'], 'edit-vahvistettu-tilin-tai-toiminnantarkastuskertomus-attachment-upload');
     }
 
     if (items['edit-toimintasuunnitelma-attachment-upload']) {
-      await uploadFile(
-        page,
-        items['edit-toimintasuunnitelma-attachment-upload'].selector?.value ?? '',
-        items['edit-toimintasuunnitelma-attachment-upload'].selector?.resultValue ?? '',
-        items['edit-toimintasuunnitelma-attachment-upload'].value
-      )
+      await fillFormField(page, items['edit-toimintasuunnitelma-attachment-upload'], 'edit-toimintasuunnitelma-attachment-upload');
     }
 
     if (items['edit-vuokrasopimus-haettaessa-vuokra-avustusta-attachment-upload']) {
-      await uploadFile(
-        page,
-        items['edit-vuokrasopimus-haettaessa-vuokra-avustusta-attachment-upload'].selector?.value ?? '',
-        items['edit-vuokrasopimus-haettaessa-vuokra-avustusta-attachment-upload'].selector?.resultValue ?? '',
-        items['edit-vuokrasopimus-haettaessa-vuokra-avustusta-attachment-upload'].value
-      )
+      await fillFormField(page, items['edit-vuokrasopimus-haettaessa-vuokra-avustusta-attachment-upload'], 'edit-vuokrasopimus-haettaessa-vuokra-avustusta-attachment-upload');
     }
 
     if (items['edit-talousarvio-attachment-upload']) {
-      await uploadFile(
-        page,
-        items['edit-talousarvio-attachment-upload'].selector?.value ?? '',
-        items['edit-talousarvio-attachment-upload'].selector?.resultValue ?? '',
-        items['edit-talousarvio-attachment-upload'].value
-      )
+      await fillFormField(page, items['edit-talousarvio-attachment-upload'], 'edit-talousarvio-attachment-upload');
     }
 
     if (items['edit-muu-liite']) {
-      await fillFormField(page, items['edit-muu-liite'], 'edit-muu-liite')
+      await fillFormField(page, items['edit-muu-liite'], 'edit-muu-liite');
     }
 
     if (items['edit-extra-info']) {

--- a/e2e/utils/data/application/application_data_52.ts
+++ b/e2e/utils/data/application/application_data_52.ts
@@ -77,7 +77,6 @@ const baseFormRegisteredCommunity_52: FormData = {
         "edit-compensation-purpose": {
           value: faker.lorem.sentences(4),
         },
-
         "edit-myonnetty-avustus": {
           role: 'dynamicmultivalue',
           label: '',
@@ -1253,6 +1252,48 @@ const wrongValues: FormDataWithRemoveOptionalProps = {
   },
 };
 
+const fieldSwapForm: FormDataWithRemoveOptionalProps = {
+  title: 'Field swap form',
+  testFieldSwap: true,
+  formPages: {
+    "1_hakijan_tiedot": {
+      items: {},
+      itemsToSwap: [
+        {field: 'edit-bank-account-account-number-select', swapValue: PROFILE_INPUT_DATA.iban2},
+      ]
+    },
+    "2_avustustiedot": {
+      items: {},
+      itemsToSwap: [
+        {field: 'edit-compensation-purpose', swapValue: 'The new purpose!'},
+      ]
+    },
+    "lisatiedot_ja_liitteet": {
+      items: {
+        'edit-yhteison-saannot-attachment-upload': {
+          role: 'checkbox',
+          selector: {
+            type: 'data-drupal-selector',
+            name: 'data-drupal-selector',
+            value: 'edit-yhteison-saannot-isdeliveredlater'
+          },
+          value: 'Liite toimitetaan myöhemmin',
+        },
+        'edit-vahvistettu-tilinpaatos-attachment-upload': {
+          role: 'checkbox',
+          selector: {
+            type: 'data-drupal-selector',
+            name: 'data-drupal-selector',
+            value: 'edit-vahvistettu-tilinpaatos-isincludedinotherfile'
+          },
+          value: 'Liite on toimitettu yhtenä tiedostona tai toisen hakemuksen yhteydessä',
+        },
+      },
+    },
+  },
+  expectedErrors: {},
+};
+
 const sendApplication: FormDataWithRemoveOptionalProps = {
   title: 'Send to AVUS2',
   formPages: {
@@ -1279,6 +1320,7 @@ const registeredCommunityApplications_52 = {
   draft: baseFormRegisteredCommunity_52,
   missing_values: createFormData(baseFormRegisteredCommunity_52, missingValues),
   wrong_values: createFormData(baseFormRegisteredCommunity_52, wrongValues),
+  swap_fields: createFormData(baseFormRegisteredCommunity_52, fieldSwapForm),
   success: createFormData(baseFormRegisteredCommunity_52, sendApplication),
 }
 

--- a/e2e/utils/data/application/application_data_67.ts
+++ b/e2e/utils/data/application/application_data_67.ts
@@ -673,6 +673,10 @@ const copyForm: FormDataWithRemoveOptionalProps = {
   title: 'Original copy form',
   testFormCopying: true,
   formPages: {
+    '3_yhteison_tiedot': {
+      items: {},
+      itemsToRemove: ['edit-business-purpose'],
+    },
     'lisatiedot_ja_liitteet': {
       items: {},
       itemsToRemove: [

--- a/e2e/utils/data/application/application_data_67.ts
+++ b/e2e/utils/data/application/application_data_67.ts
@@ -687,7 +687,15 @@ const copyForm: FormDataWithRemoveOptionalProps = {
       ],
     },
   },
-  expectedErrors: {},
+  expectedErrors: {
+    'edit-yhteison-saannot-attachment-upload': 'Virhe sivulla 4. Lisätiedot ja liitteet: Yhteisön säännöt ei sisällä liitettyä tiedostoa, se täytyy toimittaa joko myöhemmin tai olla jo toimitettu.',
+    'edit-vahvistettu-tilinpaatos-attachment-upload': 'Virhe sivulla 4. Lisätiedot ja liitteet: Vahvistettu tilinpäätös (edelliseltä päättyneeltä tilikaudelta) ei sisällä liitettyä tiedostoa, se täytyy toimittaa joko myöhemmin tai olla jo toimitettu.',
+    'edit-vahvistettu-toimintakertomus-attachment-upload': 'Virhe sivulla 4. Lisätiedot ja liitteet: Vahvistettu toimintakertomus (edelliseltä päättyneeltä tilikaudelta) ei sisällä liitettyä tiedostoa, se täytyy toimittaa joko myöhemmin tai olla jo toimitettu.',
+    'edit-vahvistettu-tilin-tai-toiminnantarkastuskertomus-attachment-upload': 'Virhe sivulla 4. Lisätiedot ja liitteet: Vahvistettu tilin- tai toiminnantarkastuskertomus (edelliseltä päättyneeltä tilikaudelta) ei sisällä liitettyä tiedostoa, se täytyy toimittaa joko myöhemmin tai olla jo toimitettu.',
+    'edit-vuosikokouksen-poytakirja-attachment-upload': 'Virhe sivulla 4. Lisätiedot ja liitteet: Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös ei sisällä liitettyä tiedostoa, se täytyy toimittaa joko myöhemmin tai olla jo toimitettu.',
+    'edit-toimintasuunnitelma-attachment-upload': 'Virhe sivulla 4. Lisätiedot ja liitteet: Toimintasuunnitelma (sille vuodelle jolle haet avustusta) ei sisällä liitettyä tiedostoa, se täytyy toimittaa joko myöhemmin tai olla jo toimitettu.',
+    'edit-talousarvio-attachment-upload': 'Virhe sivulla 4. Lisätiedot ja liitteet: Talousarvio (sille vuodelle jolle haet avustusta) ei sisällä liitettyä tiedostoa, se täytyy toimittaa joko myöhemmin tai olla jo toimitettu.',
+  },
 };
 
 const sendApplication: FormDataWithRemoveOptionalProps = {


### PR DESCRIPTION
# [AU-2453](https://helsinkisolutionoffice.atlassian.net/browse/AU-2453)

## What was done

This pull request implements a field value swap test for application 52. This has been done in order to test that checkbox values selected on the applications attachment page stay "ticked" after the form has been edited a second time. This is done by:

1. Filling in the form normally with the form test. Here we make sure to tic a few checkbox on the attachment page.
2. Going back to the form during the field swap test, while making sure that we don't visit the attachment page.
3. Validating the content of the form after the field swap test has finished.


## Other smaller changes

- Added `expectedErrors` to the 67 forms `copyForm` test (they were missing and causing the tests to fail). Also removed the field `edit-business-purpose`, since this field isn't currently being copied correctly.

- Added to the .readme.

## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2453-e2e-attachment-checkboxes`
* `make fresh`
* `make drush-cr`

## How to test

Set `ENABLED_FORM_VARIANTS="copy,swap_fields"` in the .env file and run `make test-pw-p PROJECT=forms-52 forms-67`. Make sure it passes.

[AU-2453]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ