### PR TITLE
fix: AU-2490, AU-2491: small fixes to KUVAKEHA

### DIFF
--- a/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/en/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -261,7 +261,7 @@ elements: |
     '#markup': '<h4>Planned expenses</h4>'
   budget_other_cost:
     '#title': 'Other costs'
-    '#help': "Add below all the project's planned expenses by expense category."
+    '#description': "Add below all the project's planned expenses by expense category."
   muu_huomioitava_panostus:
     '#markup': '<h4>Other notable input</h4>'
   sisaltyyko_toiminnan_toteuttamiseen_jotain_muuta_rahanarvoista_p:

--- a/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/language/sv/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -264,7 +264,7 @@ elements: |
     '#markup': '<h4>Planerade utgifter</h4>'
   budget_other_cost:
     '#title': 'Övriga kostnader'
-    '#help': 'Lägg till alla projektets planerade utgifter per utgiftskategori nedan.'
+    '#description': 'Lägg till alla projektets planerade utgifter per utgiftskategori nedan.'
   muu_huomioitava_panostus:
     '#markup': '<h4>Övrig betydande insats</h4>'
   sisaltyyko_toiminnan_toteuttamiseen_jotain_muuta_rahanarvoista_p:
@@ -291,7 +291,7 @@ elements: |
     '#markup': "<div class=\"hds-notification hds-notification--info\">\r\n<div class=\"hds-notification__content\">\r\n<div class=\"hds-notification__label\"><span>Innehållet i bilagorna kan inte granskas i efterhand</span></div>\r\n\r\n<div class=\"hds-notification__body\">\r\n<p>Observera att du inte kan öppna bilagorna efter att du har bifogat dem blanketten. Du ser bara bilagans filnamn.</p>\r\n\r\n<p>Även om du inte kan granska innehållet i bilagorna i efterhand skickas bilagorna som bifogats blanketten med övriga uppgifter till personen som behandlar ansökan om understöd.</p>\r\n</div>\r\n</div>\r\n</div>"
   projektisuunnitelma_liite:
     '#title': 'Projekt plan'
-    '#help': '<p>Projektplan för önskad period</p>'
+    '#help': '<p>Projektplan för den tid som ansökan gäller</p>'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''
@@ -299,7 +299,7 @@ elements: |
     '#isAttachmentNew__title': ''
   talousarvio_liite:
     '#title': Budget
-    '#help': '<p>Budget för den begärda perioden</p>'
+    '#help': '<p>Budget för den tid som ansökan gäller</p>'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -740,7 +740,8 @@ elements: |-
       budget_other_cost:
         '#type': grants_budget_other_cost
         '#title': 'Muut kulut'
-        '#help': 'Lisää alle kaikki hankkeen suunnitellut menot kululuokittain.'
+        '#description': 'Lisää alle kaikki hankkeen suunnitellut menot kululuokittain.'
+        '#description_display': before
         '#multiple': true
         '#incomeGroup': general
         '#multiple__min_items': 1


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* [AU-2490](https://helsinkisolutionoffice.atlassian.net/browse/AU-2490): Fix SV tooltips in attachments
* [AU-2491](https://helsinkisolutionoffice.atlassian.net/browse/AU-2491): Change Suunnitellut menot tooltip to description

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2491-kuva-keha`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [KUVAKEHA](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/taide_ja_kulttuuri_kehittamisavu)
* [ ] Go to page 6
* [ ] Check that in Suunnitellut menot there is a description and not a tooltip
* [ ] Check translations
* [ ] Go to SV page 7
* [ ] Check that Projekt plan and Budget tooltips are correct, as stated in ticket

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-2490]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AU-2491]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ