### PR TITLE
feat: AU-2535, E2E: Confirm that the tests reach the correct profile form and bug fixing

### DIFF
--- a/e2e/utils/data/application/application_data_48.ts
+++ b/e2e/utils/data/application/application_data_48.ts
@@ -457,7 +457,8 @@ const baseForm_48: FormData = {
         "edit-ensimmaisen-yleisolle-avoimen-tilaisuuden-paivamaara": {
           role: 'input',
           value: "2023-11-01",
-          viewPageFormatter: viewPageFormatDate
+          viewPageFormatter: viewPageFormatDate,
+          viewPageSelector: '#kuva_projekti--aikataulu',
         },
         "edit-festivaalin-tai-tapahtuman-kohdalla-tapahtuman-paivamaarat": {
           role: 'input',
@@ -466,12 +467,14 @@ const baseForm_48: FormData = {
         "edit-hanke-alkaa": {
           role: 'input',
           value: "2023-11-01",
-          viewPageFormatter: viewPageFormatDate
+          viewPageFormatter: viewPageFormatDate,
+          viewPageSelector: '#kuva_projekti--aikataulu',
         },
         "edit-hanke-loppuu": {
           role: 'input',
           value: "2023-12-01",
-          viewPageFormatter: viewPageFormatDate
+          viewPageFormatter: viewPageFormatDate,
+          viewPageSelector: '#kuva_projekti--aikataulu',
         },
         "edit-laajempi-hankekuvaus": {
           role: 'input',

--- a/e2e/utils/data/application/application_data_53.ts
+++ b/e2e/utils/data/application/application_data_53.ts
@@ -80,11 +80,13 @@ const baseFormRegisteredCommunity_53: FormData = {
           role: 'input',
           value: '2023-09-23',
           viewPageFormatter: viewPageFormatDate,
+          viewPageSelector: '#kasko_ip_lisa--ajalle_alkaen',
         },
         "edit-paattyy": {
           role: 'input',
           value: '2023-11-30',
           viewPageFormatter: viewPageFormatDate,
+          viewPageSelector: '#kasko_ip_lisa--ajalle_alkaen',
         },
         "nextbutton": {
           role: 'button',

--- a/e2e/utils/data/application/application_data_62.ts
+++ b/e2e/utils/data/application/application_data_62.ts
@@ -393,10 +393,12 @@ const baseFormRegisteredCommunity_62: FormData = {
         "edit-projekti-alkaa": {
           value: '2023-12-01',
           viewPageFormatter: viewPageFormatDate,
+          viewPageSelector: '#nuorisotoiminta_projektiavustush--projektin_aikataulu',
         },
         "edit-projekti-loppuu": {
           value: '2023-12-31',
           viewPageFormatter: viewPageFormatDate,
+          viewPageSelector: '#nuorisotoiminta_projektiavustush--projektin_aikataulu',
         },
         "edit-osallistujat-7-28": {
           value: faker.number.int({min: 12, max: 5000}).toString(),

--- a/e2e/utils/data/profile_data_private_person.ts
+++ b/e2e/utils/data/profile_data_private_person.ts
@@ -5,7 +5,7 @@ import {createFormData} from "../form_data_helpers";
 
 const profileDataBase: FormData = {
   title: 'Save profile data',
-  formSelector: 'grants-profile-private-person',
+  formSelector: 'grants-role-private_person',
   formPath: '/fi/oma-asiointi/hakuprofiili/muokkaa',
   formPages: {
     'onlypage': {

--- a/e2e/utils/data/profile_data_registered_community.ts
+++ b/e2e/utils/data/profile_data_registered_community.ts
@@ -6,7 +6,7 @@ import {createFormData} from "../form_data_helpers";
 
 const profileDataBase: FormData = {
   title: 'Save profile data',
-  formSelector: 'grants-profile-registered-community',
+  formSelector: 'grants-role-registered_community',
   formPath: '/fi/oma-asiointi/hakuprofiili/muokkaa',
   formPages: {
     'onlyone': {

--- a/e2e/utils/data/profile_data_unregistered_community.ts
+++ b/e2e/utils/data/profile_data_unregistered_community.ts
@@ -6,7 +6,7 @@ import {createFormData} from "../form_data_helpers";
 
 const profileDataBase: FormData = {
   title: 'Save profile data',
-  formSelector: 'grants-profile-unregistered-community',
+  formSelector: 'grants-role-unregistered_community',
   formPath: '/fi/oma-asiointi/hakuprofiili/muokkaa',
   formPages: {
     'onlyone': {

--- a/e2e/utils/form_helpers.ts
+++ b/e2e/utils/form_helpers.ts
@@ -172,6 +172,10 @@ const fillProfileForm = async (
   await page.goto(formPath);
   await logCurrentUrl(page);
 
+  // Make sure we reached the correct profile form.
+  await expect(page.locator('body'), 'Reached the wrong profile form.').toHaveClass(new RegExp(`\\b${formClass}\\b`));
+  logger(`Reached the profile form: ${formClass}.`);
+
   // Hide the sliding popup.
   await hideSlidePopup(page);
 

--- a/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
@@ -106,26 +106,21 @@ class PlaceOfOperationComposite extends GrantsCompositeBase {
     $value = $this->getValue($element, $webform_submission, $options);
     $lines = ['<dl>'];
 
-    $tOpts = ['context' => 'grants_place_of_operation'];
-
     foreach ($value as $fieldName => $fieldValue) {
       if (!isset($element["#webform_composite_elements"][$fieldName])) {
         continue;
       }
       $webformElement = $element["#webform_composite_elements"][$fieldName];
 
-      // Convert date strings.
-      $fieldValue = parent::formatFieldValue($webformElement, $fieldName, $fieldValue, ['rentTimeBegin', 'rentTimeEnd']);
-
       // Convert boolean value.
-      if ($fieldName === 'free') {
-        if ($fieldValue === 'false') {
-          $fieldValue = $this->t('No', [], $tOpts);
-        }
-        if ($fieldValue === 'true') {
-          $fieldValue = $this->t('Yes', [], $tOpts);
-        }
+      if ($fieldName === 'free' && $fieldValue === 'false' || $fieldValue === false) {
+        $fieldValue = 0;
       }
+      if ($fieldName === 'free' && $fieldValue === 'true' || $fieldValue === true) {
+        $fieldValue = 1;
+      }
+
+      $fieldValue = parent::formatFieldValue($webformElement, $fieldName, $fieldValue, ['rentTimeBegin', 'rentTimeEnd']);
 
       if (parent::isCompositeAccessible($webformElement)) {
         $lines[] = '<dt>' . parent::renderCompositeTitle($webformElement['#title']) . '</dt>';

--- a/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
+++ b/public/modules/custom/grants_place_of_operation/src/Plugin/WebformElement/PlaceOfOperationComposite.php
@@ -113,10 +113,10 @@ class PlaceOfOperationComposite extends GrantsCompositeBase {
       $webformElement = $element["#webform_composite_elements"][$fieldName];
 
       // Convert boolean value.
-      if ($fieldName === 'free' && $fieldValue === 'false' || $fieldValue === false) {
+      if ($fieldName === 'free' && $fieldValue === 'false' || $fieldValue === FALSE) {
         $fieldValue = 0;
       }
-      if ($fieldName === 'free' && $fieldValue === 'true' || $fieldValue === true) {
+      if ($fieldName === 'free' && $fieldValue === 'true' || $fieldValue === TRUE) {
         $fieldValue = 1;
       }
 


### PR DESCRIPTION
# [AU-2216](https://helsinkisolutionoffice.atlassian.net/browse/AU-2216)

## What was done

This pull request implements a check to ensure that the profile form tests reach the correct profile form. The test verifies this by checking for a specific class on the page that corresponds to the profile type for which the form is being filled.

## Other changes

[Refactors of the /katso page](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1416) recently broke the E2E tests (some values we're not printed at all, and some lost their wrappers). This issue has also been fixed.

## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2535-e2e-log-profile-form-type`
* `make fresh`
* `make drush-cr`

## How to test

- Set `ENABLED_FORM_VARIANTS="draft"` in the `.env` file.

- Run `make test-pw-p PROJECT=forms-48-registered forms-62-registered forms-53 forms-52`. Make sure the tests pass, and that you see this output during the profile form tests:

![Screenshot 2024-06-13 at 12 43 19](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/e4108e73-1b0f-41ee-a967-d8410d3f9ff6)



[AU-2216]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ