### PR TITLE
hotfix: UHF-10357: Remove fields that break Avus2.

### DIFF
--- a/public/modules/custom/grants_industries/grants_industries.module
+++ b/public/modules/custom/grants_industries/grants_industries.module
@@ -204,14 +204,13 @@ function grants_industries_openid_connect_post_authorize(UserInterface $account,
     foreach ($context["user_data"]["ad_groups"] as $ad_group) {
       $industryKey = '';
       $ad_group_lower = strtolower($ad_group);
-      // @todo remove in prod
+      // If user has one of the designated groups, set the industry key.
       if (str_contains($ad_group_lower, 'owakayttajat')) {
         $industryKey = 'KUVA';
       }
       if (str_contains($ad_group_lower, 'kanslia_kayttajat')) {
         $industryKey = 'KANSLIA';
       }
-      // If user has one of the designated groups, set the industry key.
       if (str_contains($ad_group_lower, 'ta_kuva')) {
         $industryKey = 'KUVA';
       }
@@ -226,6 +225,16 @@ function grants_industries_openid_connect_post_authorize(UserInterface $account,
       }
       if (str_contains($ad_group_lower, 'ta_sote')) {
         $industryKey = 'SOTE';
+      }
+      // New mappings.
+      if (str_contains($ad_group_lower, 'laaja_kanslia') || str_contains($ad_group_lower, 'suppea_kanslia')) {
+        $industryKey = 'KANSLIA';
+      }
+      if (str_contains($ad_group_lower, 'laaja_kasko') || str_contains($ad_group_lower, 'suppea_kasko')) {
+        $industryKey = 'KASKO';
+      }
+      if (str_contains($ad_group_lower, 'laaja_kuva') || str_contains($ad_group_lower, 'suppea_kuva')) {
+        $industryKey = 'KUVA';
       }
       if ($industryKey != '') {
         $industryKeys[] = $industryKey;

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -75,9 +75,6 @@ function grants_metadata__validate_third_party_settings(array &$form, FormStateI
     ];
   }
 
-  $avus2BreakingChange = $formValues["third_party_settings"]["grants_metadata"]["avus2BreakingChange"];
-  $formValues['avus2BreakingChange'] = $avus2BreakingChange;
-
   // Set values back to form state.
   $form_state->setValues($formValues);
 }
@@ -176,7 +173,7 @@ function _grants_metadata_handle_versions_status(Webform $entity): void {
     $formParentData->save();
     \Drupal::messenger()->addStatus(t('Form @id status updated to @status',
       [
-        '@id' => $entity->id(),
+        '@id' => $formParentData->id(),
         '@status' => $status,
       ]));
     \Drupal::messenger()->addStatus(t('Parent form @id archived.', ['@id' => $formParentData->id()]));
@@ -655,9 +652,6 @@ function grants_metadata_form_alter(&$form, FormStateInterface $form_state, $for
       }
     }
 
-    $currentUser = Drupal::currentUser();
-    $isSuperUser = $currentUser->id() == 1;
-
     $form['third_party_settings']['grants_metadata']['status'] = [
       '#type' => 'radios',
       '#title' => t('Status'),
@@ -668,39 +662,24 @@ function grants_metadata_form_alter(&$form, FormStateInterface $form_state, $for
       ],
       '#required' => TRUE,
       '#default_value' => $formStatus ?? 'development',
-      '#disabled' => ($isDuplicateForm || !$isSuperUser),
+      '#disabled' => $isDuplicateForm,
       '#description' => t('
 <p>In production: Changing the webform elements is not allowed.</p>
 <p>In development: Webform elements can be edited. Form can be filled up in non-production environments.</p>
 <p>Archived: Older version of the form which cannot be filled anymore.</p>
-<strong>Only admins/developers should change this, if required.</strong>
       ', [], $tOpts),
     ];
 
     $form['third_party_settings']['grants_metadata']['parent'] = [
       '#type' => 'select',
       '#title' => t('Parent'),
-      '#description' => t('Parent form, if this webform was duplicated or replaces existing form.
-<strong>Only admins/developers should change this, if required.</strong>', [], $tOpts),
+      '#description' => t('Parent form, if this webform was duplicated or replaces existing form.', [], $tOpts),
       '#options' => $parentOptions,
       '#default_value' => $formParent,
       '#disabled' => TRUE,
       '#required' => $isDuplicateForm,
       '#empty_option' => t('- None -'),
       '#empty_value' => '',
-    ];
-
-    $breakingChange = $bundle->getThirdPartySetting('grants_metadata', 'avus2BreakingChange') ?? FALSE;
-
-    $form['third_party_settings']['grants_metadata']['avus2BreakingChange'] = [
-      '#type' => 'checkbox',
-      '#default_value' => $breakingChange,
-      '#title' => t('This webform version has breaking changes with Avus2', [], $tOpts),
-      '#description' => t('Mark this version with a breaking changes flag.
-This will prevent applications created with an older webform version, which are in draft or received status,
-from being edited, even if normal rules would otherwise permit it.
-<strong>Only admins/developers should change this, if required.</strong>', [], $tOpts),
-      '#disabled' => !$isSuperUser,
     ];
   }
 
@@ -794,6 +773,7 @@ function _grants_metadata_handle_admin_webform_alter(&$form, FormStateInterface 
       $showStatusMessage = TRUE;
 
       if ($editingRestricted) {
+
         \Drupal::messenger()
           ->addWarning($restrictionMsg);
 

--- a/public/modules/custom/grants_metadata/grants_metadata.module
+++ b/public/modules/custom/grants_metadata/grants_metadata.module
@@ -75,6 +75,9 @@ function grants_metadata__validate_third_party_settings(array &$form, FormStateI
     ];
   }
 
+  $avus2BreakingChange = $formValues["third_party_settings"]["grants_metadata"]["avus2BreakingChange"];
+  $formValues['avus2BreakingChange'] = $avus2BreakingChange;
+
   // Set values back to form state.
   $form_state->setValues($formValues);
 }
@@ -173,7 +176,7 @@ function _grants_metadata_handle_versions_status(Webform $entity): void {
     $formParentData->save();
     \Drupal::messenger()->addStatus(t('Form @id status updated to @status',
       [
-        '@id' => $formParentData->id(),
+        '@id' => $entity->id(),
         '@status' => $status,
       ]));
     \Drupal::messenger()->addStatus(t('Parent form @id archived.', ['@id' => $formParentData->id()]));
@@ -652,6 +655,9 @@ function grants_metadata_form_alter(&$form, FormStateInterface $form_state, $for
       }
     }
 
+    $currentUser = Drupal::currentUser();
+    $isSuperUser = $currentUser->id() == 1;
+
     $form['third_party_settings']['grants_metadata']['status'] = [
       '#type' => 'radios',
       '#title' => t('Status'),
@@ -662,24 +668,39 @@ function grants_metadata_form_alter(&$form, FormStateInterface $form_state, $for
       ],
       '#required' => TRUE,
       '#default_value' => $formStatus ?? 'development',
-      '#disabled' => $isDuplicateForm,
+      '#disabled' => ($isDuplicateForm || !$isSuperUser),
       '#description' => t('
 <p>In production: Changing the webform elements is not allowed.</p>
 <p>In development: Webform elements can be edited. Form can be filled up in non-production environments.</p>
 <p>Archived: Older version of the form which cannot be filled anymore.</p>
+<strong>Only admins/developers should change this, if required.</strong>
       ', [], $tOpts),
     ];
 
     $form['third_party_settings']['grants_metadata']['parent'] = [
       '#type' => 'select',
       '#title' => t('Parent'),
-      '#description' => t('Parent form, if this webform was duplicated or replaces existing form.', [], $tOpts),
+      '#description' => t('Parent form, if this webform was duplicated or replaces existing form.
+<strong>Only admins/developers should change this, if required.</strong>', [], $tOpts),
       '#options' => $parentOptions,
       '#default_value' => $formParent,
       '#disabled' => TRUE,
       '#required' => $isDuplicateForm,
       '#empty_option' => t('- None -'),
       '#empty_value' => '',
+    ];
+
+    $breakingChange = $bundle->getThirdPartySetting('grants_metadata', 'avus2BreakingChange') ?? FALSE;
+
+    $form['third_party_settings']['grants_metadata']['avus2BreakingChange'] = [
+      '#type' => 'checkbox',
+      '#default_value' => $breakingChange,
+      '#title' => t('This webform version has breaking changes with Avus2', [], $tOpts),
+      '#description' => t('Mark this version with a breaking changes flag.
+This will prevent applications created with an older webform version, which are in draft or received status,
+from being edited, even if normal rules would otherwise permit it.
+<strong>Only admins/developers should change this, if required.</strong>', [], $tOpts),
+      '#disabled' => !$isSuperUser,
     ];
   }
 
@@ -752,12 +773,9 @@ function _grants_metadata_handle_admin_webform_alter(&$form, FormStateInterface 
   $routeParam = \Drupal::routeMatch()->getParameter('webform');
   $formStatus = $routeParam->getThirdPartySetting('grants_metadata', 'status');
 
-  $currentUser = Drupal::currentUser();
-  $isAdmin = ApplicationHandler::isGrantAdmin($currentUser);
-
   $released = $formStatus === 'released';
   $archived = $formStatus === 'archived';
-  $editingRestricted = ($released || $archived) && !$isAdmin;
+  $editingRestricted = ($released || $archived);
   $restrictionMsg = $released ?
   t('Form is published for production use, only limited editing is allowed.') :
   t('Form is archived and editing is not allowed.');
@@ -775,9 +793,7 @@ function _grants_metadata_handle_admin_webform_alter(&$form, FormStateInterface 
 
       $showStatusMessage = TRUE;
 
-      if ($editingRestricted && !$isAdmin) {
-        $form['#disabled'] = TRUE;
-
+      if ($editingRestricted) {
         \Drupal::messenger()
           ->addWarning($restrictionMsg);
 

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -612,13 +612,18 @@ class AtvSchema {
   /**
    * Converts a value to its boolean string representation.
    *
+   * This is due to strange behavior in Avus where boolean values are sometimes
+   * needed to be strings and sometimes as booleans.
+   * This must return value as is since in some cases the value is
+   * null and we need to keep it that way.
+   *
    * @param mixed $itemValue
    *   The item value to be converted.
    *
-   * @return string
+   * @return mixed
    *   The converted boolean string representation of the item value.
    */
-  private static function convertToBooleanString(mixed $itemValue): string {
+  private static function convertToBooleanString(mixed $itemValue): mixed {
     $falseValues = [FALSE, '0', 0, 'No'];
     $trueValues = [TRUE, '1', 1, 'Yes'];
 

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
@@ -440,8 +440,6 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
         ->setSetting('fieldsForApplication', [
           'premiseName',
           'premiseType',
-          'isOthersUse',
-          'isOwnedByApplicant',
           'postCode',
           'isOwnedByCity',
           'citySection',

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -18,6 +18,7 @@ $settings['error_page']['template_dir'] = '../error_templates';
 
 // AD roles <-> Drupal roles mapping.
 $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
+  // Old mappings.
   [
     'ad_role' => 'sl_avustustest_paakayttajat',
     'roles' => ['ad_user', 'grants_admin'],
@@ -81,5 +82,42 @@ $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
   [
     'ad_role' => 'sg_kanslia_kayttajat',
     'roles' => ['ad_user', 'content_producer_industry'],
+  ],
+  // New mappings.
+  [
+    'ad_role' => 'Drupal_Helfi_kaupunkitaso_paakayttajat',
+    'roles' => ['ad_user', 'grants_admin'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_paakayttajat',
+    'roles' => ['ad_user', 'grants_admin'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea',
+    'roles' => ['ad_user', 'content_producer'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_laaja_Kanslia',
+    'roles' => ['ad_user', 'content_producer', 'grants_producer_industry'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea_Kanslia',
+    'roles' => ['ad_user', 'content_producer'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_laaja_Kasko',
+    'roles' => ['ad_user', 'content_producer', 'grants_producer_industry'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea_Kasko',
+    'roles' => ['ad_user', 'content_producer'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_laaja_Kuva',
+    'roles' => ['ad_user', 'content_producer', 'grants_producer_industry'],
+  ],
+  [
+    'ad_role' => 'Drupal_Helfi_Avustukset_sisallontuottajat_suppea_Kuva',
+    'roles' => ['ad_user', 'content_producer'],
   ],
 ];


### PR DESCRIPTION
# [UHF-10357](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10357)
<!-- What problem does this solve? -->

There is incorrect field definition for realizedPremisesArray -field. Avus2 can't handle these 2 fields: isOthersUse & isOwnedByApplicant and process fails with error. 

## What was done
<!-- Describe what was done -->

* Removed 2 errorenous fields.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout hotfix/UHF-10357`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Login as a registered community, fill out form [Taiteen perusopetuksen avustukset](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/kulttuurin-avustukset/taiteen-perusopetuksen-avustukset) and see the status change to RECEIVED. This means that the application was processed by Avus2 and and things work as expected.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)
* [x] Missing regression tests, there's a ticket for it. 


[UHF-10357]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ