### PR TITLE
fix: AU-2942: fix tooltip in kuva toiminta

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_toiminta.yml
@@ -368,7 +368,7 @@ elements: |
     '#markup': '<p>Regarding the previous completed financial year. As stated in the financial statements.</p>'
   organisaatio_kuului_valtionosuusjarjestelmaan_vos_:
     '#title': 'The organization belonged to the central government subsidies system (VOS)'
-    '#help': '<p>Select yes, only if you know for sure that your organization receives funding in the form of the central government subsidies. This does not refer to all the grants granted by the state, but to a separate statutory form of funding for a limited group. For art and culture operators the central government subsidies are calculated based on, for example, person-years of work and their unit price or the number of teaching hours of basic arts education.</p>'
+    '#help': 'Select yes, only if you know for sure that your organization received funding in the form of the central government subsidies. This does not refer to all the grants granted by the state, but to a separate statutory form of funding for a limited group. For art and culture operators the central government subsidies are calculated based on, for example, person-years of work and their unit price or the number of teaching hours of basic arts education.'
     '#options':
       1: 'Yes'
       0: 'No'

--- a/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_toiminta.yml
@@ -367,7 +367,7 @@ elements: |
     '#markup': '<p>Föregående avslutade räkenskapsår. Enligt bokslutet.</p>'
   organisaatio_kuului_valtionosuusjarjestelmaan_vos_:
     '#title': 'Organisationen fick statsandelar (VOS)'
-    '#help': '<p>Välj ja, bara om du med säkerhet vet att din organisation får finansiering i form av statsandelar. Detta innebär inte alla stöd som beviljas av staten, utan snarare en lagstadgad separat finansieringsform för en begränsad grupp. Statsandelar till konst- och kulturaktörer är subventioner som baseras på beräknade andelar, till exempel årsverken och deras styckpris eller antalet undervisningstimmar i den grundläggande konstundervisningen.</p>'
+    '#help': 'Välj ja, bara om du med säkerhet vet att din organisation fick finansiering i form av statsandelar. Detta innebär inte alla stöd som beviljas av staten, utan snarare en lagstadgad separat finansieringsform för en begränsad grupp. Statsandelar till konst- och kulturaktörer är subventioner som baseras på beräknade andelar, till exempel årsverken och deras styckpris eller antalet undervisningstimmar i den grundläggande konstundervisningen.'
     '#options':
       1: Ja
       0: Nej

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -1269,7 +1269,7 @@ elements: |-
         '#type': radios
         '#required': true
         '#title': 'Organisaatio kuului valtionosuusjärjestelmään (VOS)'
-        '#help': 'Valitse kyllä, vain jos varmuudella tiedät organisaatiosi saavan rahoitusta juuri valtionosuuden muodossa. Tällä ei tarkoiteta kaikkia valtion myöntämiä avustuksia, vaan kyseessä on rajattua joukkoa koskeva lakisääteinen erillinen rahoitusmuoto. Taide- ja kulttuuritoimijoiden valtionosuudet ovat laskennallisiin osuuksiin, esimerkiksi henkilötyövuosiin ja niiden yksikköhintaan tai taiteen perusopetuksen opetustuntimäärään perustuvia tukia.'
+        '#help': 'Valitse kyllä, vain jos varmuudella tiedät organisaatiosi saaneen rahoitusta juuri valtionosuuden muodossa. Tällä ei tarkoiteta kaikkia valtion myöntämiä avustuksia, vaan kyseessä on rajattua joukkoa koskeva lakisääteinen erillinen rahoitusmuoto. Taide- ja kulttuuritoimijoiden valtionosuudet ovat laskennallisiin osuuksiin, esimerkiksi henkilötyövuosiin ja niiden yksikköhintaan tai taiteen perusopetuksen opetustuntimäärään perustuvia tukia.'
         '#options':
           1: Kyllä
           0: Ei


### PR DESCRIPTION
# [AU-2942](https://helsinkisolutionoffice.atlassian.net/browse/AU-2942)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix tooltip in kuva toiminta

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2942-kuva-toiminta`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [kuva toiminta](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kuva_toiminta)
* [ ] Go to page 6
* [ ] Scroll to Toteutuneet tulot ja menot
* [ ] Check that Organisaatio kuului valtionosuusjärjestelmään (VOS) tooltip text is correct (tiedät organisaatiosi _saaneen_)
* [ ] Check translatons

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)
