### PR TITLE
fix: AU-2468: Change language back to FI

### DIFF
--- a/conf/cmi/language.negotiation.yml
+++ b/conf/cmi/language.negotiation.yml
@@ -14,4 +14,4 @@ url:
     en: ''
     fi: ''
     sv: ''
-selected_langcode: en
+selected_langcode: fi


### PR DESCRIPTION
# [AU-2468](https://helsinkisolutionoffice.atlassian.net/browse/AU-2468)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Change default language back to FI.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2468-default-lang`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that https://hel-fi-drupal-grant-applications.docker.so will redirect you to FI frontpage


## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2230]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2468]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ