### PR TITLE
feat: AU-2548: Added new AD-group <-> Drupal role mappings.

### DIFF
--- a/public/modules/custom/grants_industries/grants_industries.module
+++ b/public/modules/custom/grants_industries/grants_industries.module
@@ -227,13 +227,13 @@ function grants_industries_openid_connect_post_authorize(UserInterface $account,
         $industryKey = 'SOTE';
       }
       // New mappings.
-      if (str_contains($ad_group_lower, 'laaja_Kanslia') || str_contains($ad_group_lower, 'suppea_Kanslia')) {
+      if (str_contains($ad_group_lower, 'laaja_kanslia') || str_contains($ad_group_lower, 'suppea_kanslia')) {
         $industryKey = 'KANSLIA';
       }
-      if (str_contains($ad_group_lower, 'laaja_Kasko') || str_contains($ad_group_lower, 'suppea_Kasko')) {
+      if (str_contains($ad_group_lower, 'laaja_kasko') || str_contains($ad_group_lower, 'suppea_kasko')) {
         $industryKey = 'KASKO';
       }
-      if (str_contains($ad_group_lower, 'laaja_Kuva') || str_contains($ad_group_lower, 'suppea_Kuva')) {
+      if (str_contains($ad_group_lower, 'laaja_kuva') || str_contains($ad_group_lower, 'suppea_kuva')) {
         $industryKey = 'KUVA';
       }
       if ($industryKey != '') {

--- a/public/modules/custom/grants_industries/grants_industries.module
+++ b/public/modules/custom/grants_industries/grants_industries.module
@@ -204,14 +204,13 @@ function grants_industries_openid_connect_post_authorize(UserInterface $account,
     foreach ($context["user_data"]["ad_groups"] as $ad_group) {
       $industryKey = '';
       $ad_group_lower = strtolower($ad_group);
-      // @todo remove in prod
+      // If user has one of the designated groups, set the industry key.
       if (str_contains($ad_group_lower, 'owakayttajat')) {
         $industryKey = 'KUVA';
       }
       if (str_contains($ad_group_lower, 'kanslia_kayttajat')) {
         $industryKey = 'KANSLIA';
       }
-      // If user has one of the designated groups, set the industry key.
       if (str_contains($ad_group_lower, 'ta_kuva')) {
         $industryKey = 'KUVA';
       }
@@ -226,6 +225,16 @@ function grants_industries_openid_connect_post_authorize(UserInterface $account,
       }
       if (str_contains($ad_group_lower, 'ta_sote')) {
         $industryKey = 'SOTE';
+      }
+      // New mappings.
+      if (str_contains($ad_group_lower, 'laaja_Kanslia') || str_contains($ad_group_lower, 'suppea_Kanslia')) {
+        $industryKey = 'KANSLIA';
+      }
+      if (str_contains($ad_group_lower, 'laaja_Kasko') || str_contains($ad_group_lower, 'suppea_Kasko')) {
+        $industryKey = 'KASKO';
+      }
+      if (str_contains($ad_group_lower, 'laaja_Kuva') || str_contains($ad_group_lower, 'suppea_Kuva')) {
+        $industryKey = 'KUVA';
       }
       if ($industryKey != '') {
         $industryKeys[] = $industryKey;

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -774,11 +774,10 @@ function _grants_metadata_handle_admin_webform_alter(&$form, FormStateInterface 
   $formStatus = $routeParam->getThirdPartySetting('grants_metadata', 'status');
 
   $currentUser = Drupal::currentUser();
-  $isAdmin = ApplicationHandler::isGrantAdmin($currentUser);
 
   $released = $formStatus === 'released';
   $archived = $formStatus === 'archived';
-  $editingRestricted = ($released || $archived) && !$isAdmin;
+  $editingRestricted = ($released || $archived);
   $restrictionMsg = $released ?
   t('Form is published for production use, only limited editing is allowed.') :
   t('Form is archived and editing is not allowed.');
@@ -796,9 +795,7 @@ function _grants_metadata_handle_admin_webform_alter(&$form, FormStateInterface 
 
       $showStatusMessage = TRUE;
 
-      if ($editingRestricted && !$isAdmin) {
-        $form['#disabled'] = TRUE;
-
+      if ($editingRestricted) {
         \Drupal::messenger()
           ->addWarning($restrictionMsg);
 

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -773,8 +773,6 @@ function _grants_metadata_handle_admin_webform_alter(&$form, FormStateInterface 
   $routeParam = \Drupal::routeMatch()->getParameter('webform');
   $formStatus = $routeParam->getThirdPartySetting('grants_metadata', 'status');
 
-  $currentUser = Drupal::currentUser();
-
   $released = $formStatus === 'released';
   $archived = $formStatus === 'archived';
   $editingRestricted = ($released || $archived);

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -18,6 +18,7 @@ $settings['error_page']['template_dir'] = '../error_templates';
 
 // AD roles <-> Drupal roles mapping.
 $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
+  // Old mappings.
   [
     'ad_role' => 'sl_avustustest_paakayttajat',
     'roles' => ['ad_user', 'grants_admin'],
@@ -82,12 +83,41 @@ $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
     'ad_role' => 'sg_kanslia_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
   ],
+  // New mappings.
   [
     'ad_role' => 'Drupal_Helfi_kaupunkitaso_paakayttajat',
     'roles' => ['ad_user', 'grants_admin'],
   ],
   [
+    'ad_role' => 'Drupal_Helfi_Avustukset_paakayttajat',
+    'roles' => ['ad_user', 'grants_admin'],
+  ],
+  [
     'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea',
+    'roles' => ['ad_user', 'content_producer'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_laaja_Kanslia',
+    'roles' => ['ad_user', 'content_producer', 'grants_producer_industry'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea_Kanslia',
+    'roles' => ['ad_user', 'content_producer'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_laaja_Kasko',
+    'roles' => ['ad_user', 'content_producer', 'grants_producer_industry'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea_Kasko',
+    'roles' => ['ad_user', 'content_producer'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_laaja_Kuva',
+    'roles' => ['ad_user', 'content_producer', 'grants_producer_industry'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea_Kuva',
     'roles' => ['ad_user', 'content_producer'],
   ],
 ];


### PR DESCRIPTION
# [AU-2548](https://helsinkisolutionoffice.atlassian.net/browse/AU-2548)

## What was done

This pull request implements a few new AD-group <-> Drupal role mappings according to the instructions in the ticket. It also implements AD-group <-> INDUSTRY mappings according to the AD-group names.

## Other fixes

Fixed and issue in `grants_metadata.module` where no users other than the ones with the `grants_admin` role could edit anything on a Webforms third-party settings page.

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2544-new-ad-group-drupal-role-mappings`
* `make fresh`
* `make drush-cr`

## How to test

- [ ] Check that the new AD-group <-> Drupal role mappings are set according to [this](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8831107145/AD-ryhm+t).
- [ ] Check that the new AD-group <-> INDUSTRY mappings are set according to [this](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8831107145/AD-ryhm+t).
- [ ] Check that the roles `grant_producer` and `grant_producer_industry` can access the correct settings on Webforms.
- [ ] Take this to the staging environment and let Tero / Pirjo test it.

[AU-2544]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AU-2548]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ