### PR TITLE
fix: AU-2425: add aria label to application search

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--application-search-search-api.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--application-search-search-api.html.twig
@@ -97,7 +97,7 @@
 
             {% for key, value in newExposedFilter %}
               {% if key not in ['search', 'items_per_page'] and value is not same as('All') %}
-                <button class="reset-search search-filter-button" data-field="{{ 'edit-' ~ key }}"><span class="hel-icon hel-icon--cross-circle" aria-hidden="true"></span> <span>{{ value }}</span></button>
+                <button class="reset-search search-filter-button" data-field="{{ 'edit-' ~ key }}" aria-label="{{ 'Delete'|t }} {{ value }}"><span class="hel-icon hel-icon--cross-circle" aria-hidden="true"></span> <span>{{ value }}</span></button>
               {% endif %}
             {% endfor %}
 


### PR DESCRIPTION
# [AU-2425](https://helsinkisolutionoffice.atlassian.net/browse/AU-2425)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add aria label to application search

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2425-etsi-avustusta`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [Etsi avustusta](https://hel-fi-drupal-grant-applications.docker.so/fi/etsi-avustusta)
* [ ] Select some search parameters
* [ ] Check that buttons are read as "Delete x"
* [ ] Check translations

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

