### PR TITLE
fix: UHF-10813: Hide edit button for application if saving process is not completed

### DIFF
--- a/public/modules/custom/grants_admin_applications/src/Form/AtvFormBase.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/AtvFormBase.php
@@ -140,7 +140,6 @@ abstract class AtvFormBase extends FormBase {
     // application testing in problematic cases.
     $headers['X-hki-UpdateSource'] = 'RESEND';
 
-
     $content = $atvDoc->getContent();
     $status = $atvDoc->getStatus();
     $content['formUpdate'] = TRUE;

--- a/public/modules/custom/grants_admin_applications/src/Form/AtvFormBase.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/AtvFormBase.php
@@ -136,6 +136,11 @@ abstract class AtvFormBase extends FormBase {
     $headers['X-hki-appEnv'] = Helpers::getAppEnv();
     $headers['X-hki-applicationNumber'] = $applicationId;
 
+    // We set the data source for integration to be used in controlling
+    // application testing in problematic cases.
+    $headers['X-hki-UpdateSource'] = 'RESEND';
+
+
     $content = $atvDoc->getContent();
     $status = $atvDoc->getStatus();
     $content['formUpdate'] = TRUE;

--- a/public/modules/custom/grants_handler/src/ApplicationStatusService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationStatusService.php
@@ -108,7 +108,6 @@ final class ApplicationStatusService implements ContainerInjectionInterface {
 
     if (in_array($submissionStatus, [
       $statuses['DRAFT'],
-      $statuses['SUBMITTED'],
       $statuses['RECEIVED'],
       $statuses['PREPARING'],
     ])) {

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -218,7 +218,7 @@ final class ApplicationUploaderService {
       // We set the data source for integration to be used in controlling
       // application testing in problematic cases.
       $headers['X-hki-UpdateSource'] = 'USER';
-      
+
       // Current environment as a header to be added to meta -fields.
       $headers['X-hki-appEnv'] = Helpers::getAppEnv();
       // Set application number to meta as well to enable better searches.

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -215,6 +215,10 @@ final class ApplicationUploaderService {
 
       $headers['X-Case-Status'] = $updatedDocumentFromAtv->getStatus();
 
+      // We set the data source for integration to be used in controlling
+      // application testing in problematic cases.
+      $headers['X-hki-UpdateSource'] = 'USER';
+      
       // Current environment as a header to be added to meta -fields.
       $headers['X-hki-appEnv'] = Helpers::getAppEnv();
       // Set application number to meta as well to enable better searches.

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -809,6 +809,8 @@ class GrantsHandler extends WebformHandlerBase {
 
     $form["elements"]["2_avustustiedot"]["avustuksen_tiedot"]["acting_year"]["#options"] = $this->applicationActingYears;
 
+    $dataIntegrityStatus = '';
+
     if ($this->applicationNumber) {
       $dataIntegrityStatus = $this->applicationDataService->validateDataIntegrity(
         $submissionData,
@@ -868,7 +870,7 @@ moment and reload the page.',
     if (!$this->applicationStatusService->isSubmissionChangesAllowed($webform_submission)) {
 
       $status = $this->applicationStatusService->getWebformStatus($webform_submission->getWebform());
-
+      $errorMsg = '';
       switch ($status) {
         case 'archived':
           $errorMsg = $this->t('The application form has changed, make a new application.');
@@ -876,13 +878,19 @@ moment and reload the page.',
           break;
 
         default:
-          $errorMsg = $this->t('Application period is closed. You can edit the draft, but not submit it.');
+          // We show integrity error earlier, so suppress error here.
+          if($dataIntegrityStatus == 'OK') {
+            $errorMsg = $this->t('Application period is closed. You can edit the draft, but not submit it.');
+          }
+
           $form['actions']['submit']['#disabled'] = TRUE;
           break;
       }
 
-      $this->messenger()
-        ->addError($errorMsg);
+      if ($errorMsg != '') {
+        $this->messenger()
+          ->addError($errorMsg);
+      }
     }
 
     $all_current_errors = $this->grantsFormNavigationHelper->getAllErrors($webform_submission);

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -879,7 +879,7 @@ moment and reload the page.',
 
         default:
           // We show integrity error earlier, so suppress error here.
-          if($dataIntegrityStatus == 'OK') {
+          if ($dataIntegrityStatus == 'OK') {
             $errorMsg = $this->t('Application period is closed. You can edit the draft, but not submit it.');
           }
 


### PR DESCRIPTION
# [UHF-10813](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10813)
<!-- What problem does this solve? -->

We used to show "Edit" button for user even if saving process to ATV / Avus2 wasn't finished. We allowed user to access form, but every field & submit button was disabled.

This behavior was considered confusing for end user, so we removed the "Edit" button from application view page. Now user gets to see the form only if the process is completed.

## What was done
<!-- Describe what was done -->

* Removed SUBMITTED status from allowed edit statuses.
* Fixed error message that was shown if underlying form had newer version. This functionality relied on SUBMITTED status being on allowed list.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/UHF-10813-submitted-editable`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

This again is very difficult to test without disabling sending of applications manually from [ConfigMap](https://console-openshift-console.apps.arodevtest.hel.fi/k8s/ns/hki-kanslia-avustus-integration-test/configmaps/drupal-avustus-config-map). Sadly only Ilkka seems to have permissions to do that.

So I'm suggesting looking through the code, testing normal operation locally and then to finish testing in STAGE env by PO.

* [ ] Check that code follows our standards



[UHF-10813]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ