### PR TITLE
feat: AU-2528: E2E, Added a isApplicationClosed check

### DIFF
--- a/e2e/utils/form_variant_helpers.ts
+++ b/e2e/utils/form_variant_helpers.ts
@@ -40,7 +40,7 @@ const setDisabledFormVariants = (): void => {
 const setEnabledFormVariants = (): void => {
   if (!process.env.ENABLED_FORM_VARIANTS) {
     process.env.ENABLED_FORM_VARIANTS = 'FALSE';
-    logger('ENABLED_FORM_VARIANTS has not been set in .env. Running tests that are not disabled');
+    logger('ENABLED_FORM_VARIANTS has not been set in .env. Running tests that are not disabled.');
     return;
   }
   const variants = process.env.ENABLED_FORM_VARIANTS.split(',').map(variant => variant.trim());


### PR DESCRIPTION
# [AU-2528](https://helsinkisolutionoffice.atlassian.net/browse/AU-2528)

## What was done

This pull request implements an "is application closed" check for the main form filling test. The check is needed in order to ensure that an application is actually closed in a situation where we don't reach the applications URL when trying to access it.

**Previously**:

The form filling test assumed that an application was closed if we ended up on any other URL than the form's URL while trying to access the application, which would skip the test.

**Now**:

An application is only assumed to be closed if:

- The user gets redirected to a URL starting with /fi/tietoa-avustuksista/.
- The "Tämä avustushaku ei ole avoimena" error message is present on the page.

This check provides a more accurate determination of whether the application is actually closed or not.


## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2528-e2e-form-url-check`
* `make fresh`
* `make drush-cr`

## How to test

- Remove `ENABLED_FORM_VARIANTS` and `DISABLED_FORM_VARIANTS` from the `.env` file if you want to run all form variants. If you're in a hurry, you can set `ENABLED_FORM_VARIANTS="draft"`.

- Start by running a few test to make sure everything still works normally: `make test-pw-p PROJECT=forms-64`.

- Now, login with an admin user and **close** the [Nuorisotoimi, projektiavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/nuorisotoiminta_projektiavustush/settings) application by setting the "Hakemus sulkeutuu" value to be in the past, and disabling the "Onko hakemus jatkuva" boolean.

- Run `make test-pw-p PROJECT=forms-62-registered`. You should be met with a warning message indicating that the form is closed, and the test should be skipped.

<img width="1687" alt="Screenshot 2024-06-05 at 13 05 16" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/a417c214-be5a-4f21-b761-dbf84dda5624">

- Next, introduce an error to the code by installing a broken version of the ATV module: `make shell & composer require drupal/helfi_atv:0.9.27 & drush cr`.

- Run `make test-pw-p PROJECT=forms-62-registered` again. You should be met with the same message as before, since the form is still closed.

- Finally, open up the [Nuorisotoimi, projektiavustushakemus](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/structure/webform/manage/nuorisotoiminta_projektiavustush/settings) application and run `make test-pw-p PROJECT=forms-62-registered` again. This time an exception should be thrown:

<img width="1432" alt="Screenshot 2024-06-05 at 13 18 53" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/2b5be9cf-8c7c-487c-8ce6-91a00f71c3a7">




[AU-2528]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ