### PR TITLE
fix: AU-2481, AU-2482: fix message translations

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -750,8 +750,8 @@ class GrantsHandler extends WebformHandlerBase {
         $form['#disabled'] = TRUE;
         $this->messenger()
           ->addWarning($this->t('Your data is safe, but not all the
-          information in your application has been updated yet. Please wait a
-           moment and reload the page.',
+information in your application has been updated yet. Please wait a
+moment and reload the page.',
             [],
             $tOpts));
       }

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -141,7 +141,7 @@ msgid 'Edit application'
 msgstr 'Muokkaa hakemusta'
 
 msgctxt "grants_handler"
-msgid "Your data is safe, but not all the information in your application has been updated yet. Please wait a moment and reload the page."
+msgid "Your data is safe, but not all the\ninformation in your application has been updated yet. Please wait a\nmoment and reload the page."
 msgstr "Tietosi ovat turvassa, mutta kaikkia hakemuksesi tietoja ei ole vielä päivitetty. Odota hetki ja lataa sivu uudelleen."
 
 msgid "File upload failed, error has been logged."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -141,7 +141,7 @@ msgid "Edit application"
 msgstr "Uppdatera ansökning"
 
 msgctxt "grants_handler"
-msgid "Your data is safe, but not all the information in your application has been updated yet. Please wait a moment and reload the page."
+msgid "Your data is safe, but not all the\ninformation in your application has been updated yet. Please wait \nmoment and reload the page."
 msgstr "Din information är säker, men all information i din ansökan har inte uppdaterats ännu. Vänligen vänta ett ögonblick och ladda om sidan."
 
 msgid "File upload failed, error has been logged."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -453,6 +453,9 @@ msgstr "Du har inte de nödvändiga behörigheterna för att göra en ansökan. 
 msgid "Grant application (@number) saving failed. Error has been logged."
 msgstr "Det gick inte att spara bidragsansökan (@number). Ett fel har loggats."
 
+msgid "Grant application (<span id=\"saved-application-number\">@number</span>) saved."
+msgstr "Bidragsansökan @number sparat."
+
 msgid "User does not have proper mandate."
 msgstr "Användaren har inte korrekt mandat."
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* [AU-2481](https://helsinkisolutionoffice.atlassian.net/browse/AU-2481): Fix warning message translation
* [AU-2482](https://helsinkisolutionoffice.atlassian.net/browse/AU-2482): Fix status message translation

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2481-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go send any application in SV
* [ ] Make sure that "application is saved" -message is translated
* [ ] Go edit any sent application
* [ ] Make sure that "your data is safe" -message is translated

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

[AU-2481]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2482]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ