### PR TITLE
fix: AU-2537: change error text when sending application with empty fields

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1188,7 +1188,10 @@ moment and reload the page.',
 
         // If we HAVE errors, then refresh them from the.
         $this->messenger()
-          ->addError($this->t('Validation failed, please check inputs.', [], $tOpts));
+          ->addError($this->t('The application cannot be submitted because not all
+mandatory questions have been answered. Return to the application form and fill in
+at least those questions and fields that are marked with an asterisk (*). You can
+submit the application only after you have provided all the necessary information.', [], $tOpts));
       }
     }
   }

--- a/public/modules/custom/grants_handler/translations/fi.po
+++ b/public/modules/custom/grants_handler/translations/fi.po
@@ -621,8 +621,8 @@ msgid "Additional information concerning the application"
 msgstr "Lisätietoja hakemukseen liittyen"
 
 msgctxt "grants_handler"
-msgid "Validation failed, please check inputs."
-msgstr "Kenttien validaatio epäonnistui, tarkista syötteet."
+msgid "The application cannot be submitted because not all\nmandatory questions have been answered. Return to the application form and fill in\nat least those questions and fields that are marked with an asterisk (*). You can\nsubmit the application only after you have provided all the necessary information."
+msgstr "Hakemusta ei voida lähettää, koska kaikkiin pakollisiin kysymyksiin ei ole vastattu. Palaa hakulomakkeeseen ja täytä ainakin ne kysymykset ja kentät, jotka on merkitty tähdellä (*). Voit lähettää hakemuksen vasta, kun olet antanut kaikki pakolliset tiedot."
 
 msgctxt "grants_handler"
 msgid "No applications in progress."

--- a/public/modules/custom/grants_handler/translations/sv.po
+++ b/public/modules/custom/grants_handler/translations/sv.po
@@ -621,8 +621,8 @@ msgid "Additional information concerning the application"
 msgstr "Ytterligare information för ansökan"
 
 msgctxt "grants_handler"
-msgid "Validation failed, please check inputs."
-msgstr "Valideringen misslyckades, kontrollera ingångarna."
+msgid "The application cannot be submitted because not all\nmandatory questions have been answered. Return to the application form and fill in\nat least those questions and fields that are marked with an asterisk (*). You can\nsubmit the application only after you have provided all the necessary information."
+msgstr "Ansökan kan inte skickas in eftersom inte alla obligatoriska frågor har besvarats. Gå tillbaka till ansökningsformuläret och fyll i åtminstone de frågor och fält som är markerade med en asterisk (*). Du kan skicka in ansökan först när du har lämnat all nödvändig information."
 
 msgctxt "grants_handler"
 msgid "No applications in progress."


### PR DESCRIPTION
# [AU-2537](https://helsinkisolutionoffice.atlassian.net/browse/AU-2537)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Error text was pretty vague when seding an application with empty fields, so it has been changed to more descriptive

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2537-error-message`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open [any application](https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/kaupunginkanslia_tyollisyysavust)
* [ ] Fill out fields in the first page
* [ ] Go straight to the preview-page without opening any other pages
* [ ] Mark checkbox and hit send
* [ ] Check that appearing error message matches the text in the ticket
* [ ] Check translations

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


[AU-2537]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ