### PR TITLE
AU-2342: Hide attachments with only a description in preview page

### DIFF
--- a/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
@@ -223,6 +223,16 @@ class GrantsAttachments extends WebformCompositeBase {
       }
     }
 
+    // Hide value, if only description field is filled.
+    // We filter all attachment fields without an attachment
+    // during ATV save.
+    if (
+      (isset($value['description']) && !empty($value['description'])) &&
+      (!isset($value['attachmentName']) || empty($value['attachmentName']))
+    ) {
+      return [];
+    }
+
     // This notes that we have uploaded file in process.
     if (isset($value['attachment']) && $value['attachment'] !== NULL) {
       // Load file.


### PR DESCRIPTION
# [AU-2342](https://helsinkisolutionoffice.atlassian.net/browse/AU-2342)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Hide attachment field values which have only description field filled (As we filter these out anyways when submitting / saving to ATV)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/AU-2342-hide-description-only-attachment`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open any application (https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/ymparistopalvelut_yleisavustus)
* [ ] Go to attachments page and to "Muut liittet" section add some descriptions but NO actual file.
* [ ] Check preview page and make sure you cannot see the attachment value if there IS NOT a file attached.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[AU-2342]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ