### PR TITLE
feat: AU-2545: E2E documentation

### DIFF
--- a/e2e/utils/data/test_data.ts
+++ b/e2e/utils/data/test_data.ts
@@ -6,6 +6,30 @@ import {
 } from './profile_data'
 import {Page} from "@playwright/test";
 
+/**
+ * The following interfaces and types are used to define the structure of the test data
+ * and tests that are used to test the applications on the website.
+ *
+ * @file Provides interfaces and types for tests and test data.
+ */
+
+/**
+ * Interface for a selector object.
+ * Used in test data to define selectors for form fields.
+ */
+interface Selector {
+  type: string;
+  label?: string;
+  name: string;
+  value?: string;
+  details?: SelectorDetails;
+  resultValue?: string;
+}
+
+/**
+ * Interface for selector details.
+ * Used by the Selector interface.
+ */
 interface SelectorDetails {
   role?: string;
   label?: string;
@@ -16,37 +40,10 @@ interface SelectorDetails {
   };
 }
 
-interface Selector {
-  type: string;
-  label?: string;
-  name: string;
-  value?: string;
-  details?: SelectorDetails;
-  resultValue?: string;
-}
-
-interface MultiValueField {
-  buttonSelector: Selector;
-  items: Array<Array<FormField>>;
-  expectedErrors?: Object;
-}
-
-interface DynamicMultiValueField {
-  radioSelector: Selector;
-  revealedElementSelector: Selector;
-  multi: MultiValueField;
-  expectedErrors?: Object;
-}
-
-interface DynamicSingleValueField {
-  radioSelector: Selector;
-  revealedElementSelector: Selector;
-  items: Array<{
-    [pageKey: string]: FormField;
-  }>;
-  expectedErrors?: Object;
-}
-
+/**
+ * Interface for a form field object.
+ * Used by the fields in the form data.
+ */
 interface FormField {
   label?: string;
   role?: string;
@@ -62,31 +59,10 @@ interface FormField {
   printPageSkipValidation?: boolean;
 }
 
-type RemoveList = string[];
-
-type HiddenItemsList = string[];
-
-type ExpectedInlineError = {
-  selector: string;
-  errorMessage: string;
-}
-
-type ViewPageFormatterFunction = (param: string) => string;
-
-type FieldSwapItemList = FieldSwapItem[];
-
-type FieldSwapItem = {
-  field: string;
-  swapValue: string;
-};
-
-type TooltipsList = Tooltip[];
-
-type Tooltip = {
-  aria_label: string;
-  message: string;
-};
-
+/**
+ * Interface for a form field object with a removal option.
+ * Used by the fields in the form data.
+ */
 interface FormFieldWithRemove extends FormField {
   type?: string;
   label?: string;
@@ -98,10 +74,93 @@ interface FormFieldWithRemove extends FormField {
   dynamic_multi?: DynamicMultiValueField;
 }
 
+/**
+ * Interface for a multi-value field object.
+ * Used by various fields in the form data.
+ */
+interface MultiValueField {
+  buttonSelector: Selector;
+  items: Array<Array<FormField>>;
+  expectedErrors?: Object;
+}
+
+/**
+ * Interface for a dynamic multi-value field object.
+ * Used by various fields in the form data.
+ */
+interface DynamicMultiValueField {
+  radioSelector: Selector;
+  revealedElementSelector: Selector;
+  multi: MultiValueField;
+  expectedErrors?: Object;
+}
+
+/**
+ * Interface for a dynamic single-value field object.
+ * Used by various fields in the form data.
+ */
+interface DynamicSingleValueField {
+  radioSelector: Selector;
+  revealedElementSelector: Selector;
+  items: Array<{
+    [pageKey: string]: FormField;
+  }>;
+  expectedErrors?: Object;
+}
+
+/**
+ * Interface for a page handler object.
+ * Used to define the page handlers for the form data.
+ */
+interface PageHandlers {
+  [key: string]: (page: Page, formData: FormPage) => Promise<void>;
+}
+
+/**
+ * Interface for a form page object.
+ * Used to define the form pages in the form data.
+ */
+interface FormPage {
+  items: FormItems;
+  itemsToRemove?: RemoveList | undefined;
+  itemsToBeHidden?: HiddenItemsList | undefined;
+  itemsToSwap?: FieldSwapItemList | undefined;
+  tooltipsToValidate?: TooltipsList| undefined;
+  expectedInlineErrors?: ExpectedInlineError[] | undefined;
+}
+
+/**
+ * Type for a collection of form items.
+ * Used to define the form items in the form page.
+ */
 type FormItems = {
   [itemKey: string]: Partial<FormFieldWithRemove>;
 };
 
+/**
+ * Interface for a form data object.
+ * Used to define the form data for the tests.
+ */
+interface FormData {
+  title: string;
+  formSelector: string;
+  formPath: string;
+  formPages: {
+    [pageKey: string]: FormPage;
+  };
+  expectedDestination?: string;
+  expectedErrors: {},
+  viewPageSkipValidation?: boolean,
+  testFormCopying?: boolean,
+  testFieldSwap?: boolean,
+  validatePrintPage?: boolean,
+  validateTooltips?: boolean,
+}
+
+/**
+ * Interface for a form data object with a removal option.
+ * Used to define the form data for the tests.
+ */
 interface FormDataWithRemove extends FormData {
   formPages: {
     [pageKey: string]: {
@@ -121,51 +180,98 @@ type FormDataWithRemoveOptionalProps =
   Partial<Pick<FormDataWithRemove, 'formSelector' | 'formPath'>>
   & Omit<FormDataWithRemove, 'formSelector' | 'formPath'>;
 
-interface FormPage {
-  items: FormItems;
-  itemsToRemove?: RemoveList | undefined;
-  itemsToBeHidden?: HiddenItemsList | undefined;
-  itemsToSwap?: FieldSwapItemList | undefined;
-  tooltipsToValidate?: TooltipsList| undefined;
-  expectedInlineErrors?: ExpectedInlineError[] | undefined;
-}
+/**
+ * Type for a remove list.
+ * Used to define the list of items to be
+ * removed from the form in itemsToRemove.
+ */
+type RemoveList = string[];
 
-interface FormData {
-  title: string;
-  formSelector: string;
-  formPath: string;
-  formPages: {
-    [pageKey: string]: FormPage;
-  };
-  expectedDestination?: string;
-  expectedErrors: {},
-  viewPageSkipValidation?: boolean,
-  testFormCopying?: boolean,
-  testFieldSwap?: boolean,
-  validatePrintPage?: boolean,
-  validateTooltips?: boolean,
-}
+/**
+ * Type for a hidden items list.
+ * Used to define the list of items to be
+ * hidden in itemsToBeHidden.
+ */
+type HiddenItemsList = string[];
 
-interface PageHandlers {
-  [key: string]: (page: Page, formData: FormPage) => Promise<void>;
+/**
+ * Type for expected inline errors.
+ * Used to define the expected inline errors in
+ * the form data in expectedInlineErrors.
+ */
+type ExpectedInlineError = {
+  selector: string;
+  errorMessage: string;
 }
+/**
+ * Type for a field swap item list.
+ * Used to define the list of items to be swapped in itemsToSwap.
+ */
+type FieldSwapItemList = FieldSwapItem[];
 
+/**
+ * Type for a field swap item.
+ * Used to define the items to be swapped in itemsToSwap.
+ */
+type FieldSwapItem = {
+  field: string;
+  swapValue: string;
+};
+
+/**
+ * Type for a list of tooltips.
+ * Used to define the list of tooltips to be validated in tooltipsToValidate.
+ */
+type TooltipsList = Tooltip[];
+
+/**
+ * Interface for a tooltip object.
+ * Used to define the tooltip in tooltipsList.
+ */
+type Tooltip = {
+  aria_label: string;
+  message: string;
+};
+
+/**
+ * Type for a view page formatter function.
+ * Used to format the raw input data to a view page format.
+ */
+type ViewPageFormatterFunction = (param: string) => string;
+
+/**
+ * Interface for a collection of pages.
+ * These page collections are used to define the test scenarios
+ * in the public smoke tests.
+ */
 interface PageCollection {
   [key: string]: TestScenario;
 }
 
+/**
+ * Interface for a test scenario object.
+ * Used to define the test scenarios in the public smoke tests.
+ */
 interface TestScenario {
   url: string;
   validatePageTitle: boolean,
   components: ComponentDetails[];
 }
 
+/**
+ * Interface for component details.
+ * Used to define the component details in the public smoke tests.
+ */
 interface ComponentDetails {
   containerClass: string;
   elements: ElementDetails[];
   occurrences?: number;
 }
 
+/**
+ * Interface for element details.
+ * Used to define the element details in the public smoke tests.
+ */
 interface ElementDetails {
   selector: string;
   countExact?: number;
@@ -173,12 +279,12 @@ interface ElementDetails {
   expectedText?: string[];
 }
 
-// Type guard for MultiValueField
+// Type guard for MultiValueField.
 function isMultiValueField(value: any): value is MultiValueField {
   return typeof value === 'object' && value !== null /* Add more conditions if needed */;
 }
 
-// Type guard for DynamicValueField
+// Type guard for DynamicValueField.
 function isDynamicMultiValueField(value: any): value is DynamicMultiValueField {
   return typeof value === 'object' && value !== null /* Add more conditions if needed */;
 }


### PR DESCRIPTION
# [AU-2545](https://helsinkisolutionoffice.atlassian.net/browse/AU-2545)

## What was done

This pull request implements the last parts of the E2E test documentation. The code is documented pretty well overall. Only the types and interfaces lacked any documentation in the `test_data.ts` file, so I added a few comments.

## How to install

Make sure your instance is up and running on correct branch.
* `git checkout feature/AU-2545-e2e-documentation`
* `make fresh`
* `make drush-cr`

## How to test

- Review the added documentation in the `test_data.ts` file. Also look through the [Confluence](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/8481833123/Regressiotestit) page and make sure it look alright.

[AU-2545]: https://helsinkisolutionoffice.atlassian.net/browse/AU-2545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ