### PR TITLE
Disallow submitting form while community_practices_business is null

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationHelpers.php
+++ b/public/modules/custom/grants_handler/src/ApplicationHelpers.php
@@ -197,6 +197,11 @@ abstract class ApplicationHelpers {
     $applicationType = $webform->getThirdPartySetting('grants_metadata', 'applicationType');
 
     $latestApplicationForm = self::getLatestApplicationForm($applicationType);
+
+    if (!$latestApplicationForm) {
+      return FALSE;
+    }
+
     $parent = $latestApplicationForm->getThirdPartySetting('grants_metadata', 'parent');
     $hasBreakingChanges = $latestApplicationForm->getThirdPartySetting('grants_metadata', 'avus2BreakingChange');
 

--- a/public/modules/custom/grants_metadata/src/DocumentContentMapper.php
+++ b/public/modules/custom/grants_metadata/src/DocumentContentMapper.php
@@ -218,7 +218,7 @@ class DocumentContentMapper {
    *   Typed data values.
    */
   private static function processBusinessPractice(array &$typedDataValues): void {
-    if (isset($typedDataValues['community_practices_business'])) {
+    if (isset($typedDataValues['community_practices_business']) && $typedDataValues['community_practices_business'] !== null) {
       $typedDataValues['community_practices_business'] = $typedDataValues['community_practices_business'] === 'true' ? 1 : 0;
     }
   }

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/ApplicationDefinitionTrait.php
@@ -341,7 +341,8 @@ trait ApplicationDefinitionTrait {
       ->setSetting('typeOverride', [
         'dataType' => 'string',
         'jsonType' => 'bool',
-      ]);
+      ])
+      ->addConstraint('NotBlank');
 
     $info['additional_information'] = DataDefinition::create('string')
       ->setSetting('jsonPath', ['compensation', 'additionalInformation'])


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)

User was able to submit form without ticking community_practices_business option. Fixed by making form validation stricter.

## What was done

- Fix logic that sets the value when not present
- Make validation stricter

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout origin/fix_community_practices_business_submit`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

- Log in with Suomi.fi authentication https://hel-fi-drupal-grant-applications.docker.so/fi/user/login
- 

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

