### PR TITLE
fix: AU-448: Change correct status to production check

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHandler.php
@@ -1060,7 +1060,7 @@ class ApplicationHandler {
     $isProd = self::isProduction($appEnv);
 
     if (
-      ($isProd && $status !== 'production') ||
+      ($isProd && $status !== 'released') ||
       $status === 'archived'
     ) {
       return FALSE;


### PR DESCRIPTION
# [AU-448](https://helsinkisolutionoffice.atlassian.net/browse/AU-448)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* isApplicationOpen was using wrong comparison string for prod flag.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-448-fix-prod-status`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] You can add your environment to prod list by adding it to ApplicationHandler::isProduction
* [ ] Switch between develop and this branch (clear cache between changes).
* [ ] You should see the button in this branch.


## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-448]: https://helsinkisolutionoffice.atlassian.net/browse/AU-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ