### PR TITLE
fix: AU-2494: add text to KUVAKEHA subventions

### DIFF
--- a/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -56,7 +56,7 @@ elements: |
   subventions:
     '#title': Grants
   markup:
-    '#markup': '<p>Only apply for one grant type at a time with each application.</p>'
+    '#markup': '<p>Only apply for one grant type at a time with each application. Enter the amount only regarding the year that you are applying the grant for with this application.</p>'
   info_kyseessa_on_monivuotinen_avustus:
     '#markup': "<p>&nbsp;</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\">An affirmative answer opens a further question</div>\r\n</div>\r\n</div>"
   kyseessa_on_monivuotinen_avustus:

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -59,7 +59,7 @@ elements: |
   subventions:
     '#title': Understöd
   markup:
-    '#markup': '<p>Ansök alltid endast om en typ av understöd åt gången.</p>'
+    '#markup': '<p>Ansök alltid endast om en typ av understöd åt gången. Ange här endast stödsumman för det år, för vilket du nu ansöker om stöd.</p>'
   info_kyseessa_on_monivuotinen_avustus:
     '#markup': "<p>&nbsp;</p>\r\n\r\n<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Ett jakande svar öppnar ytterligare en fråga</span></div>\r\n</div>\r\n</div>"
   kyseessa_on_monivuotinen_avustus:

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -195,7 +195,7 @@ elements: |-
             - subventions
       markup:
         '#type': webform_markup
-        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan.</p>'
+        '#markup': '<p>Hae yhdell&auml; hakemuksella aina vain yht&auml; avustuslajia kerrallaan. Kirjaa tähän avustussumma vain sen vuoden osalta, jolle haet avustusta tällä hakemuksella.</p>'
       info_kyseessa_on_monivuotinen_avustus:
         '#type': webform_markup
         '#markup': |


### PR DESCRIPTION
# [AU-2494](https://helsinkisolutionoffice.atlassian.net/browse/AU-2494)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add text to KUVAKEHA subventions

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2494-kuvakeha`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [KUVAKEHA](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/taide_ja_kulttuuri_kehittamisavu)
* [ ] Go to page 2
* [ ] Check that subvention markup is as mentioned in the ticket
* [ ] Check translations

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


[AU-2494]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ