### PR TITLE
UHF-9946: Fix icons on applicant role selection page

### DIFF
--- a/public/modules/custom/grants_mandate/templates/select-applicant-role.html.twig
+++ b/public/modules/custom/grants_mandate/templates/select-applicant-role.html.twig
@@ -1,5 +1,5 @@
 <div class="hds-card--mandate-card-content">
-  <span aria-hidden="true" class="hds-icon hds-icon--{{ icon}} hds-icon--size-m"></span>
+  {% include '@hdbt/misc/icon.twig' ignore missing with {icon: icon} %}
   <h2 class="hds-card__heading-m heading-m" role="heading" aria-level="2">{{ role }}</h2>
   <div class="hds-card__text">
     {{ role_description }}


### PR DESCRIPTION
# [UHF-9946](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9946)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fix issue with missing icons on applicant role selection page.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9946_icon_fix`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in with test user and go to applicant role selection page. You should now see icons on the cards.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)
