### PR TITLE
fix: AU-2529: fix translation in service page auth block

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
+++ b/public/modules/custom/grants_handler/src/Plugin/Block/ServicePageAuthBlock.php
@@ -171,7 +171,7 @@ class ServicePageAuthBlock extends BlockBase implements ContainerFactoryPluginIn
 
     $applicationLink = Link::fromTextAndUrl($applicationLinkText, $applicationLinkUrl);
     $descrtiption = $this->t('Please familiarize yourself with the instructions
-    on this page before proceeding to the application.', [], $tOpts);
+on this page before proceeding to the application.', [], $tOpts);
 
     $webformLink = Url::fromRoute('grants_webform_print.print_webform', ['webform' => $webformId]);
 

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -489,7 +489,7 @@ msgid "Log in to the service and do the identification."
 msgstr "Kirjaudu palveluun ja tee tunnistautuminen."
 
 msgctxt "grants_handler"
-msgid "Please familiarize yourself with the instructions on this page before proceeding to the application."
+msgid "Please familiarize yourself with the instructions\non this page before proceeding to the application."
 msgstr "Tutustuthan ohjeistukseen tällä sivulla ennen hakemukselle siirtymistä."
 
 msgctxt "grants_handler"

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -489,7 +489,7 @@ msgid "Log in to the service and do the identification."
 msgstr "Logga in på tjänsten och gör identifieringen."
 
 msgctxt "grants_handler"
-msgid "Please familiarize yourself with the instructions on this page before proceeding to the application."
+msgid "Please familiarize yourself with the instructions\non this page before proceeding to the application."
 msgstr "Bekanta dig med instruktionerna på den här sidan innan du går vidare till ansökan."
 
 msgctxt "grants_handler"


### PR DESCRIPTION
# [AU-2529](https://helsinkisolutionoffice.atlassian.net/browse/AU-2529)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix translation in service page auth block

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2529-translation`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any service page with an approppriate role (you are able to apply), check that blue box has correct language

![image](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/26737690/a5a15bf6-b18c-42e0-a9e3-c9b434818f1e)

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


[AU-2529]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ