### PR TITLE
Hotfix UHF-10550. Fix missing integrationID's

### DIFF
--- a/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
@@ -504,20 +504,20 @@ class ResendApplicationsForm extends AtvFormBase {
           $fileNameMatched = TRUE;
         }
         if ($fileNameMatched && $item['ID'] === 'integrationID') {
-          // update integrationID in place
+          // Update integrationID in place.
           $item['value'] = $intID;
-          // set the value to control adding new integrationID
-          $integrationIdUpdated = true;
+          // Set the value to control adding new integrationID.
+          $integrationIdUpdated = TRUE;
           break;
         }
       }
-      // If filename matched but no integrationID was found, add it
+      // If filename matched but no integrationID was found, add it.
       if ($fileNameMatched && !$integrationIdUpdated) {
         $innerArray[] = [
           'ID' => 'integrationID',
           'value' => $intID,
           'valueType' => 'string',
-          'meta' => "[]"
+          'meta' => "[]",
         ];
       }
     }
@@ -639,7 +639,6 @@ class ResendApplicationsForm extends AtvFormBase {
       $fieldInfo = $this->findByFilename($attachment, $attachmentInfo);
       $fieldLabel = $this->extractFieldValue($fieldInfo, 'description');
 
-
       $rowElement = [
         'field' => [
           '#markup' => $fieldLabel,
@@ -674,6 +673,17 @@ class ResendApplicationsForm extends AtvFormBase {
     }
   }
 
+  /**
+   * Extract field value from array.
+   *
+   * @param array $attachmentInfo
+   *   Attachment info.
+   * @param string $fieldId
+   *   Field id.
+   *
+   * @return string|null
+   *   String or null.
+   */
   private function extractFieldValue(array $attachmentInfo, string $fieldId): ?string {
     foreach ($attachmentInfo as $innerArray) {
       foreach ($innerArray as $item) {
@@ -682,9 +692,21 @@ class ResendApplicationsForm extends AtvFormBase {
         }
       }
     }
-    return null; // Return null if no match is found
+    // Return null if no match is found.
+    return NULL;
   }
 
+  /**
+   * Find by filename.
+   *
+   * @param array $attachment
+   *   Attachment.
+   * @param array $attachmentInfo
+   *   Attachment info.
+   *
+   * @return array|null
+   *   Array or null.
+   */
   private function findByFilename(array $attachment, array $attachmentInfo): ?array {
     foreach ($attachmentInfo as $innerArray) {
       foreach ($innerArray as $item) {
@@ -693,9 +715,9 @@ class ResendApplicationsForm extends AtvFormBase {
         }
       }
     }
-    return null; // Return null if no match is found
+    // Return null if no match is found.
+    return NULL;
   }
-
 
   /**
    * Try to figure our if attachments are ok.

--- a/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
@@ -6,6 +6,7 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\grants_attachments\AttachmentHandlerHelper;
 use Drupal\grants_handler\EventException;
 use Drupal\grants_handler\Helpers;
 use Drupal\helfi_atv\AtvDocument;
@@ -97,6 +98,8 @@ class ResendApplicationsForm extends AtvFormBase {
     $document = $form_state->getValue('atvdocument');
     $messages = $form_state->getValue('messages');
 
+    $storage = $form_state->getStorage();
+
     if ($document) {
       $documentArray = json_decode($document, TRUE);
       $prettyJson = json_encode($documentArray, JSON_PRETTY_PRINT);
@@ -138,8 +141,26 @@ class ResendApplicationsForm extends AtvFormBase {
         ],
       ];
 
+      $form['status']['attachmentList'] = [
+        '#type' => 'table',
+        '#caption' => $this->t('Attachments'),
+        '#header' => [
+          $this->t('ID'),
+          $this->t('Created'),
+          $this->t('Filename'),
+          $this->t('IntegrationID'),
+          $this->t('Form OK', [], self::$tOpts),
+          $this->t('Handler OK', [], self::$tOpts),
+          $this->t('Avus2 OK', [], self::$tOpts),
+        ],
+      ];
+
       if ($messages) {
         $this->buildMessages($messages, $form);
+      }
+
+      if ($storage['atvDocument']) {
+        $this->buildAttachments($storage['atvDocument'], $form);
       }
 
       $form['disclaimer'] = [
@@ -147,7 +168,7 @@ class ResendApplicationsForm extends AtvFormBase {
         '#suffix' => '<p>',
         '#markup' => $this->t(
           '* Please note that older applications might not have avus2 message received status available.',
-         [], self::$tOpts),
+          [], self::$tOpts),
       ];
 
       $form['resendMessages'] = [
@@ -182,7 +203,7 @@ class ResendApplicationsForm extends AtvFormBase {
    * @return \Drupal\helfi_atv\AtvDocument|false
    *   The document or false if not found.
    */
-  private function getDocument(string $applicationId):AtvDocument|false {
+  private function getDocument(string $applicationId): AtvDocument|false {
     $sParams = [
       'transaction_id' => $applicationId,
       'lookfor' => 'appenv:' . Helpers::getAppEnv(),
@@ -192,7 +213,8 @@ class ResendApplicationsForm extends AtvFormBase {
       $res = $this->atvService->searchDocuments($sParams);
     }
     catch (GuzzleException | \Exception $e) {
-      $this->logger(self::LOGGER_CHANNEL)->error('Error: @error', ['@error' => $e->getMessage()]);
+      $this->logger(self::LOGGER_CHANNEL)
+        ->error('Error: @error', ['@error' => $e->getMessage()]);
       return FALSE;
     }
     return reset($res);
@@ -255,7 +277,7 @@ class ResendApplicationsForm extends AtvFormBase {
 
     $this->messenger()->addStatus($this->t(
       'Selected messages has been resent, processing the messages might take a few moments',
-     [], self::$tOpts));
+      [], self::$tOpts));
     $formState->setRebuild();
   }
 
@@ -270,7 +292,6 @@ class ResendApplicationsForm extends AtvFormBase {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function resendMessage(array $messageData, string $applicationNumber): void {
-
     $endpoint = getenv('AVUSTUS2_MESSAGE_ENDPOINT');
     $username = getenv('AVUSTUS2_USERNAME');
     $password = getenv('AVUSTUS2_PASSWORD');
@@ -299,14 +320,13 @@ class ResendApplicationsForm extends AtvFormBase {
             '%nextId' => $messageData['messageId'],
             '%eventId' => $event['eventID'],
           ]);
-
       }
       catch (EventException $e) {
         // Log event error.
-        $this->logger(self::LOGGER_CHANNEL)->error('%error', ['%error' => $e->getMessage()]);
+        $this->logger(self::LOGGER_CHANNEL)
+          ->error('%error', ['%error' => $e->getMessage()]);
       }
     }
-
   }
 
   /**
@@ -318,36 +338,45 @@ class ResendApplicationsForm extends AtvFormBase {
    *   The form state object.
    */
   public function getStatus(array $form, FormStateInterface $formState): void {
-
     try {
       $applicationId = $formState->getValue('applicationId');
       $placeholders = ['@applicationId' => $applicationId];
-      $this->logger(self::LOGGER_CHANNEL)->info('Status check init for: @applicationId', $placeholders);
+      $this->logger(self::LOGGER_CHANNEL)
+        ->info('Status check init for: @applicationId', $placeholders);
 
       /** @var \Drupal\helfi_atv\AtvDocument $atvDoc */
       $atvDoc = $this->getDocument($applicationId);
 
       if (!$atvDoc) {
-        $this->messenger()->addWarning($this->t('No application found for id: @applicationId', $placeholders));
-        $this->logger(self::LOGGER_CHANNEL)->warning('No application found for id: @applicationId', $placeholders);
+        $this->messenger()
+          ->addWarning($this->t('No application found for id: @applicationId', $placeholders));
+        $this->logger(self::LOGGER_CHANNEL)
+          ->warning('No application found for id: @applicationId', $placeholders);
         return;
       }
 
       $messages = $this->messageService->parseMessages($atvDoc->getContent(), FALSE, TRUE);
 
-      $this->messenger()->addStatus($this->t('Application found: @applicationId', $placeholders));
+      $this->messenger()
+        ->addStatus($this->t('Application found: @applicationId', $placeholders));
       $statusArray = $atvDoc->getStatusArray();
 
       if (!empty($statusArray)) {
         $formState->setValue('status', $statusArray);
         $formState->setValue('atvdocument', $atvDoc->toJson());
         $formState->setValue('messages', $messages);
+
+        $storage = $formState->getStorage();
+        $storage['atvDocument'] = $atvDoc;
+        $formState->setStorage($storage);
+
         $formState->setRebuild();
       }
     }
     catch (\Exception $e) {
       $uuid = Uuid::uuid4()->toString();
-      $this->messenger()->addError('Error has occured and has been logged. ID: @uuid', ['@uuid' => $uuid]);
+      $this->messenger()
+        ->addError('Error has occured and has been logged. ID: @uuid', ['@uuid' => $uuid]);
       $this->logger(self::LOGGER_CHANNEL)->error(
         'Error: status check: @error, ID: @uuid',
         ['@error' => $e->getMessage(), '@uuid' => $uuid]
@@ -356,7 +385,12 @@ class ResendApplicationsForm extends AtvFormBase {
   }
 
   /**
-   * Resend application callback submit handler.
+   * Resend application submit handler.
+   *
+   * @param array $form
+   *   The form object.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   The form state object.
    */
   public function resendApplicationCallback(array $form, FormStateInterface $formState): void {
     $formState->setValue('status', NULL);
@@ -364,29 +398,134 @@ class ResendApplicationsForm extends AtvFormBase {
     try {
       $applicationId = trim($formState->getValue('applicationId'));
       $placeholders = ['@applicationId' => $applicationId];
-      $this->logger(self::LOGGER_CHANNEL)->info('Application resend init for: @applicationId', $placeholders);
+      $this->logApplicationResendInit($applicationId);
+
       $atvDoc = $this->getDocument($applicationId);
 
       if (!$atvDoc) {
-        $this->messenger()->addWarning($this->t('No application found for id: @applicationId', $placeholders));
-        $this->logger(self::LOGGER_CHANNEL)->warning('No application found for id: @applicationId', $placeholders);
-
-        $formState->setRebuild();
+        $this->handleApplicationNotFound($placeholders, $formState);
         return;
       }
 
-      $this->messenger()->addStatus($this->t('Application found: @applicationId', $placeholders));
+      $this->processAttachments($atvDoc, $placeholders);
       $this->sendApplicationToIntegrations($atvDoc, $applicationId);
       $formState->setRebuild();
     }
     catch (GuzzleException | \Exception $e) {
-      $uuid = Uuid::uuid4()->toString();
-      $this->messenger()->addError('Error has occured and has been logged. ID: @uuid', ['@uuid' => $uuid]);
-      $this->logger(self::LOGGER_CHANNEL)->error(
-        'Error: Admin application forms - Resend error: @error, ID: @uuid',
-        ['@error' => $e->getMessage(), '@uuid' => $uuid]
-      );
+      $this->handleException($e);
     }
+  }
+
+  /**
+   * Log application resend init.
+   *
+   * @param string $applicationId
+   *   The application id.
+   */
+  private function logApplicationResendInit(string $applicationId): void {
+    $placeholders = ['@applicationId' => $applicationId];
+    $this->logger(self::LOGGER_CHANNEL)
+      ->info('Application resend init for: @applicationId', $placeholders);
+  }
+
+  /**
+   * Handle situation when application is not found.
+   *
+   * @param array $placeholders
+   *   Placeholders.
+   * @param \Drupal\Core\Form\FormStateInterface $formState
+   *   Form state.
+   *
+   * @return void
+   *   Void.
+   */
+  private function handleApplicationNotFound(array $placeholders, FormStateInterface $formState): void {
+    $this->messenger()
+      ->addWarning($this->t('No application found for id: @applicationId', $placeholders));
+    $this->logger(self::LOGGER_CHANNEL)
+      ->warning('No application found for id: @applicationId', $placeholders);
+
+    $formState->setRebuild();
+  }
+
+  /**
+   * Process attachments for removal.
+   *
+   * @param \Drupal\helfi_atv\AtvDocument $atvDoc
+   *   The ATV document.
+   * @param array $placeholders
+   *   Placeholders.
+   *
+   * @return void
+   *   Void.
+   */
+  private function processAttachments(AtvDocument $atvDoc, array $placeholders): void {
+    $attachments = $atvDoc->getAttachments();
+    $appEnv = $atvDoc->getMetadata()['appenv'];
+    $content = $atvDoc->getContent();
+    $events = $content['events'];
+    $attachmentInfo = $content['attachmentsInfo']['attachmentsArray'];
+
+    foreach ($attachments as $attachment) {
+      if ($this->areAttachmentsOk($events, $attachment, $attachmentInfo, $appEnv)['form'] === FALSE) {
+        $this->updateIntegrationIdForAttachment($attachment, $attachmentInfo, $appEnv);
+      }
+    }
+
+    $content['attachmentsInfo']['attachmentsArray'] = $attachmentInfo;
+    $atvDoc->setContent($content);
+
+    $this->messenger()
+      ->addStatus($this->t('Application found: @applicationId', $placeholders));
+  }
+
+  /**
+   * Update integation id for attachment.
+   *
+   * @param array $attachment
+   *   The attachment.
+   * @param array $attachmentInfo
+   *   The attachment info.
+   * @param string $appEnv
+   *   The application environment for this application.
+   *
+   * @return void
+   *   Void.
+   */
+  private function updateIntegrationIdForAttachment(array $attachment, array &$attachmentInfo, string $appEnv): void {
+    $intID = $appEnv . '/' . AttachmentHandlerHelper::cleanIntegrationId($attachment['href']);
+
+    foreach ($attachmentInfo as &$innerArray) {
+      $fileNameMatched = FALSE;
+
+      foreach ($innerArray as &$item) {
+        if ($item['ID'] === 'fileName' && $item['value'] === $attachment['filename']) {
+          $fileNameMatched = TRUE;
+        }
+        if ($fileNameMatched && $item['ID'] === 'integrationID') {
+          $item['value'] = $intID;
+        }
+      }
+    }
+  }
+
+  /**
+   * HAndle exceptions.
+   *
+   * @param \Exception $e
+   *   The exception.
+   *
+   * @return void
+   *   Void.
+   */
+  private function handleException(\Exception $e): void {
+    $uuid = Uuid::uuid4()->toString();
+    $this->messenger()
+      ->addError('Error has occurred and has been logged. ID: @uuid', ['@uuid' => $uuid]);
+    $this->logger(self::LOGGER_CHANNEL)->error(
+      'Error: Admin application forms - Resend error: @error, ID: @uuid',
+      ['@error' => $e->getMessage(), '@uuid' => $uuid]
+    );
   }
 
   /**
@@ -463,6 +602,175 @@ class ResendApplicationsForm extends AtvFormBase {
 
       $form['status']['messageList'][] = $rowElement;
     }
+  }
+
+  /**
+   * Build attachment list.
+   *
+   * @param \Drupal\helfi_atv\AtvDocument $atvDocument
+   *   The ATV document.
+   * @param array $form
+   *   The form object.
+   */
+  public function buildAttachments(AtvDocument $atvDocument, array &$form): void {
+    $attachments = $atvDocument->getAttachments();
+    $appEnv = $atvDocument->getMetadata()['appenv'];
+    $content = $atvDocument->getContent();
+    $events = $content['events'];
+    $attachmentInfo = $content['attachmentsInfo']['attachmentsArray'];
+
+    foreach ($attachments as $attachment) {
+      $attOk = $this->areAttachmentsOk($events, $attachment, $attachmentInfo, $appEnv);
+
+      $rowElement = [
+        'id' => [
+          '#markup' => $attachment['id'],
+        ],
+        'created' => [
+          '#markup' => $attachment['created_at'],
+        ],
+        'filename' => [
+          '#markup' => $attachment['filename'],
+        ],
+        'integrationId' => [
+          '#markup' => '/' . $appEnv . AttachmentHandlerHelper::cleanIntegrationId($attachment['href']),
+        ],
+        'formOk' => [
+          '#markup' => $attOk['form']
+            ? $this->t('Yes', [], self::$tOpts)
+            : $this->t('No', [], self::$tOpts),
+        ],
+        'handlerOk' => [
+          '#markup' => $attOk['handler']
+            ? $this->t('Yes', [], self::$tOpts)
+            : $this->t('No', [], self::$tOpts),
+        ],
+        'avus2Ok' => [
+          '#markup' => $attOk['avus2']
+            ? $this->t('Yes', [], self::$tOpts)
+            : $this->t('No', [], self::$tOpts),
+        ],
+      ];
+
+      $form['status']['attachmentList'][] = $rowElement;
+    }
+  }
+
+  /**
+   * Try to figure our if attachments are ok.
+   *
+   * @param mixed $events
+   *   Events.
+   * @param mixed $attachment
+   *   Attachment.
+   * @param mixed $attachmentInfo
+   *   Attachment info.
+   * @param mixed $appEnv
+   *   Application environment.
+   *
+   * @return array
+   *   Array of booleans.
+   */
+  public function areAttachmentsOk(mixed $events, mixed $attachment, mixed $attachmentInfo, mixed $appEnv): array {
+    $handlerOk = $this->filterEventsByTypeAndFilename($events, 'HANDLER_ATT_OK', $attachment['filename']);
+    $avus2Ok = $this->filterEventsByTypeAndFilename($events, 'AVUSTUS2_ATT_OK', $attachment['filename']);
+
+    $formOk = $this->checkAttachmentInfo($attachmentInfo, $attachment, $appEnv);
+
+    return [
+      'handler' => !empty($handlerOk),
+      'avus2' => !empty($avus2Ok),
+      'form' => !empty($formOk),
+    ];
+  }
+
+  /**
+   * Filter events.
+   *
+   * @param array $events
+   *   Events.
+   * @param string $eventType
+   *   Event type.
+   * @param string $filename
+   *   Filename.
+   *
+   * @return array
+   *   Filtered events.
+   */
+  private function filterEventsByTypeAndFilename(array $events, string $eventType, string $filename): array {
+    return array_filter($events, function ($event) use ($eventType, $filename) {
+      return $event['eventType'] === $eventType && $event['eventTarget'] === $filename;
+    });
+  }
+
+  /**
+   * Check attachment info for existing intergation ID.
+   *
+   * @param mixed $attachmentInfo
+   *   Attachment info.
+   * @param mixed $attachment
+   *   Attachment.
+   * @param mixed $appEnv
+   *   Application environment.
+   *
+   * @return bool
+   *   True if found, false otherwise.
+   */
+  private function checkAttachmentInfo(mixed $attachmentInfo, mixed $attachment, mixed $appEnv): bool {
+    if (!is_array($attachmentInfo)) {
+      return FALSE;
+    }
+
+    foreach ($attachmentInfo as $info) {
+      $filenameFound = $this->findValueById($info, 'fileName', $attachment['filename']);
+      $intFound = $this->findIntegrationId($info, $attachment, $appEnv);
+
+      if ($filenameFound && $intFound) {
+        return TRUE;
+      }
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Find value by id.
+   *
+   * @param array $info
+   *   Info.
+   * @param string $id
+   *   Id.
+   * @param string $value
+   *   Value.
+   *
+   * @return bool
+   *   True if found, false otherwise.
+   */
+  private function findValueById(array $info, string $id, string $value): bool {
+    foreach ($info as $item) {
+      if ($item['ID'] === $id && $item['value'] === $value) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Find integration id.
+   *
+   * @param array $info
+   *   Info.
+   * @param mixed $attachment
+   *   Attachment.
+   * @param mixed $appEnv
+   *   Application environment.
+   *
+   * @return bool
+   *   True if found, false otherwise.
+   */
+  private function findIntegrationId(array $info, mixed $attachment, mixed $appEnv): bool {
+    $targetId = '/' . $appEnv . AttachmentHandlerHelper::cleanIntegrationId($attachment['href']);
+    return $this->findValueById($info, 'integrationID', $targetId);
   }
 
 }

--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -612,6 +612,12 @@ class GrantsAttachments extends WebformCompositeBase {
       // If not, then brute force value from form.
       if (empty($formFiletype) && $formFiletype !== '0') {
         foreach (self::recursiveFind($form, $webformKey) as $value) {
+          // If user has removed file and then readded it to element, there's
+          // one empty element in the value array, and that resulted in missing
+          // integrationID in document json. So we need to check if the
+          // #filetype actually exists and use it only in the case it does.
+          // But since this is always the same file element, the filetype is
+          // same in every iteration of the fields' values.
           if ($value != NULL && $value['#filetype'] != '') {
             $formFiletype = $value['#filetype'];
           }

--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -14,8 +14,11 @@ use Drupal\file\Entity\File;
 use Drupal\grants_attachments\AttachmentHandlerHelper;
 use Drupal\grants_handler\GrantsErrorStorage;
 use Drupal\grants_handler\Helpers;
+use Drupal\helfi_atv\AtvDocumentNotFoundException;
+use Drupal\helfi_atv\AtvFailedToConnectException;
 use Drupal\webform\Element\WebformCompositeBase;
 use Drupal\webform\Utility\WebformElementHelper;
+use GuzzleHttp\Exception\GuzzleException;
 
 /**
  * Provides a 'grants_attachments'.
@@ -257,6 +260,7 @@ class GrantsAttachments extends WebformCompositeBase {
       '#element_validate' => [
         '\Drupal\grants_attachments\Element\GrantsAttachments::validateUpload',
         [self::class, 'validateAttachmentRequired'],
+        [self::class, 'validateAttachmentRemoval'],
       ],
     ];
 
@@ -447,6 +451,59 @@ class GrantsAttachments extends WebformCompositeBase {
   }
 
   /**
+   * Delete file attachment from ATV when removing it from form.
+   *
+   * @param array $element
+   *   Element to be validated.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Form state.
+   * @param array $form
+   *   The form.
+   */
+  public static function validateAttachmentRemoval(array &$element, FormStateInterface $form_state, array &$form): void {
+    $triggeringElement = $form_state->getTriggeringElement();
+
+    // Check if the triggering element is the "Remove" button.
+    if (str_contains($triggeringElement['#name'], '_attachment_remove_button')) {
+      $ename = $element['#name'];
+      $ename_exp = explode('[', $ename);
+      $file_fid = $form_state->getValue($ename_exp[0])['attachment'];
+
+      if ($file_fid) {
+        // Get stored files.
+        $storage = $form_state->getStorage();
+
+        // Check if we have stored information about this file.
+        if (isset($storage['fids_info'][$file_fid])) {
+          // Get integrationID from stored information.
+          $integrationID = $storage['fids_info'][$file_fid]['integrationID'];
+          // Clean integrationID for deletion.
+          $cleanIntegrationId = AttachmentHandlerHelper::cleanIntegrationId(
+            $integrationID
+          );
+
+          /** @var \Drupal\helfi_atv\AtvService $atvService */
+          $atvService = \Drupal::service('helfi_atv.atv_service');
+          $logger = \Drupal::logger('grants_attachments');
+          try {
+            // Try to remove attachment from ATV.
+            $atvService->deleteAttachmentViaIntegrationId($cleanIntegrationId);
+          }
+          catch (AtvDocumentNotFoundException | AtvFailedToConnectException | GuzzleException $e) {
+            // Log error.
+            $logger
+              ->error('Deletion failed for integrationID: @integrationID, @error',
+              [
+                '@integrationID' => $cleanIntegrationId,
+                '@error' => $e->getMessage(),
+              ]);
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Validate & upload file attachment.
    *
    * @param array $element
@@ -555,7 +612,7 @@ class GrantsAttachments extends WebformCompositeBase {
       // If not, then brute force value from form.
       if (empty($formFiletype) && $formFiletype !== '0') {
         foreach (self::recursiveFind($form, $webformKey) as $value) {
-          if ($value != NULL) {
+          if ($value != NULL && $value['#filetype'] != '') {
             $formFiletype = $value['#filetype'];
           }
         }

--- a/public/modules/custom/grants_handler/src/EventsService.php
+++ b/public/modules/custom/grants_handler/src/EventsService.php
@@ -59,6 +59,7 @@ class EventsService {
    */
   public array $eventTypes = [
     'AVUSTUS2_MSG_OK' => 'AVUSTUS2_MSG_OK',
+    'AVUSTUS2_ATT_OK' => 'AVUSTUS2_ATT_OK',
     'STATUS_UPDATE' => 'STATUS_UPDATE',
     'MESSAGE_AVUS2' => 'MESSAGE_AVUS2',
     'MESSAGE_APP' => 'MESSAGE_APP',


### PR DESCRIPTION
# [UHF-10550](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10550)
<!-- What problem does this solve? -->

When user added attachment and then removed it, the next uploaded attachment was missing integrationID that broke Avus2 downloads. This PR fixes that and adds functionality to fix integrationID's in resending process.

## What was done
<!-- Describe what was done -->

* The form now works with removal of files and readding them to form -> integrationID's are present.
* Adds functionality to check possibly missing integratinID's in resend process.
* Refactor ResendForm to make Sonar happy

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout hotfix/UHF-10550`
  * `make fresh`
  * * Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

The first part is easy, just check that the integrationID is present in application in ATV and you're done.

* [x] Add any application and add & remove & re-add files and see that they still have integrationID present.

The 2nd part is tougher, and probably we're not able to test this resending.
* [ ] Add an application as a DRAFT
* [ ] Ask Janne to remove some integrationID's directly from ATV
* [ ] Send application to Avus2
* [ ] Ask Tero to verify than the application doesn't come through to Avus2
* [ ] Try resending application from /fi/admin/tools/resend-applications
* [ ] Ask Tero to reimport application, see that attachments come through
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [x] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10550]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ