### PR TITLE
feat: AU-2541: Fixed a bug in GrantsCompositeBase.php

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/WebformElement/GrantsCompositeBase.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformElement/GrantsCompositeBase.php
@@ -104,18 +104,21 @@ class GrantsCompositeBase extends WebformCompositeBase {
    *   Webform Element.
    * @param string $fieldName
    *   Field name in question.
-   * @param string $fieldValue
+   * @param mixed $fieldValue
    *   Value of the Field.
    * @param array $dateFieldNamesArray
    *   Array of Date Fields names.
    *
-   * @return string
+   * @return mixed
    *   The formatted Field Value.
    */
   public function formatFieldValue(array $webformElement,
-                                    string $fieldName,
-                                    string $fieldValue,
-                                    $dateFieldNamesArray = ['dateBegin', 'dateEnd']) {
+                                   string $fieldName,
+                                   mixed $fieldValue,
+                                   array $dateFieldNamesArray = ['dateBegin', 'dateEnd']): mixed {
+    if ($fieldValue === NULL) {
+      return NULL;
+    }
     if (in_array($fieldName, $dateFieldNamesArray) && $fieldValue) {
       return date("d.m.Y", strtotime($fieldValue));
     }


### PR DESCRIPTION
# [AU-2541](https://helsinkisolutionoffice.atlassian.net/browse/AU-2541)

## What was done

This pull request fixes a bug in the `formatFieldValue()` function inside `GrantsCompositeBase.php`. The function would throw a fatal error in situations where a `NULL` value was passed into the function as the `$fieldValue` parameters value. This could happen in a situation where someone left an empty field in a form.


## How to install

Make sure your instance is up and running on correct branch.
* `feature/AU-2533-e2e-set-wait-for-text-variable-to-env`
* `make fresh`
* `make drush-cr`

## How to test

- Set `ENABLED_FORM_VARIANTS="missing_values"` in the `.env` file:

- Run `make test-pw-p PROJECT=forms-60` (this test was broken in the pipeline). Make sure the tests pass. You can also run other tests to make sure everything still works. I ran every test:

![Screenshot 2024-06-18 at 14 57 29](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/3ab1ca1c-c148-4cca-bdc8-2b3847ea624f)




[AU-2533]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2541]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ