### PR TITLE
fix: UHF-10142: Allow "Delete" button to show on RECEIVED applications when navigating on the form.

### DIFF
--- a/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Element/GrantsAttachments.php
@@ -176,7 +176,7 @@ class GrantsAttachments extends WebformCompositeBase {
           && $applicationStatusService->isSubmissionEditable($submission)
         ) {
           // By default we allow deletion of the attachment if submission is
-          // editable AND the file type is not 45 (other file).
+          // editable AND the file type is not 45 (account confirmation).
           $showDeleteButton = TRUE;
 
           // But since the attachments currently work differently than the other


### PR DESCRIPTION
# [UHF-10142](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10142)
<!-- What problem does this solve? -->

There was a bug in the delete button code for RECEIVED applications that hid the button when user is navigating from one page to another and back to attachment page.

This PR allows that button to be shown, but also makes sure that the button is shown ONLY for justUploaded files. If files are sent to Avus2 they are not allowed to be deleted.

Pretty much this bugfix is useless until [ATV-181](https://helsinkisolutionoffice.atlassian.net/browse/ATV-181) gets resolved. So even after this PR we fix Webform related issues, the file still is left on the ATV Document in production since the content policies do not allow files to be deleted from documents where `draft: false`

## What was done
<!-- Describe what was done -->

* Conditions for showing delete button were updated to use isSubmissionEditable() functionality
* An extra check was added to allow file removal if status is RECEIVED, but only for just added files after visiting different form pages.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout feature/UHF-10142-files-browsing`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

This is currently installed to [DEV ](https://avustukset.dev.hel.ninja/) environment. If tested quickly no need to run locally.

* [x] Login & fill any application, eg [this](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/muut-avustukset/kaupunginhallitus-yleisavustus)
* [x] Leave files empty, click checkboxes to allow sending of the application without uploading attachments
* [x] After you've gotten the RECEIVED status go back to form and add one file to any of the attachment fields, navigate to other pages and come back to attachment page and see that remove button is still available.
* [x] Add couple more files, but not all. Send application.
* [x] Go back to the form, see that files sent are not removable.
* [x] Add more files and browse form. See that only recently added files are removable
* [x] Fill another applicatoin, only to DRAFT this time. Make sure all files (except account confirmation) are removable.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [x] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10142]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ATV-181]: https://helsinkisolutionoffice.atlassian.net/browse/ATV-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ