### PR TITLE
feat: AU-2357: Fixed a AD-role mapping typo

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -20,7 +20,7 @@ $settings['error_page']['template_dir'] = '../error_templates';
 $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
   [
     'ad_role' => '[sl_avustustest_paakayttajat]',
-    'roles' => ['ad_user', 'super_administrator'],
+    'roles' => ['ad_user', 'grants_admin'],
   ],
   [
     'ad_role' => '[sl_avustustest_pk_kanslia_kayttajat]',


### PR DESCRIPTION
# [AU-2357](https://helsinkisolutionoffice.atlassian.net/browse/AU-2357)

## What was done

Fixed a AD-role <-> Drupal role mapping typo in all.settings.php.

## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2357-ad-role-fix`
* `make fresh`
* `make drush-cr`

## How to test

Nothing to test. Verify that the roles in all.settings.php are the same as in helfi_helsinki_profiili.settings.yml.

[AU-2357]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ