### PR TITLE
AU-2435: Modify send application list search behaviour

### DIFF
--- a/public/modules/custom/grants_handler/templates/application-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list.html.twig
@@ -9,11 +9,11 @@
         <div class="application-list-filter hds-text-input">
           <label for="applicationListFilter" class="hds-text-input__label">{{ "Search for an application"|t({}, {'context': 'grants_handler'})}}</label>
           <div class="hds-text-input__input-wrapper">
-            <input autocomplete="off" class="hds-text-input__input search" type="text" name="applicationListFilter" id="applicationListFilter" />
+            <input autocomplete="off" class="hds-text-input__input" type="text" name="applicationListFilter" id="applicationListFilter" />
           </div>
         </div>
         <div>
-          <button type="button" class="hds-button hds-button--primary">
+          <button id="searchForApplication" type="button" class="hds-button hds-button--primary">
             <span class="hds-button__label">{{ "Search for application"|t({}, {'context': 'grants_handler'})}}</span>
             <span aria-hidden="true" class="hel-icon hel-icon--search"></span>
           </button>

--- a/public/modules/custom/grants_oma_asiointi/js/application-draft-list.js
+++ b/public/modules/custom/grants_oma_asiointi/js/application-draft-list.js
@@ -14,6 +14,18 @@
           $('#oma-asiointi__sent .application-list__count-value').html(sentList.update().matchingItems.length);
         });
 
+        $('#searchForApplication').click(function() {
+          const searchValue = $('#applicationListFilter').val();
+          sentList.search(searchValue);
+        });
+
+        $('#applicationListFilter').on('keypress', function(e) {
+          if (e.which == 13) {
+            const searchValue = $('#applicationListFilter').val();
+            sentList.search(searchValue);
+          }
+        });
+
         $('select.sort').change(function () {
           selectionArray = $(this).val().split(' ');
           var selection = selectionArray[1];


### PR DESCRIPTION
# [AU-2435](https://helsinkisolutionoffice.atlassian.net/browse/AU-2435)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Accessibility change: Changed search to activate only when user presses enter key on the search field or by pressing the search button (no more dynamically after each keystroke)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2435-sent-application-list-changes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Clear browser caches
* [ ] Login in as any user that has some submitted applications.
* [ ] https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi
* [ ] Try to search applications and check that search is triggered:
* [ ] When you press enter key while focused in input field
* [ ] When you press the search button

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
