### PR TITLE
fix: AU-2508: add content editor to content listing

### DIFF
--- a/conf/cmi/language/fi/views.view.content.yml
+++ b/conf/cmi/language/fi/views.view.content.yml
@@ -8,6 +8,7 @@ display:
           label: Otsikko
         type:
           label: Sisältötyyppi
+          separator: ', '
         name:
           label: Kirjoittaja
         status:

--- a/conf/cmi/language/fi/views.view.content.yml
+++ b/conf/cmi/language/fi/views.view.content.yml
@@ -8,7 +8,6 @@ display:
           label: Otsikko
         type:
           label: Sisältötyyppi
-          separator: ', '
         name:
           label: Kirjoittaja
         status:
@@ -20,6 +19,8 @@ display:
           label: Päivitetty
         operations:
           label: Toimenpiteet
+        revision_uid:
+          label: 'Viimeisin muokkaaja'
       title: Sisältö
       pager:
         options:

--- a/conf/cmi/language/sv/views.view.content.yml
+++ b/conf/cmi/language/sv/views.view.content.yml
@@ -11,6 +11,7 @@ display:
         name:
           label: Författare
         status:
+        label: Status
           settings:
             format_custom_false: 'Ej publicerad'
             format_custom_true: Publicerad
@@ -46,7 +47,8 @@ display:
           expose:
             label: Innehållstyp
         status:
-          expose: {  }
+          expose:
+            label: Status
           group_info:
             label: 'Status för publicering'
             group_items:

--- a/conf/cmi/language/sv/views.view.content.yml
+++ b/conf/cmi/language/sv/views.view.content.yml
@@ -11,7 +11,7 @@ display:
         name:
           label: Författare
         status:
-        label: Status
+          label: Status
           settings:
             format_custom_false: 'Ej publicerad'
             format_custom_true: Publicerad

--- a/conf/cmi/language/sv/views.view.content.yml
+++ b/conf/cmi/language/sv/views.view.content.yml
@@ -11,7 +11,6 @@ display:
         name:
           label: Författare
         status:
-          label: Status
           settings:
             format_custom_false: 'Ej publicerad'
             format_custom_true: Publicerad
@@ -19,6 +18,8 @@ display:
           label: Uppdaterad
         operations:
           label: Funktioner
+        revision_uid:
+          label: 'Redigerat senast'
       title: Innehåll
       pager:
         options:
@@ -45,8 +46,7 @@ display:
           expose:
             label: Innehållstyp
         status:
-          expose:
-            label: Status
+          expose: {  }
           group_info:
             label: 'Status för publicering'
             group_items:

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -146,6 +146,71 @@ display:
           empty_zero: false
           hide_alter_empty: true
           type: user_name
+        revision_uid:
+          id: revision_uid
+          table: node_revision
+          field: revision_uid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: revision_uid
+          plugin_id: field
+          label: 'Revision user'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         langcode:
           id: langcode
           table: node_field_data


### PR DESCRIPTION
# [AU-2508](https://helsinkisolutionoffice.atlassian.net/browse/AU-2508)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add content editor to content listing

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2508-content-editor`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to [content listing](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/content)
* [ ] Check that latest editor is visible
![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/542ecd70-e4eb-4991-8fa9-2680d79843b8)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


[AU-2508]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ