### PR TITLE
fix: AU-2473: Fix profiles

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormPrivatePerson.php
@@ -126,6 +126,7 @@ class GrantsProfileFormPrivatePerson extends GrantsProfileFormBase {
     $form['addressWrapper'] = [
       '#type' => 'webform_section',
       '#title' => $this->t('Address'),
+      '#title_tag' => 'h4',
       '#prefix' => '<div id="addresses-wrapper">',
       '#suffix' => '</div>',
     ];

--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormUnregisteredCommunity.php
@@ -367,6 +367,7 @@ you can do that by going to the Helsinki-profile from this link.', [], $this->tO
     $form['addressWrapper'] = [
       '#type' => 'webform_section',
       '#title' => $this->t('Addresses', [], $this->tOpts),
+      '#title_tag' => 'h4',
       '#prefix' => '<div id="addresses-wrapper">',
       '#suffix' => '</div>',
     ];
@@ -503,6 +504,7 @@ One address is mandatory information in your personal information and on the app
     $form['officialWrapper'] = [
       '#type' => 'webform_section',
       '#title' => $this->t('Persons responsible for operations', [], $this->tOpts),
+      '#title_tag' => 'h4',
       '#prefix' => '<div id="officials-wrapper">',
       '#suffix' => '</div>',
     ];


### PR DESCRIPTION
# [AU-2473](https://helsinkisolutionoffice.atlassian.net/browse/AU-2473)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Some headers were of wrong depth on Edit Profile page of private person and unregistered community. This is fixed now.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2473-omat-yhteystiedot`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in
* [ ] Choose Private person as asiointirooli
* [ ] Go to [Edit profile](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi/hakuprofiili/muokkaa). See that the headers of webform sections are all H4, not H3
* [ ] Choose Unregistered community as asiointirooli
* [ ] Go to [Edit profile](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi/hakuprofiili/muokkaa). See that the headers of webform sections are all H4, not H3
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2473]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ