### PR TITLE
fix: AU-2388: add paginator to drafts

### DIFF
--- a/public/modules/custom/grants_handler/templates/application-list.html.twig
+++ b/public/modules/custom/grants_handler/templates/application-list.html.twig
@@ -64,7 +64,7 @@
         {% endfor %}
       </ul>
     {% endif %}
-    {% if type != 'drafts' and items %}
+    {% if items %}
       <div class="hds-pagination-container" {% if items|length < 11 %} style="display:none;"{% endif %}>
         <ul aria-label={{"Pagination"|t}} role="navigation" class="pagination application-list__pagination"></ul>
       </div>

--- a/public/modules/custom/grants_oma_asiointi/js/application-draft-list.js
+++ b/public/modules/custom/grants_oma_asiointi/js/application-draft-list.js
@@ -53,6 +53,13 @@
 
         });
     }
+    if ($("#oma-asiointi__drafts")[0]) {
+      const draftsListOptions = {
+        pagination: true,
+        page: 10,
+      };
+      new List('oma-asiointi__drafts', draftsListOptions);
+    }
   }
 };
 })(jQuery, Drupal, drupalSettings);


### PR DESCRIPTION
# [AU-2388](https://helsinkisolutionoffice.atlassian.net/browse/AU-2388)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added paginator to drafts

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2388-drafts-paginator`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in with a user you have loads of (over 10) drafts
* [ ] Go to [oma asiointi](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi)
* [ ] Check that you see 10 drafts and a paginator
* [ ] Log in with a user you have less than 10 drafts
* [ ] Go to [oma asiointi](https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi)
* [ ] Check that you have all of your drafts and no paginator

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[AU-2388]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ