### PR TITLE
feature: AU-2542: Attempting to fix inline form error validation in the pipelines

### DIFF
--- a/e2e/utils/data/application/application_data_52.ts
+++ b/e2e/utils/data/application/application_data_52.ts
@@ -1171,6 +1171,13 @@ const missingValues: FormDataWithRemoveOptionalProps = {
         'edit-contact-person-phone-number',
         'edit-community-address-community-address-select',
       ],
+      expectedInlineErrors: [
+        { selector: '.form-item-bank-account-account-number-select', errorMessage: 'Valitse tilinumero kenttä on pakollinen.' },
+        { selector: '.form-item-email', errorMessage: 'Sähköpostiosoite kenttä on pakollinen.' },
+        { selector: '.form-item-contact-person', errorMessage: 'Yhteyshenkilö kenttä on pakollinen.' },
+        { selector: '.form-item-contact-person-phone-number', errorMessage: 'Puhelinnumero kenttä on pakollinen.' },
+        { selector: '.webform-type-community-address-composite', errorMessage: 'Yhteisön osoite kenttä on pakollinen.' },
+      ],
     },
     '2_avustustiedot': {
       items: {},
@@ -1224,6 +1231,9 @@ const wrongValues: FormDataWithRemoveOptionalProps = {
         },
       },
       itemsToRemove: [],
+      expectedInlineErrors: [
+        { selector: '.form-item-email', errorMessage: 'Sähköpostiosoite kenttä ei ole oikeassa muodossa.' },
+      ],
     },
     '4_talous': {
       items: {},

--- a/e2e/utils/error_validation_helpers.ts
+++ b/e2e/utils/error_validation_helpers.ts
@@ -76,14 +76,17 @@ const validateInlineFormErrors = async (page: Page, expectedInlineErrors: Expect
 
   // Refresh the page by clicking the active navigation item.
   await page.locator('.progress-step.is-active').click();
+
+  // Wait for the page to fully load and display errors.
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForLoadState('load');
+  await page.waitForLoadState('networkidle');
 
   // Validate the inline form errors after the page refresh.
   for (const inlineError of expectedInlineErrors) {
     logger(`Validating inline form error: ${inlineError.errorMessage}`)
-    const locator = await page.locator(inlineError.selector).locator('.form-item--error-message');
-    const textContent = await locator.innerText();
-    await expect(textContent.trim(), 'Failed to validate inline form error.').toBe(inlineError.errorMessage);
+    const errorContainer = await page.locator(inlineError.selector).locator('.form-item--error-message');
+    await expect(errorContainer, 'Failed to validate inline form error.').toContainText(inlineError.errorMessage);
   }
 
   logger('Inline errors validated successfully.');


### PR DESCRIPTION
# [AU-2542](https://helsinkisolutionoffice.atlassian.net/browse/AU-2542)

## What was done

This pull request attempts to fix inline form error validation in our pipelines. For some reason the tests seem to work locally, but fail when executed in the staging environment. Still, I've attempted to eliminate any flakiness with these changes. Inline error validation has also been added to form 52.


## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2542-e2e-fix-inline-form-error-validation`
* `make fresh`
* `make drush-cr`

## How to test

- Set `ENABLED_FORM_VARIANTS="wrong_values,missing_values"` values in the `.env` file.

- Run `make test-pw-p PROJECT=forms-51 forms-52 forms-62`. Make sure that all the tests pass, and that you see various "Validating inline form error:" messages during the form filling test:

![Screenshot 2024-06-24 at 15 53 27](https://github.com/City-of-Helsinki/hel-fi-drupal-grants/assets/117807015/899c690a-f75b-48f5-8632-fe91450bdac5)



[AU-2542]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ