### PR TITLE
fix: AU-2520: fix subvention type names

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -268,7 +268,7 @@ third_party_options:
     29: 'Development grant / The Helsinki Model'
     31: 'Start grant'
     32: 'Facility usage grant'
-    34: 'Basic art education'
+    34: 'Basic arts education'
     35: 'Early childhood education'
     36: 'Liberal adult education'
     37: 'Event grant'
@@ -279,7 +279,7 @@ third_party_options:
     42: 'Grant for other associations promoting physical activity'
     43: 'Targeted sports grant'
     44: 'Development grant'
-    45: 'Development grant / The Helsinki Model'
+    45: 'Development grant for the Helsinki Model'
     46: 'Development grant for basic art education'
 langcode: en
 config_import_ignore:


### PR DESCRIPTION
# [AU-2520](https://helsinkisolutionoffice.atlassian.net/browse/AU-2520)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix subvention type names

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2520-avustuslajit`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [TPO](https://hel-fi-drupal-grant-applications.docker.so/en/uusi-hakemus/taide_ja_kulttuuriavustukset_tai) and [KUVAKEHA](https://hel-fi-drupal-grant-applications.docker.so/en/uusi-hakemus/taide_ja_kulttuuri_kehittamisavu)
* [ ] Check that subvention type names match the ones in the ticket

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-2520]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ