### PR TITLE
fix: UHF-10344: update e2e node image to custom one

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,7 +1,5 @@
 FROM ghcr.io/city-of-helsinki/node:latest
 
-USER root
-
 ENV PLAYWRIGHT_BROWSERS_PATH=0
 
 WORKDIR app

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/nodejs-20
+FROM ghcr.io/city-of-helsinki/node:latest
+
+USER root
 
 ENV PLAYWRIGHT_BROWSERS_PATH=0
 


### PR DESCRIPTION
# [UHF-10344](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10344)
<!-- What problem does this solve? -->

Regression tests broke because of some docker image rate limits, this tries to use custom image from Coty-of-Helsinki repo.

## What was done
<!-- Describe what was done -->

* Updated image in Dockerfile



[UHF-10344]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ