### PR TITLE
feat: AU-2533, E2E: Implemented the possibility to set timeouts for the waitForTextWithInterval function in the .env file.

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -26,6 +26,14 @@ ENABLED_FORM_VARIANTS="draft"
 # leading to faster tests.
 CREATE_PROFILE="FALSE"
 
+# Wait for text timeout (how long to wait) in MS (defaults to 60000, 1 minute).
+# Used by the waitForTextWithInterval() function. This is mainly used when verifying applications sent to Avus2.
+WAIT_FOR_TEXT_TIMEOUT="10000"
+
+# Wait for text interval (how often to query) in MS (defaults to 5000, 5 second).
+# Used by the waitForTextWithInterval() function. This is mainly used when verifying applications sent to Avus2.
+WAIT_FOR_TEXT_INTERVAL="5000"
+
 # A flag indicating if the "debugging mode" should be turned on.
 # Messages will be printed during test runs if set to "TRUE".
 APP_DEBUG="TRUE"

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -61,6 +61,8 @@ The file should be located in the `/e2e` directory.
 - **ENABLED_FORM_VARIANTS**: Can be used to explicitly run specific form variants. Others are skipped.
 - **DISABLED_FORM_VARIANTS**: Can be used to disable form variants (types of form tests).
 - **CREATE_PROFILE**: Boolean indicating if new profiles should be created on each test run.
+- **WAIT_FOR_TEXT_TIMEOUT**: The time to wait for text in MS (defaults to 60000, 1 minute). Used by the waitForTextWithInterval() function.
+- **WAIT_FOR_TEXT_INTERVAL**: How often to query text in MS (defaults to 5000, 5 seconds). Used by the waitForTextWithInterval() function.
 
 Example `.env` file:
 ```
@@ -91,6 +93,14 @@ ENABLED_FORM_VARIANTS="copy"
 # If you set this to "FALSE", a new profile will only be created once every hour,
 # leading to faster tests.
 CREATE_PROFILE="FALSE"
+
+# Wait for text timeout (how long to wait) in MS (defaults to 60000, 1 minute).
+# Used by the waitForTextWithInterval() function. This is mainly used when verifying applications sent to Avus2.
+WAIT_FOR_TEXT_TIMEOUT="10000"
+
+# Wait for text interval (how often to query) in MS (defaults to 5000, 5 second).
+# Used by the waitForTextWithInterval() function. This is mainly used when verifying applications sent to Avus2.
+WAIT_FOR_TEXT_INTERVAL="5000"
 
 # A flag indicating if the "debugging mode" should be turned on.
 # Messages will be printed during test runs if set to "TRUE".

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   globalTeardown: require.resolve('./tests/global.teardown.ts'),
   globalSetup: require.resolve('./tests/init.setup.ts'),
   testDir: './tests',
-  timeout: 240 * 1000,
+  timeout: 300 * 1000,
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/e2e/utils/form_helpers.ts
+++ b/e2e/utils/form_helpers.ts
@@ -293,7 +293,7 @@ const verifySubmit = async (
 
   // Attempt to locate the "Vastaanotettu" text on the page. Keep polling for 60000ms (1 minute).
   // Note: We do this instead of using Playwrights "expect" method so that test execution isn't interrupted if this fails.
-  const applicationReceived = await waitForTextWithInterval(page, 'Vastaanotettu', 60000, 5000);
+  const applicationReceived = await waitForTextWithInterval(page, 'Vastaanotettu');
   if (!applicationReceived) {
     logger('WARNING: Failed to validate that the application was received.');
     return;

--- a/e2e/utils/helpers.ts
+++ b/e2e/utils/helpers.ts
@@ -114,10 +114,30 @@ const getApplicationNumberFromBreadCrumb = async (page: Page) => {
 const waitForTextWithInterval = async (
   page: Page,
   text: string,
-  timeout: number,
-  interval: number
+  timeout?: number,
+  interval?: number,
 ): Promise<boolean> => {
   logger(`Attempting to locate text: "${text}"...`);
+
+  // Default values for timeouts.
+  const DEFAULT_TIMEOUT = 60000;
+  const DEFAULT_INTERVAL = 5000;
+
+  // Read from environment variables or use defaults.
+  const envTimeout = process.env.WAIT_FOR_TEXT_TIMEOUT ? parseInt(process.env.WAIT_FOR_TEXT_TIMEOUT) : DEFAULT_TIMEOUT;
+  const envInterval = process.env.WAIT_FOR_TEXT_INTERVAL ? parseInt(process.env.WAIT_FOR_TEXT_INTERVAL) : DEFAULT_INTERVAL;
+
+  // Check for passed in values.
+  timeout = timeout ?? envTimeout;
+  interval = interval ?? envInterval;
+
+  // Check if the environment variables are correctly set, otherwise use defaults.
+  if (timeout < interval) {
+    logger(`Environment variables invalid. Using default values: Timeout ${DEFAULT_TIMEOUT}ms, Interval ${DEFAULT_INTERVAL}ms`);
+    timeout = DEFAULT_TIMEOUT;
+    interval = DEFAULT_INTERVAL;
+  }
+
   const startTime = Date.now();
 
   while (true) {


### PR DESCRIPTION
# [AU-2533](https://helsinkisolutionoffice.atlassian.net/browse/AU-2533)

## What was done

This pull request implements the possibility to set timeouts for `waitForTextWithInterval` function in the `.env` file. The following new environment variables are described in the `env.example` file:

```
# Wait for text timeout (how long to wait) in MS (defaults to 60000, 1 minute).
# Used by the waitForTextWithInterval() function. This is mainly used when verifying applications sent to Avus2.
WAIT_FOR_TEXT_TIMEOUT="10000"

# Wait for text interval (how often to query) in MS (defaults to 5000, 5 second).
# Used by the waitForTextWithInterval() function. This is mainly used when verifying applications sent to Avus2.
WAIT_FOR_TEXT_INTERVAL="5000"
```

## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2533-e2e-set-wait-for-text-variable-to-env`
* `make fresh`
* `make drush-cr`

## How to test

- Set `ENABLED_FORM_VARIANTS="success"` and the new `WAIT_FOR_TEXT_TIMEOUT` and `WAIT_FOR_TEXT_INTERVAL` values in the `.env` file:

```
# Wait for text timeout (how long to wait) in MS (defaults to 60000, 1 minute).
# Used by the waitForTextWithInterval() function.
WAIT_FOR_TEXT_TIMEOUT="10000"

# Wait for text interval (how often to query) in MS (defaults to 5000, 5 second).
# Used by the waitForTextWithInterval() function.
WAIT_FOR_TEXT_INTERVAL="2500"
```

- Run `make test-pw-p PROJECT=forms-53`. Make sure the tests pass, and that the "Vastaanotettu" text is only waited for for 10 seconds (10000ms) and queried with 2.5 second intervals (2500ms) during the `success` variant test (note that to confirm this, the test has to time out before the "Vastaanotettu" text is seen on the page).

<img width="1376" alt="Screenshot 2024-06-14 at 16 02 18" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/57b250d1-e60e-4733-b47e-22154d076227">

- Remove `WAIT_FOR_TEXT_TIMEOUT` and `WAIT_FOR_TEXT_INTERVAL` from the `.env` file. Run the same test again and verify the the test now waits for the default times (60 seconds timeout, 5 seconds interval). Note that to confirm this, the test has to time out before the "Vastaanotettu" text is seen on the page.

<img width="1467" alt="Screenshot 2024-06-14 at 15 52 27" src="https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/54abe208-74fb-4e64-a116-6ff4ce943efe">



[AU-2533]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ