### PR TITLE
fix: AU-2478: Fix applications scheduling

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
@@ -198,6 +198,13 @@ class ServicePageAuthBlock extends BlockBase implements ContainerFactoryPluginIn
   /**
    * {@inheritdoc}
    */
+  public function getCacheMaxAge(): int {
+    return 600;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCacheContexts(): array {
     return Cache::mergeContexts(parent::getCacheContexts(), [
       'languages:language_content',


### PR DESCRIPTION
# [AU-2478](https://helsinkisolutionoffice.atlassian.net/browse/AU-2478)
<!-- What problem does this solve? -->

Scheduling of applications is broken because of the caching setup.

## What was done
<!-- Describe what was done -->

* Add hard cache for 10 mins. This means that ServicePageBlock will always be cached for 10 minutes. So at most, the block should show / hide maximum of 10 mins after the scheduled time.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2478-publish-timings`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Open any application with admin access, and set the closing time for some minutes in advance. Make sure the service page is linked to form.
* If waiting is not your thing, you can change the cache [time in here for smaller value](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/b94225cc59a568d2b3b99b5dcc4ad451c5190f88/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php#L202)
* Go to service page after logging in and see that the block changes as set up in 3rd party form for application.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-2478]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ