### PR TITLE
UHF-10750: Add check for missing label text

### DIFF
--- a/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
@@ -637,13 +637,7 @@ class ResendApplicationsForm extends AtvFormBase {
       $attOk = $this->areAttachmentsOk($events, $attachment, $attachmentInfo, $appEnv);
 
       $fieldInfo = $this->findByFilename($attachment, $attachmentInfo);
-
-      // Sometimes fieldInfo is null so we need to check for that so the next method won't fail.
-      if (is_array($fieldInfo)) {
-        $fieldLabel = $this->extractFieldValue($fieldInfo, 'description');
-      } else {
-        $fieldLabel = '';
-      }
+      $fieldLabel = (string)$this->extractFieldValue($fieldInfo, 'description');
 
       $rowElement = [
         'field' => [
@@ -722,7 +716,7 @@ class ResendApplicationsForm extends AtvFormBase {
       }
     }
     // Return null if no match is found.
-    return NULL;
+    return [];
   }
 
   /**

--- a/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
@@ -637,7 +637,13 @@ class ResendApplicationsForm extends AtvFormBase {
       $attOk = $this->areAttachmentsOk($events, $attachment, $attachmentInfo, $appEnv);
 
       $fieldInfo = $this->findByFilename($attachment, $attachmentInfo);
-      $fieldLabel = $this->extractFieldValue($fieldInfo, 'description');
+
+      // Sometimes fieldInfo is null so we need to check for that so the next method won't fail.
+      if (is_array($fieldInfo)) {
+        $fieldLabel = $this->extractFieldValue($fieldInfo, 'description');
+      } else {
+        $fieldLabel = '';
+      }
 
       $rowElement = [
         'field' => [


### PR DESCRIPTION
# [UHF-10750](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10750)
<!-- What problem does this solve? -->

Resending of applications failed with 500 error if there is no file & label present. We add simple check for the array so that in this case code won't error.

## What was done
<!-- Describe what was done -->

* Add check for method to not send null items 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout hotfix/UHF-10750`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] This is hard to test since we need special circumstances to be able to test this at all.
* [ ] Check that code follows our standards




[UHF-10750]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ