### PR TITLE
fix: AU-2472: remove unused hdbt_subtheme preprocessing hook for icon path

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -44,32 +44,6 @@ function hdbt_subtheme_preprocess_status_messages(&$variables): void {
 }
 
 /**
- * Helper function to get the icons path.
- *
- * @return string|null
- *   Returns path for the icons SVG or null.
- */
-function hdbt_subtheme_get_icons_path(): ?string {
-  static $icon_path;
-  if (!isset($icon_path)) {
-    $theme_handler = \Drupal::service('theme_handler');
-    $icon_path = '/' . $theme_handler->getTheme('hdbt_subtheme')->getPath() . '/dist/icons/sprite.svg';
-
-    // Add icons path as a global variable.
-    return $icon_path;
-  }
-  return $icon_path;
-}
-
-/**
- * Implements hook_preprocess().
- */
-function hdbt_subtheme_preprocess(&$variables): void {
-  $variables['hdbt_subtheme_icons_path'] = hdbt_subtheme_get_icons_path();
-  $variables['#attached']['drupalSettings']['helfigrantapplicationsIconsPath'] = $variables['hdbt_subtheme_icons_path'];
-}
-
-/**
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_subtheme_preprocess_menu(&$variables): void {


### PR DESCRIPTION
# [AU-2472](https://helsinkisolutionoffice.atlassian.net/browse/AU-2472)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* We had an older hdbt_subtheme preprocessing hook in our system that defined the path to icons. This has since been removed from the way hdbt subtheme works (most likely in v3 update), but the function still existed and got called a lot. Now it is gone and nothing has changed in the way the site works.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2474-icon-path`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to the site.
* [ ] Navigate the site.
* [ ] Play around.
* [ ] See that there is no errors regarding the icons and that the icons work as intended.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2474]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2472]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ