### PR TITLE
feat: AU-2357: Attempting to fix AD-role <-> Drupal role mapping

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -19,67 +19,67 @@ $settings['error_page']['template_dir'] = '../error_templates';
 // AD roles <-> Drupal roles mapping.
 $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
   [
-    'ad_role' => '[sl_avustustest_paakayttajat]',
+    'ad_role' => 'sl_avustustest_paakayttajat',
     'roles' => ['ad_user', 'grants_admin'],
   ],
   [
-    'ad_role' => '[sl_avustustest_pk_kanslia_kayttajat]',
+    'ad_role' => 'sl_avustustest_pk_kanslia_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustustest_ta_kasko_kayttajat]',
+    'ad_role' => 'sl_avustustest_ta_kasko_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustustest_pk_pel_kayttajat]',
+    'ad_role' => 'sl_avustustest_pk_pel_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustustest_ta_kymp_kayttajat]',
+    'ad_role' => 'sl_avustustest_ta_kymp_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustustest_ta_kuva_kayttajat]',
+    'ad_role' => 'sl_avustustest_ta_kuva_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustustest_ta_sote_kayttajat]',
+    'ad_role' => 'sl_avustustest_ta_sote_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustus_kanslia_paakayttajat]',
+    'ad_role' => 'sl_avustus_kanslia_paakayttajat',
     'roles' => ['ad_user', 'grants_admin'],
   ],
   [
-    'ad_role' => '[sl_avustus_pk_kanslia]',
+    'ad_role' => 'sl_avustus_pk_kanslia',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustus_ta_kasko]',
+    'ad_role' => 'sl_avustus_ta_kasko',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustus_ta_kymp]',
+    'ad_role' => 'sl_avustus_ta_kymp',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustus_pk_pel]',
+    'ad_role' => 'sl_avustus_pk_pel',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustus_ta_kuva]',
+    'ad_role' => 'sl_avustus_ta_kuva',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_avustus_ta_sote]',
+    'ad_role' => 'sl_avustus_ta_sote',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sl_kanslia_owakayttajat]',
+    'ad_role' => 'sl_kanslia_owakayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
   [
-    'ad_role' => '[sg_kanslia_kayttajat]',
+    'ad_role' => 'sg_kanslia_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
 ];


### PR DESCRIPTION
# [AU-2357](https://helsinkisolutionoffice.atlassian.net/browse/AU-2357)

## What was done

This pull request is a "shot in the dark" attempt to fix AD-role <-> Drupal role mappings. The `helfi_tunnistamo` module advises to implement the mappings like this:

![Screenshot 2024-06-10 at 12 00 03](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/3aa9b33c-e404-47e4-a596-ea63198e499f)


After some testing I discovered that the `[` and `]` (square brackets) that come before and after the AD-role might not be needed. I also noticed that the `Helfi Etusivu` project doesn't use these brackets in their mappings:

![Screenshot 2024-06-10 at 12 06 42](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/0bdfc866-20c1-436e-9d5c-0aab5410c693)


I have therefore removed them fro the `all.settings.php` file, so that we can at least test the implementation like this.



## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2357-fix-ad-role-drupal-role-mapping`
* `make fresh`
* `make drush-cr`

## How to test

- Needs to be tasted in the staging environment by Tero and Pirjo. 

[AU-2357]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ