### PR TITLE
fix: UHF-10362: Fix faker created testing emails to use example.com domain

### DIFF
--- a/e2e/utils/data/application/application_data_29.ts
+++ b/e2e/utils/data/application/application_data_29.ts
@@ -11,6 +11,8 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
+
 
 const baseForm_29: FormData = {
   title: 'Save as draft.',
@@ -26,7 +28,7 @@ const baseForm_29: FormData = {
             name: 'data-drupal-selector',
             value: 'edit-email',
           },
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_48.ts
+++ b/e2e/utils/data/application/application_data_48.ts
@@ -12,6 +12,8 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
+
 
 /**
  * Basic form data for successful submit to Avus2. This object contains ALL
@@ -30,7 +32,7 @@ const baseForm_48: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_49.ts
+++ b/e2e/utils/data/application/application_data_49.ts
@@ -12,6 +12,8 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
+
 
 const baseForm_49: FormData = {
   title: 'Save as draft.',
@@ -27,7 +29,7 @@ const baseForm_49: FormData = {
             name: 'data-drupal-selector',
             value: 'edit-email',
           },
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_51.ts
+++ b/e2e/utils/data/application/application_data_51.ts
@@ -11,6 +11,7 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -23,7 +24,7 @@ const baseFormRegisteredCommunity_51: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_52.ts
+++ b/e2e/utils/data/application/application_data_52.ts
@@ -11,6 +11,8 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber,
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
+
 
 /**
  * Basic form data for successful submit to Avus2
@@ -23,7 +25,7 @@ const baseFormRegisteredCommunity_52: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_53.ts
+++ b/e2e/utils/data/application/application_data_53.ts
@@ -10,6 +10,7 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatCurrency
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -22,7 +23,7 @@ const baseFormRegisteredCommunity_53: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_54.ts
+++ b/e2e/utils/data/application/application_data_54.ts
@@ -11,6 +11,8 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
+
 
 /**
  * Basic form data for successful submit to Avus2
@@ -29,7 +31,7 @@ const baseFormRegisteredCommunity_54: FormData = {
             name: 'data-drupal-selector',
             value: 'edit-email',
           },
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_56.ts
+++ b/e2e/utils/data/application/application_data_56.ts
@@ -9,6 +9,8 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatCurrency
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
+
 
 /**
  * Basic form data for successful submit to Avus2
@@ -21,7 +23,7 @@ const baseFormRegisteredCommunity_56: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_57.ts
+++ b/e2e/utils/data/application/application_data_57.ts
@@ -9,6 +9,7 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatCurrency, viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -27,7 +28,7 @@ const baseFormRegisteredCommunity_57: FormData = {
             name: 'data-drupal-selector',
             value: 'edit-email',
           },
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_58.ts
+++ b/e2e/utils/data/application/application_data_58.ts
@@ -10,6 +10,7 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatNumber,
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -22,7 +23,7 @@ const baseFormRegisteredCommunity_58: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_60.ts
+++ b/e2e/utils/data/application/application_data_60.ts
@@ -11,6 +11,7 @@ import {
   viewPageFormatNumber,
   viewPageFormatFilePath
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -23,7 +24,7 @@ const baseFormRegisteredCommunity_60: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_61.ts
+++ b/e2e/utils/data/application/application_data_61.ts
@@ -10,6 +10,7 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -22,7 +23,7 @@ const baseFormRegisteredCommunity_61: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_62.ts
+++ b/e2e/utils/data/application/application_data_62.ts
@@ -11,6 +11,7 @@ import {
   viewPageFormatNumber,
   viewPageFormatDate
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -23,7 +24,7 @@ const baseFormRegisteredCommunity_62: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_63.ts
+++ b/e2e/utils/data/application/application_data_63.ts
@@ -11,6 +11,7 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber,
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2

--- a/e2e/utils/data/application/application_data_64.ts
+++ b/e2e/utils/data/application/application_data_64.ts
@@ -11,6 +11,7 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2

--- a/e2e/utils/data/application/application_data_65.ts
+++ b/e2e/utils/data/application/application_data_65.ts
@@ -10,6 +10,7 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -28,7 +29,7 @@ const baseForm_65: FormData = {
             name: 'data-drupal-selector',
             value: 'edit-email',
           },
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_66.ts
+++ b/e2e/utils/data/application/application_data_66.ts
@@ -10,6 +10,7 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -22,7 +23,7 @@ const baseFormRegisteredCommunity_66: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_67.ts
+++ b/e2e/utils/data/application/application_data_67.ts
@@ -11,6 +11,7 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -23,7 +24,7 @@ const baseFormRegisteredCommunity_67: FormData = {
     "1_hakijan_tiedot": {
       items: {
         "edit-email": {
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_68.ts
+++ b/e2e/utils/data/application/application_data_68.ts
@@ -11,6 +11,7 @@ import {
   viewPageFormatCurrency,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2
@@ -29,7 +30,7 @@ const baseFormRegisteredCommunity_68: FormData = {
             name: 'data-drupal-selector',
             value: 'edit-email',
           },
-          value: faker.internet.email(),
+          value: getFakeEmailAddress(),
           viewPageFormatter: viewPageFormatLowerCase,
         },
         "edit-contact-person": {

--- a/e2e/utils/data/application/application_data_69.ts
+++ b/e2e/utils/data/application/application_data_69.ts
@@ -9,6 +9,7 @@ import {
   viewPageFormatLowerCase,
   viewPageFormatNumber
 } from "../../view_page_formatters";
+import {getFakeEmailAddress} from "../../field_helpers";
 
 /**
  * Basic form data for successful submit to Avus2

--- a/e2e/utils/data/profile_data_registered_community.ts
+++ b/e2e/utils/data/profile_data_registered_community.ts
@@ -3,6 +3,7 @@ import {FormData, FormDataWithRemoveOptionalProps,} from "./test_data";
 import {PROFILE_INPUT_DATA} from "./profile_input_data";
 import {ATTACHMENTS} from "./attachment_data";
 import {createFormData} from "../form_data_helpers";
+import {getFakeEmailAddress} from "../field_helpers";
 
 const profileDataBase: FormData = {
   title: 'Save profile data',
@@ -224,7 +225,7 @@ const profileDataBase: FormData = {
                       name: 'data-drupal-selector',
                       value: 'edit-officialwrapper-[INDEX]-official-email',
                     },
-                    value: faker.internet.email().toLowerCase(),
+                    value: getFakeEmailAddress().toLowerCase(),
                     viewPageSelector: '.grants-profile',
                   },
                   {

--- a/e2e/utils/data/profile_input_data.ts
+++ b/e2e/utils/data/profile_input_data.ts
@@ -10,7 +10,7 @@ import {getFakeEmailAddress} from "../field_helpers";
  * a profiles data on an applications
  * "View" page.
  */
-interface ProfileInputData  {
+interface ProfileInputData {
   iban: string;
   iban2: string;
   address: string;
@@ -36,7 +36,7 @@ const PROFILE_INPUT_DATA: ProfileInputData = {
   city: 'Kuopio',
   communityOfficial: 'Marko Niemi',
   role: 'Vastuuhenkilö',
-  email: getFakeEmailAddress(),
+  email: getFakeEmailAddress({firstName: 'Marko', lastName: 'Niemi'}),
   phone: '0401234567'
 }
 

--- a/e2e/utils/data/profile_input_data.ts
+++ b/e2e/utils/data/profile_input_data.ts
@@ -1,3 +1,5 @@
+import {getFakeEmailAddress} from "../field_helpers";
+
 /**
  * The ProfileInputData interface.
  *
@@ -34,7 +36,7 @@ const PROFILE_INPUT_DATA: ProfileInputData = {
   city: 'Kuopio',
   communityOfficial: 'Marko Niemi',
   role: 'Vastuuhenkilö',
-  email: 'marko.niemi78@ggmmaaiill.com',
+  email: getFakeEmailAddress(),
   phone: '0401234567'
 }
 

--- a/e2e/utils/field_helpers.ts
+++ b/e2e/utils/field_helpers.ts
@@ -1,5 +1,20 @@
 import {fakerFI as faker} from "@faker-js/faker";
 
-const getFakeEmailAddress = () => faker.internet.exampleEmail().toLowerCase();
+/**
+ * Options for generating a fake email address.
+ */
+interface EmailOptions {
+  firstName?: string | undefined;
+  lastName?: string | undefined;
+  allowSpecialCharacters?: boolean | undefined;
+}
+
+/**
+ * Get a fake email address.
+ *
+ * @param options
+ */
+const getFakeEmailAddress = (options?: EmailOptions) =>
+  faker.internet.exampleEmail(options).toLowerCase();
 
 export { getFakeEmailAddress };

--- a/e2e/utils/field_helpers.ts
+++ b/e2e/utils/field_helpers.ts
@@ -1,0 +1,5 @@
+import {fakerFI as faker} from "@faker-js/faker";
+
+const getFakeEmailAddress = () => faker.internet.exampleEmail().toLowerCase();
+
+export { getFakeEmailAddress };


### PR DESCRIPTION
# [UHF-10362](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10362)
<!-- What problem does this solve? -->

Avus2 apparently sends all emails outwards from their system, and there's no way to stop that. And we discovered that faker creates email addresses that can be in use, like irmeli49@gmail.com.

## What was done
<!-- Describe what was done -->

* Email addresses creation was moved to custom function
* That function returns faker.exampleEmail() return value in lower case.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/UHF-10362-fix-faker-mails`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Changes are pretty simple, maybe a visual inspection is enough?
* [ ] AND/OR run some e2e tests, eg `make test-pw-p PROJECT=forms-48`
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [x] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10362]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ