### PR TITLE
feat: AU-2357: Set connect_existing_users to TRUE in OpenID

### DIFF
--- a/conf/cmi/openid_connect.settings.yml
+++ b/conf/cmi/openid_connect.settings.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: YpBA3MmDuJpZ9SM3DE4kR0lTY89bf2y3g0sS7s3TQ4k
 langcode: en
 always_save_userinfo: true
-connect_existing_users: false
+connect_existing_users: true
 override_registration_settings: true
 end_session_enabled: true
 user_login_display: below
@@ -10,8 +10,4 @@ redirect_login: /oma-asiointi
 redirect_logout: ''
 userinfo_mappings:
   timezone: zoneinfo
-role_mappings:
-  admin: {  }
-  content_producer: {  }
-  read_only: {  }
-  helsinkiprofiili: {  }
+role_mappings: {  }


### PR DESCRIPTION
# [AU-2357](https://helsinkisolutionoffice.atlassian.net/browse/AU-2357), [AU-2314](https://helsinkisolutionoffice.atlassian.net/browse/AU-2314)

## What was done
This pull request sets the `connect_existing_users` to TRUE in the OpenID settings. This should allow AD-users to log into Drupal if a Drupal user with the matching email already exists in the system.

![Screenshot 2024-06-05 at 14 06 15](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/c46143ac-e90d-430a-a10b-3cbfffd739e7)


## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2357-connect-ad-email-to-drupal-user`
* `make fresh`
* `make drush-cr`

## How to test
This change should be **thoroughly** tested by AD-users on the [staging](https://avustukset.stage.hel.ninja/fi/user/login?login=admin) server.

[AU-2357]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2314]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ