### PR TITLE
fix: UHF-10813: Remove SUBMITTED status from editable list.

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationStatusService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationStatusService.php
@@ -108,7 +108,6 @@ final class ApplicationStatusService implements ContainerInjectionInterface {
 
     if (in_array($submissionStatus, [
       $statuses['DRAFT'],
-      $statuses['SUBMITTED'],
       $statuses['RECEIVED'],
       $statuses['PREPARING'],
     ])) {


### PR DESCRIPTION
# [UHF-10813](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10813)
<!-- What problem does this solve? -->

It seems that at some SUBMITTED status has slipped to application statuses that were allowed to be edited. This is definitely something we don't want. This PR fixes it.

## What was done
<!-- Describe what was done -->

* Removed SUBMITTED from allowed statuses for editing form.




[UHF-10813]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ