### PR TITLE
fix: AU-2470: Fix stepper first line

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/webform/webform-progress-tracker.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/webform/webform-progress-tracker.html.twig
@@ -69,7 +69,7 @@
             <p class="grants-stepper__text" data-webform-progress-link>
                     <span class="visually-hidden"
                           data-webform-progress-state>{% if is_active or is_completed %}{{ is_active ? 'Current'|t : 'Completed'|t }}{% endif %}</span>
-              {{ page.title }}
+              {{ page.title|replace({'. ': '.&nbsp;'})|raw }}
             </p>
           {% endif %}
         </div>


### PR DESCRIPTION
# [AU-2470](https://helsinkisolutionoffice.atlassian.net/browse/AU-2470)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* The page stepper's first line breaks in a silly place (right after the number) if the first word of the stepper title is long. This adds a nonbreaking space in beween the number and the first word to make the word fit on the first line.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2470-nbsp-to-stepper`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to a [form with a long word title](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti) in the pages.
* [ ] See that the long word fits on the same line as the number (in kuva projekti, it's page 2).
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [x] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2470]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ