### PR TITLE
feature: AU-2544: Added new ad-group <-> drupal-role mappings

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -82,4 +82,12 @@ $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
     'ad_role' => 'sg_kanslia_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
+  [
+    'ad_role' => 'Drupal_Helfi_kaupunkitaso_paakayttajat',
+    'roles' => ['ad_user', 'grants_admin'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea',
+    'roles' => ['ad_user', 'content_producer'],
+  ],
 ];


### PR DESCRIPTION
# [AU-2544](https://helsinkisolutionoffice.atlassian.net/browse/AU-2544)

## What was done

This pull request implements a few new AD-group <-> Drupal-role mappings according to the instructions in the ticket.

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2544-new-ad-group-drupal-role-mappings`
* `make fresh`
* `make drush-cr`

## How to test

- Take this to the staging environment and let Tero / Pirjo test it.

[AU-2544]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ