### PR TITLE
fix: AU-2420: Fix jumplink at the start of a form page

### DIFF
--- a/public/modules/custom/grants_handler/js/webform.form.unsaved.js
+++ b/public/modules/custom/grants_handler/js/webform.form.unsaved.js
@@ -88,7 +88,7 @@
   };
   $('a').on('click', function (event) {
     let containingElement = document.querySelector('form');
-    if (unsaved && !containingElement.contains( event.target )) {
+    if (unsaved && !containingElement.contains( event.target ) && !event.target.getAttribute('href').startsWith('#')) {
       event.preventDefault();
       const $previewDialog = $(
         `<div></div>`,

--- a/public/modules/custom/grants_handler/templates/application-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list.html.twig
@@ -65,7 +65,7 @@
       </ul>
     {% endif %}
     {% if type != 'drafts' and items %}
-      <div aria-label={{"Pagination"|t}} role="navigation" class="hds-pagination-container" {% if items|length < 0 %} style="display:none;"{% endif %}>
+      <div class="hds-pagination-container">
         <ul class="pagination application-list__pagination"></ul>
       </div>
     {% endif %}

--- a/public/modules/custom/grants_handler/templates/application-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list.html.twig
@@ -65,7 +65,7 @@
       </ul>
     {% endif %}
     {% if type != 'drafts' and items %}
-      <div class="hds-pagination-container">
+      <div aria-label={{"Pagination"|t}} role="navigation" class="hds-pagination-container" {% if items|length < 0 %} style="display:none;"{% endif %}>
         <ul class="pagination application-list__pagination"></ul>
       </div>
     {% endif %}


### PR DESCRIPTION
# [AU-2420](https://helsinkisolutionoffice.atlassian.net/browse/AU-2420)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* On formpage, the unsaved confirmation script was interfering with internal links (links that point to the same page), this fixes that.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2420-jumplink-javascript-fix`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Clear browser cache (ctrl-shift-r)
* [ ] Go to a [form ](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_projekti).
* [ ] Fill out a field
* [ ] Using the tab key, go back to the very beginning of the page (one step more back from palaute link) and the hyppää pääsisältöön link appears. Click on it with a mouse and see that it works.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2420]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ