### PR TITLE
feature: AU-2502: E2E, Verify draft button test

### DIFF
--- a/e2e/tests/forms/private_person_64.ts
+++ b/e2e/tests/forms/private_person_64.ts
@@ -7,8 +7,9 @@ import {validateSubmission} from "../../utils/validation_helpers";
 import {deleteDraftApplication} from "../../utils/deletion_helpers";
 import {copyApplication} from "../../utils/copying_helpers";
 import {fillFormField, fillInputField} from "../../utils/input_helpers";
-import {privatePersonApplications as applicationData} from '../../utils/data/application_data';
 import {swapFieldValues} from "../../utils/field_swap_helpers";
+import {verifyDraftButton} from "../../utils/verify_draft_button_helpers";
+import {privatePersonApplications as applicationData} from '../../utils/data/application_data';
 
 const profileType = 'private_person';
 const formId = '64';
@@ -194,6 +195,19 @@ test.describe('ASUKASPIEN(64)', () => {
         formId,
         profileType,
         formPages
+      );
+    });
+  }
+
+  for (const [key, obj] of testDataArray) {
+    if (key !== 'draft') continue;
+    test(`Verify draft button: ${obj.title}`, async () => {
+      const storedata = getObjectFromEnv(profileType, formId);
+      await verifyDraftButton(
+        key,
+        page,
+        obj,
+        storedata
       );
     });
   }

--- a/e2e/tests/forms/registered_community_64.ts
+++ b/e2e/tests/forms/registered_community_64.ts
@@ -7,8 +7,10 @@ import {validateSubmission} from "../../utils/validation_helpers";
 import {deleteDraftApplication} from "../../utils/deletion_helpers";
 import {copyApplication} from "../../utils/copying_helpers";
 import {fillFormField, fillInputField} from "../../utils/input_helpers";
-import {registeredCommunityApplications as applicationData} from '../../utils/data/application_data';
 import {swapFieldValues} from "../../utils/field_swap_helpers";
+import {verifyDraftButton} from "../../utils/verify_draft_button_helpers";
+
+import {registeredCommunityApplications as applicationData} from '../../utils/data/application_data';
 
 const profileType = 'registered_community';
 const formId = '64';
@@ -177,6 +179,19 @@ test.describe('ASUKASPIEN(64)', () => {
         formId,
         profileType,
         formPages
+      );
+    });
+  }
+
+  for (const [key, obj] of testDataArray) {
+    if (key !== 'draft') continue;
+    test(`Verify draft button: ${obj.title}`, async () => {
+      const storedata = getObjectFromEnv(profileType, formId);
+      await verifyDraftButton(
+        key,
+        page,
+        obj,
+        storedata
       );
     });
   }

--- a/e2e/tests/forms/unregistered_community_64.ts
+++ b/e2e/tests/forms/unregistered_community_64.ts
@@ -7,8 +7,9 @@ import {validateSubmission} from "../../utils/validation_helpers";
 import {deleteDraftApplication} from "../../utils/deletion_helpers";
 import {copyApplication} from "../../utils/copying_helpers";
 import {fillFormField, fillInputField} from "../../utils/input_helpers";
-import {unRegisteredCommunityApplications as applicationData} from '../../utils/data/application_data';
 import {swapFieldValues} from "../../utils/field_swap_helpers";
+import {verifyDraftButton} from "../../utils/verify_draft_button_helpers";
+import {unRegisteredCommunityApplications as applicationData} from '../../utils/data/application_data';
 
 const profileType = 'unregistered_community';
 const formId = '64';
@@ -176,6 +177,19 @@ test.describe('ASUKASPIEN(64)', () => {
         formId,
         profileType,
         formPages
+      );
+    });
+  }
+
+  for (const [key, obj] of testDataArray) {
+    if (key !== 'draft') continue;
+    test(`Verify draft button: ${obj.title}`, async () => {
+      const storedata = getObjectFromEnv(profileType, formId);
+      await verifyDraftButton(
+        key,
+        page,
+        obj,
+        storedata
       );
     });
   }

--- a/e2e/utils/verify_draft_button_helpers.ts
+++ b/e2e/utils/verify_draft_button_helpers.ts
@@ -1,0 +1,50 @@
+import {expect, Page, test} from "@playwright/test";
+import {logCurrentUrl} from "./helpers";
+import {logger} from "./logger";
+import {FormData} from "./data/test_data";
+
+
+/**
+ * The verifyDraftButton function.
+ *
+ * This function verifies that a draft application has a
+ * "Save as draft" button on the "edit application" page.
+ *
+ * @param formKey
+ *   The form variant key.
+ * @param page
+ *   Page object from Playwright.
+ * @param formDetails
+ *   The form data.
+ * @param storedata
+ *   The env form data.
+ */
+const verifyDraftButton = async (
+  formKey: string,
+  page: Page,
+  formDetails: FormData,
+  storedata: any
+) => {
+  if (storedata === undefined || storedata[formKey] === undefined) {
+    logger(`Skipping verify draft button test: No env data stored after the "${formDetails.title}" test.`);
+    test.skip(true, 'Skip verify draft button test');
+    return;
+  }
+
+  const {applicationId, submissionUrl} = storedata[formKey];
+  logger(`Performing verify draft button test: ${applicationId}...`);
+
+  await page.goto(submissionUrl);
+  await logCurrentUrl(page);
+  await page.waitForURL('**/muokkaa');
+  logger(`Navigated to: ${submissionUrl}.`);
+
+  const draftButton = await page.locator('[data-drupal-selector="edit-actions-draft"]').count();
+  const errorMessage = `No draft button found at: ${submissionUrl}. Application ID: ${applicationId}`;
+  await expect(draftButton, errorMessage).toBeTruthy();
+  logger('Draft button verified.')
+}
+
+export {
+  verifyDraftButton,
+}

--- a/public/modules/custom/grants_admin_applications/src/Form/DeleteApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/DeleteApplicationsForm.php
@@ -43,7 +43,7 @@ final class DeleteApplicationsForm extends FormBase {
    *
    * @var \Drupal\Core\Logger\LoggerChannelFactory
    */
-  protected LoggerChannelFactory $logger;
+  protected LoggerChannelFactoryInterface $logger;
 
   /**
    * Configuration Factory.

--- a/public/modules/custom/grants_admin_applications/src/Service/HandleDocumentsBatchService.php
+++ b/public/modules/custom/grants_admin_applications/src/Service/HandleDocumentsBatchService.php
@@ -45,7 +45,7 @@ class HandleDocumentsBatchService {
    *
    * @var \Drupal\Core\Logger\LoggerChannelFactory
    */
-  protected LoggerChannelFactory $logger;
+  protected LoggerChannelFactoryInterface $logger;
 
   /**
    * Module extension list.


### PR DESCRIPTION
# [AU-2502](https://helsinkisolutionoffice.atlassian.net/browse/AU-2502)

## What was done

This pull request implements a test for verifying that an already existing draft application has a "Save as draft" button on the applications "edit" page. The test has been implemented for all 64 forms.

## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2488-service-page-blocks`
* `make fresh`
* `make drush-cr`

## How to test

- Set ENABLED_FORM_VARIANTS="draft" in the `.env` file.

- Run `make test-pw-p PROJECT=forms-64`. Make sure the test passes and that you see this:

<img width="1433" alt="Screenshot 2024-05-23 at 15 00 08" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/efecab65-b4f8-4694-83ee-c01f82f18547">


[AU-2488]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2502]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ