### PR TITLE
feat: UHF-XXXX: Fix failing tests by fixing dependency-related errors.

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -49,12 +49,12 @@ module:
   flysystem: 0
   focal_point: 0
   gin_toolbar: 0
+  grants_events: 0
   grant_applications_content: 0
   grant_applications_noscript: 0
   grants_admin_applications: 0
   grants_applicant_info: 0
   grants_application_search: 0
-  grants_attachments: 0
   grants_audit_log: 0
   grants_budget_components: 0
   grants_club_section: 0
@@ -217,9 +217,10 @@ module:
   webform_translation_permissions: 0
   webform_ui: 0
   webform_views: 0
-  grants_handler: 1
+  grants_attachments: 1
   menu_admin_per_menu: 1
   pathauto: 1
+  grants_handler: 2
   content_translation: 10
   externalauth: 10
   views: 10

--- a/public/modules/custom/grants_admin_applications/src/Form/AtvFormBase.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/AtvFormBase.php
@@ -10,9 +10,9 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\grants_attachments\AttachmentFixerService;
+use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationGetterService;
 use Drupal\grants_handler\ApplicationHelpers;
-use Drupal\grants_handler\EventsService;
 use Drupal\grants_handler\Helpers;
 use Drupal\grants_handler\MessageService;
 use Drupal\helfi_atv\AtvDocument;
@@ -62,7 +62,7 @@ abstract class AtvFormBase extends FormBase {
       $container->get('database'),
       $container->get('grants_handler.application_getter_service'),
       $container->get('http_client'),
-      $container->get('grants_handler.events_service'),
+      $container->get('grants_events.events_service'),
       $container->get('helfi_atv.atv_service'),
       $container->get('grants_handler.message_service'),
       $container->get('current_user'),

--- a/public/modules/custom/grants_attachments/grants_attachments.info.yml
+++ b/public/modules/custom/grants_attachments/grants_attachments.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - webform
   - grants_metadata
+  - grants_events
 
 'interface translation project': grants_attachments
 'interface translation server pattern': modules/custom/grants_attachments/translations/%language.po

--- a/public/modules/custom/grants_attachments/grants_attachments.info.yml
+++ b/public/modules/custom/grants_attachments/grants_attachments.info.yml
@@ -6,7 +6,6 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - webform
   - grants_metadata
-  - grants_handler
 
 'interface translation project': grants_attachments
 'interface translation server pattern': modules/custom/grants_attachments/translations/%language.po

--- a/public/modules/custom/grants_attachments/grants_attachments.services.yml
+++ b/public/modules/custom/grants_attachments/grants_attachments.services.yml
@@ -26,11 +26,12 @@ services:
       '@helfi_atv.atv_service',
       '@grants_profile.service',
       '@grants_metadata.atv_schema',
-      '@grants_events.events_service',
       '@helfi_audit_log.audit_log',
       '@entity_type.manager',
       '@grants_metadata.application_data_service'
     ]
+    calls:
+      - [ setEventsService, [ '@?grants_events.events_service' ] ]
 
   grants_attachments.attachment_fixer_service:
     class: Drupal\grants_attachments\AttachmentFixerService

--- a/public/modules/custom/grants_attachments/grants_attachments.services.yml
+++ b/public/modules/custom/grants_attachments/grants_attachments.services.yml
@@ -26,7 +26,7 @@ services:
       '@helfi_atv.atv_service',
       '@grants_profile.service',
       '@grants_metadata.atv_schema',
-      '@grants_handler.events_service',
+      '@grants_events.events_service',
       '@helfi_audit_log.audit_log',
       '@entity_type.manager',
       '@grants_metadata.application_data_service'

--- a/public/modules/custom/grants_attachments/src/AttachmentHandler.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentHandler.php
@@ -72,7 +72,7 @@ class AttachmentHandler {
    *
    * @var \Drupal\grants_events\EventsService
    */
-  protected EventsService $eventsService;
+  protected EventsService $eventService;
 
   /**
    * Constructs an AttachmentHandler object.
@@ -124,7 +124,7 @@ class AttachmentHandler {
    *   Events service.
    */
   public function setEventsService(EventsService $eventsService): void {
-    $this->eventsService = $eventsService;
+    $this->eventService = $eventsService;
   }
 
   /**

--- a/public/modules/custom/grants_attachments/src/AttachmentHandler.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentHandler.php
@@ -12,10 +12,10 @@ use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\TempStore\TempStoreException;
 use Drupal\grants_attachments\Plugin\WebformElement\GrantsAttachments;
+use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationHelpers;
 use Drupal\grants_handler\DebuggableTrait;
 use Drupal\grants_handler\EventException;
-use Drupal\grants_handler\EventsService;
 use Drupal\grants_handler\Helpers;
 use Drupal\grants_metadata\ApplicationDataService;
 use Drupal\grants_metadata\AtvSchema;
@@ -82,7 +82,7 @@ class AttachmentHandler {
    *   Profile service.
    * @param \Drupal\grants_metadata\AtvSchema $atvSchema
    *   ATV schema.
-   * @param \Drupal\grants_handler\EventsService $eventService
+   * @param \Drupal\grants_events\EventsService $eventService
    *   Events service.
    * @param \Drupal\helfi_audit_log\AuditLogService $auditLogService
    *   Audit log mandate errors.

--- a/public/modules/custom/grants_attachments/src/AttachmentHandler.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentHandler.php
@@ -68,6 +68,13 @@ class AttachmentHandler {
   protected EntityStorageInterface $fileStorage;
 
   /**
+   * Events service.
+   *
+   * @var \Drupal\grants_events\EventsService
+   */
+  protected EventsService $eventsService;
+
+  /**
    * Constructs an AttachmentHandler object.
    *
    * @param \Drupal\grants_attachments\AttachmentRemover $grants_attachments_attachment_remover
@@ -82,8 +89,6 @@ class AttachmentHandler {
    *   Profile service.
    * @param \Drupal\grants_metadata\AtvSchema $atvSchema
    *   ATV schema.
-   * @param \Drupal\grants_events\EventsService $eventService
-   *   Events service.
    * @param \Drupal\helfi_audit_log\AuditLogService $auditLogService
    *   Audit log mandate errors.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
@@ -101,7 +106,6 @@ class AttachmentHandler {
     protected AtvService $atvService,
     protected GrantsProfileService $grantsProfileService,
     protected AtvSchema $atvSchema,
-    protected EventsService $eventService,
     protected AuditLogService $auditLogService,
     EntityTypeManagerInterface $entityTypeManager,
     protected ApplicationDataService $applicationDataService,
@@ -111,6 +115,16 @@ class AttachmentHandler {
     $this->fileStorage = $entityTypeManager->getStorage('file');
 
     $this->setDebug(NULL);
+  }
+
+  /**
+   * Set the getter service.
+   *
+   * @param \Drupal\grants_events\EventsService $eventsService
+   *   Events service.
+   */
+  public function setEventsService(EventsService $eventsService): void {
+    $this->eventsService = $eventsService;
   }
 
   /**

--- a/public/modules/custom/grants_attachments/src/Controller/GrantsAttachmentsController.php
+++ b/public/modules/custom/grants_attachments/src/Controller/GrantsAttachmentsController.php
@@ -7,10 +7,10 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\grants_attachments\Plugin\WebformElement\GrantsAttachments;
+use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationGetterService;
 use Drupal\grants_handler\ApplicationStatusService;
 use Drupal\grants_handler\ApplicationUploaderService;
-use Drupal\grants_handler\EventsService;
 use Drupal\grants_metadata\ApplicationDataService;
 use Drupal\helfi_atv\AtvService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -34,7 +34,7 @@ class GrantsAttachmentsController extends ControllerBase {
    *   The helfi_atv service.
    * @param \Symfony\Component\HttpFoundation\RequestStack $requestStack
    *   Drupal requests.
-   * @param \Drupal\grants_handler\EventsService $eventsService
+   * @param \Drupal\grants_events\EventsService $eventsService
    *   Use submission events productively.
    * @param \Drupal\grants_handler\ApplicationStatusService $applicationStatusService
    *   Application status service.
@@ -62,7 +62,7 @@ class GrantsAttachmentsController extends ControllerBase {
     return new static(
       $container->get('helfi_atv.atv_service'),
       $container->get('request_stack'),
-      $container->get('grants_handler.events_service'),
+      $container->get('grants_events.events_service'),
       $container->get('grants_handler.application_status_service'),
       $container->get('grants_metadata.application_data_service'),
       $container->get('grants_handler.application_getter_service'),

--- a/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
@@ -5,7 +5,7 @@ namespace Drupal\grants_attachments\Plugin\WebformElement;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\grants_attachments\AttachmentHandler;
 use Drupal\grants_attachments\Element\GrantsAttachments as ElementGrantsAttachments;
-use Drupal\grants_handler\EventsService;
+use Drupal\grants_events\EventsService;
 use Drupal\webform\Plugin\WebformElement\WebformCompositeBase;
 use Drupal\webform\WebformSubmissionInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -79,7 +79,7 @@ final class GrantsAttachments extends WebformCompositeBase {
   /**
    * Events service.
    *
-   * @var \Drupal\grants_handler\EventsService
+   * @var \Drupal\grants_events\EventsService
    */
   protected EventsService $eventsService;
 
@@ -93,7 +93,7 @@ final class GrantsAttachments extends WebformCompositeBase {
     $plugin_definition,
   ): GrantsAttachments {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
-    $instance->eventsService = $container->get('grants_handler.events_service');
+    $instance->eventsService = $container->get('grants_events.events_service');
     return $instance;
   }
 

--- a/public/modules/custom/grants_events/grants_events.info.yml
+++ b/public/modules/custom/grants_events/grants_events.info.yml
@@ -1,0 +1,5 @@
+name: 'grants_events'
+type: module
+description: 'Handle application events'
+package: helfi
+core_version_requirement: ^10 || ^11

--- a/public/modules/custom/grants_events/grants_events.module
+++ b/public/modules/custom/grants_events/grants_events.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Primary module hooks for grants_events module.
+ */

--- a/public/modules/custom/grants_events/grants_events.services.yml
+++ b/public/modules/custom/grants_events/grants_events.services.yml
@@ -1,0 +1,4 @@
+services:
+  grants_events.events_service:
+    class: Drupal\grants_events\EventsService
+    arguments: [ '@http_client', '@logger.factory' ]

--- a/public/modules/custom/grants_events/src/EventException.php
+++ b/public/modules/custom/grants_events/src/EventException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\grants_events;
+
+/**
+ * Exception for Event exceptions.
+ */
+class EventException extends \Exception {
+
+}

--- a/public/modules/custom/grants_events/src/EventsService.php
+++ b/public/modules/custom/grants_events/src/EventsService.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace Drupal\grants_events;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\grants_handler\DebuggableTrait;
+use Drupal\grants_metadata\AtvSchema;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Send event updates to documents via integration.
+ */
+class EventsService {
+
+  use DebuggableTrait;
+
+  /**
+   * The HTTP client.
+   *
+   * @var \GuzzleHttp\Client
+   */
+  protected Client $httpClient;
+
+  /**
+   * Logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface|\Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected LoggerChannelInterface|LoggerChannelFactoryInterface $logger;
+
+  /**
+   * API endopoint.
+   *
+   * @var string
+   */
+  protected string $endpoint;
+
+  /**
+   * Api username.
+   *
+   * @var string
+   */
+  protected string $username;
+
+  /**
+   * Api password.
+   *
+   * @var string
+   */
+  protected string $password;
+
+  /**
+   * Event types that are supported.
+   *
+   * @var array|string[]
+   */
+  public array $eventTypes = [
+    'AVUSTUS2_MSG_OK' => 'AVUSTUS2_MSG_OK',
+    'AVUSTUS2_ATT_OK' => 'AVUSTUS2_ATT_OK',
+    'STATUS_UPDATE' => 'STATUS_UPDATE',
+    'MESSAGE_AVUS2' => 'MESSAGE_AVUS2',
+    'MESSAGE_APP' => 'MESSAGE_APP',
+    'MESSAGE_READ' => 'MESSAGE_READ',
+    'MESSAGE_RESEND' => 'MESSAGE_RESEND',
+    'HANDLER_ATT_OK' => 'HANDLER_ATT_OK',
+    'HANDLER_ATT_DELETE' => 'HANDLER_ATT_DELETE',
+    'HANDLER_RESEND_APP' => 'HANDLER_RESEND_APP',
+    'HANDLER_APP_COPIED' => 'HANDLER_APP_COPIED',
+    'INTEGRATION_INFO_ATT_OK' => 'INTEGRATION_INFO_ATT_OK',
+    'INTEGRATION_INFO_APP_OK' => 'INTEGRATION_INFO_APP_OK',
+    'EVENT_INFO' => 'EVENT_INFO',
+    'HANDLER_ATT_DELETED' => 'HANDLER_ATT_DELETED',
+    'INTEGRATION_ERROR_AVUS2' => 'INTEGRATION_ERROR_AVUS2',
+    'INTEGRATION_ERROR_ATV_ATT' => 'INTEGRATION_ERROR_ATV_ATT',
+  ];
+
+  /**
+   * Constructs a MessageService object.
+   *
+   * @param \GuzzleHttp\Client $http_client
+   *   Client to post data.
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   Log things.
+   */
+  public function __construct(
+    Client $http_client,
+    LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    $this->httpClient = $http_client;
+    $this->logger = $loggerFactory->get('grants_handler_events_service');
+
+    $this->endpoint = getenv('AVUSTUS2_EVENT_ENDPOINT');
+    $this->username = getenv('AVUSTUS2_USERNAME');
+    $this->password = getenv('AVUSTUS2_PASSWORD');
+
+    $this->setDebug(NULL);
+
+  }
+
+  /**
+   * Get event types.
+   *
+   * @return array|string[]
+   *   Event types.
+   */
+  public function getEventTypes(): array {
+    return $this->eventTypes;
+  }
+
+  /**
+   * Log event to document via event integration.
+   *
+   * @param string $applicationNumber
+   *   Application to be logged.
+   * @param string $eventType
+   *   Type of event, must be configured in this class as active one.
+   * @param string $eventDescription
+   *   Free message to be added.
+   * @param string $eventTarget
+   *   Target ID for event.
+   * @param array $eventData
+   *   If we have already built-up event data, use this.
+   *
+   * @return array|null
+   *   EventID if success, otherways NULL
+   *
+   * @throws \Drupal\grants_events\EventException
+   */
+  public function logEvent(
+    string $applicationNumber,
+    string $eventType,
+    string $eventDescription,
+    string $eventTarget,
+    array $eventData = [],
+  ): ?array {
+
+    if (empty($eventData)) {
+      $eventData = self::getEventData($eventType, $applicationNumber, $eventDescription, $eventTarget);
+    }
+
+    $eventDataJson = Json::encode($eventData);
+
+    if (TRUE === $this->debug) {
+      $this->logger->debug(
+        'Event ID: %eventId, JSON:  %json',
+        [
+          '%eventId' => $eventData['eventID'],
+          '%json' => $eventDataJson,
+        ]);
+    }
+
+    try {
+
+      $res = $this->httpClient->post($this->endpoint, [
+        'auth' => [$this->username, $this->password, "Basic"],
+        'body' => $eventDataJson,
+      ]);
+
+      if ($res->getStatusCode() == 200) {
+        $this->logger->info('Event logged: %eventId, message sent.', ['%eventId' => $eventData['eventID']]);
+        return $eventData;
+      }
+
+    }
+    catch (\Exception $e) {
+      throw new EventException($e->getMessage());
+    }
+    catch (GuzzleException $e) {
+      throw new EventException($e->getMessage());
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Filter events by given key.
+   *
+   * @param array $events
+   *   Events to be filtered.
+   * @param string $typeKey
+   *   Event type wanted.
+   *
+   * @return array
+   *   Filtered events.
+   */
+  public function filterEvents(array $events, string $typeKey): array {
+    $messageEvents = array_filter($events, function ($event) use ($typeKey) {
+      if ($event['eventType'] == $this->eventTypes[$typeKey]) {
+        return TRUE;
+      }
+      return FALSE;
+    });
+
+    return [
+      'events' => $messageEvents,
+      'event_targets' => array_column($messageEvents, 'eventTarget'),
+      'event_ids' => array_column($messageEvents, 'eventID'),
+    ];
+  }
+
+  /**
+   * Build event object/array from given data.
+   *
+   * @param string $eventType
+   *   Type of event, must be in self::$eventTypes.
+   * @param string $applicationNumber
+   *   Application number for event.
+   * @param string $eventDescription
+   *   Event description.
+   * @param string $eventTarget
+   *   Eent target.
+   *
+   * @return array
+   *   Event data in array.
+   *
+   * @throws \Drupal\grants_events\EventException
+   */
+  public function getEventData(string $eventType, string $applicationNumber, string $eventDescription, string $eventTarget): array {
+    $eventData = [];
+
+    if (!in_array($eventType, $this->eventTypes)) {
+      throw new EventException('Not valid event type: ' . $eventType);
+    }
+    else {
+      $eventData['eventType'] = $eventType;
+    }
+
+    $eventData['eventID'] = Uuid::uuid4()->toString();
+    $eventData['caseId'] = $applicationNumber;
+    $eventData['eventDescription'] = AtvSchema::sanitizeInput($eventDescription);
+    $eventData['eventTarget'] = $eventTarget;
+
+    if (!isset($eventData['eventSource'])) {
+      $eventData['eventSource'] = getenv('EVENTS_SOURCE');
+    }
+
+    $dt = new \DateTime();
+    $dt->setTimezone(new \DateTimeZone('Europe/Helsinki'));
+
+    $eventData['timeCreated'] = $eventData['timeUpdated'] = $dt->format('Y-m-d\TH:i:s');
+    return $eventData;
+  }
+
+}

--- a/public/modules/custom/grants_handler/grants_handler.install
+++ b/public/modules/custom/grants_handler/grants_handler.install
@@ -216,6 +216,8 @@ function grants_handler_schema(): array {
  *   Name of field.
  * @param int $new_length
  *   New length for field.
+ *
+ * @throws \Exception
  */
 function _module_change_text_field_max_length($entity_type_id, $field_name, $new_length) {
   $name = 'field.storage.' . $entity_type_id . "." . $field_name;
@@ -368,4 +370,12 @@ function grants_handler_update_9008(&$sandbox) {
   \Drupal::database()
     ->schema()
     ->createTable('grants_handler_locks', $schema['grants_handler_locks']);
+}
+
+/**
+ * Install grants_events module.
+ */
+function grants_handler_update_9009(&$sandbox): void {
+  // Enable the grants_attachments module.
+  \Drupal::service('module_installer')->install(['grants_events']);
 }

--- a/public/modules/custom/grants_handler/grants_handler.module
+++ b/public/modules/custom/grants_handler/grants_handler.module
@@ -1289,8 +1289,8 @@ function grants_handler_preprocess_webform_submission_handler_details(&$variable
   $submission = $variables['submission'];
   $submissionData = $submission->getData();
 
-  /** @var \Drupal\grants_handler\EventsService $eventService */
-  $eventService = \Drupal::service('grants_handler.events_service');
+  /** @var \Drupal\grants_events\EventsService $eventService */
+  $eventService = \Drupal::service('grants_events.events_service');
 
   $handlerEvents = array_filter($submissionData['events'], function ($event) use ($eventService) {
     if ($event['eventType'] == $eventService->getEventTypes()['EVENT_INFO']) {
@@ -1314,7 +1314,7 @@ function grants_handler_preprocess_webform_submission_attachment_list(&$variable
   $submissionData = $submission->getData();
 
   // Get submission events.
-  $eventService = \Drupal::service('grants_handler.events_service');
+  $eventService = \Drupal::service('grants_events.events_service');
   $attachmentEventsHandler = $eventService->filterEvents($submissionData['events'], 'HANDLER_ATT_OK');
 
   $attachments = [];

--- a/public/modules/custom/grants_handler/grants_handler.services.yml
+++ b/public/modules/custom/grants_handler/grants_handler.services.yml
@@ -11,7 +11,7 @@ services:
         '@helfi_helsinki_profiili.userdata',
         '@http_client',
         '@logger.factory',
-        '@grants_handler.events_service',
+        '@grants_events.events_service',
         '@helfi_atv.atv_service',
         '@current_user',
         '@grants_handler.application_status_service'
@@ -28,9 +28,7 @@ services:
         '@datetime.time'
     ]
 
-  grants_handler.events_service:
-    class: Drupal\grants_handler\EventsService
-    arguments: [ '@http_client', '@logger.factory' ]
+
 
   grants_handler.form_lock_service:
     class: Drupal\grants_handler\FormLockService

--- a/public/modules/custom/grants_handler/grants_handler.services.yml
+++ b/public/modules/custom/grants_handler/grants_handler.services.yml
@@ -11,11 +11,12 @@ services:
         '@helfi_helsinki_profiili.userdata',
         '@http_client',
         '@logger.factory',
-        '@grants_events.events_service',
         '@helfi_atv.atv_service',
         '@current_user',
         '@grants_handler.application_status_service'
     ]
+    calls:
+      - [ setEventsService, [ '@?grants_events.events_service' ] ]
 
   grants_handler.navigation_helper:
     class: Drupal\grants_handler\GrantsHandlerNavigationHelper
@@ -27,8 +28,6 @@ services:
         '@helfi_helsinki_profiili.userdata',
         '@datetime.time'
     ]
-
-
 
   grants_handler.form_lock_service:
     class: Drupal\grants_handler\FormLockService

--- a/public/modules/custom/grants_handler/src/Controller/MessageController.php
+++ b/public/modules/custom/grants_handler/src/Controller/MessageController.php
@@ -9,10 +9,10 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationGetterService;
 use Drupal\grants_handler\DebuggableTrait;
 use Drupal\grants_handler\EventException;
-use Drupal\grants_handler\EventsService;
 use Drupal\grants_handler\MessageService;
 use Drupal\helfi_atv\AtvService;
 use GuzzleHttp\Exception\GuzzleException;
@@ -33,7 +33,7 @@ class MessageController extends ControllerBase {
   /**
    * The controller constructor.
    *
-   * @param \Drupal\grants_handler\EventsService $eventsService
+   * @param \Drupal\grants_events\EventsService $eventsService
    *   Use submission events productively.
    * @param \Drupal\grants_handler\MessageService $messageService
    *   Use messages productively.
@@ -62,7 +62,7 @@ class MessageController extends ControllerBase {
    */
   public static function create(ContainerInterface $container): MessageController|static {
     return new static(
-      $container->get('grants_handler.events_service'),
+      $container->get('grants_events.events_service'),
       $container->get('grants_handler.message_service'),
       $container->get('request_stack'),
       $container->get('helfi_atv.atv_service'),

--- a/public/modules/custom/grants_handler/src/Form/CopyApplicationModalForm.php
+++ b/public/modules/custom/grants_handler/src/Form/CopyApplicationModalForm.php
@@ -10,11 +10,11 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Renderer;
 use Drupal\Core\Url;
+use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationGetterService;
 use Drupal\grants_handler\ApplicationInitService;
 use Drupal\grants_handler\ApplicationStatusService;
 use Drupal\grants_handler\DebuggableTrait;
-use Drupal\grants_handler\EventsService;
 use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -49,7 +49,7 @@ class CopyApplicationModalForm extends FormBase {
     // Create a new form object and inject its services.
     $form = new static(
       $container->get('renderer'),
-      $container->get('grants_handler.events_service'),
+      $container->get('grants_events.events_service'),
       $container->get('grants_handler.application_status_service'),
       $container->get('grants_handler.application_init_service'),
       $container->get('grants_handler.application_getter_service')

--- a/public/modules/custom/grants_handler/src/MessageService.php
+++ b/public/modules/custom/grants_handler/src/MessageService.php
@@ -104,8 +104,6 @@ class MessageService {
    *   Client to post data.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
    *   Log things.
-   * @param \Drupal\grants_events\EventsService $eventsService
-   *   Log events to atv document.
    * @param \Drupal\helfi_atv\AtvService $atvService
    *   Access to ATV.
    * @param \Drupal\Core\Session\AccountProxyInterface $currentUser

--- a/public/modules/custom/grants_handler/src/MessageService.php
+++ b/public/modules/custom/grants_handler/src/MessageService.php
@@ -9,6 +9,7 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\grants_events\EventsService;
 use Drupal\grants_metadata\AtvSchema;
 use Drupal\helfi_atv\AtvService;
 use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
@@ -47,7 +48,7 @@ class MessageService {
   /**
    * Log events via integration.
    *
-   * @var \Drupal\grants_handler\EventsService
+   * @var \Drupal\grants_events\EventsService
    */
   protected EventsService $eventsService;
 
@@ -103,7 +104,7 @@ class MessageService {
    *   Client to post data.
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $loggerFactory
    *   Log things.
-   * @param \Drupal\grants_handler\EventsService $eventsService
+   * @param \Drupal\grants_events\EventsService $eventsService
    *   Log events to atv document.
    * @param \Drupal\helfi_atv\AtvService $atvService
    *   Access to ATV.

--- a/public/modules/custom/grants_handler/src/MessageService.php
+++ b/public/modules/custom/grants_handler/src/MessageService.php
@@ -117,7 +117,6 @@ class MessageService {
     HelsinkiProfiiliUserData $helfi_helsinki_profiili_userdata,
     Client $http_client,
     LoggerChannelFactoryInterface $loggerFactory,
-    EventsService $eventsService,
     AtvService $atvService,
     AccountProxyInterface $currentUser,
     ApplicationStatusService $applicationStatusService,
@@ -125,7 +124,6 @@ class MessageService {
     $this->helfiHelsinkiProfiiliUserdata = $helfi_helsinki_profiili_userdata;
     $this->httpClient = $http_client;
     $this->logger = $loggerFactory->get('grants_handler_message_service');
-    $this->eventsService = $eventsService;
     $this->atvService = $atvService;
     $this->currentUser = $currentUser;
     $this->applicationStatusService = $applicationStatusService;
@@ -135,6 +133,16 @@ class MessageService {
     $this->password = getenv('AVUSTUS2_PASSWORD');
 
     $this->setDebug(NULL);
+  }
+
+  /**
+   * Set the getter service.
+   *
+   * @param \Drupal\grants_events\EventsService $eventsService
+   *   Events service.
+   */
+  public function setEventsService(EventsService $eventsService): void {
+    $this->eventsService = $eventsService;
   }
 
   /**

--- a/public/modules/custom/grants_handler/tests/src/Kernel/DataConversionTest.php
+++ b/public/modules/custom/grants_handler/tests/src/Kernel/DataConversionTest.php
@@ -43,6 +43,7 @@ class DataConversionTest extends GrantsKernelTestBase implements ServiceModifier
     'helfi_yjdh',
     // Project modules.
     'grants_applicant_info',
+    'grants_events',
     'grants_attachments',
     'grants_budget_components',
     'grants_club_section',

--- a/public/modules/custom/grants_metadata/grants_metadata.services.yml
+++ b/public/modules/custom/grants_metadata/grants_metadata.services.yml
@@ -17,4 +17,4 @@ services:
       '@database'
     ]
     calls:
-      - [ setEventsService, [ '@?grants_handler.events_service' ] ]
+      - [ setEventsService, [ '@?grants_events.events_service' ] ]

--- a/public/modules/custom/grants_metadata/src/ApplicationDataService.php
+++ b/public/modules/custom/grants_metadata/src/ApplicationDataService.php
@@ -7,8 +7,8 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\TypedData\TypedDataInterface;
 use Drupal\grants_attachments\AttachmentHandler;
+use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\DebuggableTrait;
-use Drupal\grants_handler\EventsService;
 use Drupal\grants_handler\Helpers;
 
 /**
@@ -40,7 +40,7 @@ final class ApplicationDataService {
   /**
    * Events service.
    *
-   * @var \Drupal\grants_handler\EventsService
+   * @var \Drupal\grants_events\EventsService
    */
   protected EventsService $eventsService;
 
@@ -63,7 +63,7 @@ final class ApplicationDataService {
   /**
    * Set the getter service.
    *
-   * @param \Drupal\grants_handler\EventsService $eventsService
+   * @param \Drupal\grants_events\EventsService $eventsService
    *   Events service.
    */
   public function setEventsService(EventsService $eventsService): void {

--- a/public/modules/custom/grants_metadata/tests/src/Kernel/AtvSchemaTest.php
+++ b/public/modules/custom/grants_metadata/tests/src/Kernel/AtvSchemaTest.php
@@ -45,6 +45,7 @@ class AtvSchemaTest extends GrantsKernelTestBase implements ServiceModifierInter
     'helfi_yjdh',
     // Project modules.
     'grants_applicant_info',
+    'grants_events',
     'grants_attachments',
     'grants_budget_components',
     'grants_club_section',

--- a/tools/make/project/install.mk
+++ b/tools/make/project/install.mk
@@ -3,7 +3,7 @@ ifeq ($(DRUPAL_CONF_EXISTS),yes)
 else
 	DRUPAL_NEW_TARGETS := up build drush-si drush-helfi-enable-modules drush-locale-update drush-helfi-locale-import drush-unblock drush-uli
 endif
-DRUPAL_POST_INSTALL_TARGETS := drush-locale-update drush-deploy drush-helfi-locale-import drush-unblock
+DRUPAL_POST_INSTALL_TARGETS := drush-deploy drush-locale-update drush-helfi-locale-import drush-unblock
 
 OC_LOGIN_TOKEN ?= $(shell bash -c 'read -s -p "You must obtain an API token by visiting https://oauth-openshift.apps.arodevtest.hel.fi/oauth/token/request (Token):" token; echo $$token')
 

--- a/tools/make/project/zzavustusasiointi.mk
+++ b/tools/make/project/zzavustusasiointi.mk
@@ -60,9 +60,11 @@ drush-sync-db: ## Sync database
 ifeq ($(DUMP_SQL_EXISTS),yes)
 	$(call step,Import local SQL dump...)
 	$(call drush,sql-query --file=${DOCKER_PROJECT_ROOT}/$(DUMP_SQL_FILENAME) && echo 'SQL dump imported')
+	$(call drush,cr -y)
 else
 	$(call step,Sync database from @$(DRUPAL_SYNC_SOURCE)...)
 	$(call drush,sql-sync -y --structure-tables-key=common,key_value_expire @$(DRUPAL_SYNC_SOURCE) @self)
+	$(call drush,cr -y)
 endif
 
 PHONY += drush-create-dump


### PR DESCRIPTION
# [UHF-XXXX](https://helsinkisolutionoffice.atlassian.net/browse/UHF-XXXX)
<!-- What problem does this solve? -->

Some of the latest refactorings created a circular dependency that wasn't issue when `make fresh` was run, but `make new` failed with missing services error. 

This breaks automatic testing because the dump cannot be created when make new fails.

## What was done
<!-- Describe what was done -->

* Fixed circular dependency by refactoring Event handling to separate module and updating all code to use the new module.
* This fixes the make new issue, but make fresh fails because the new module is not installed yet when something needs it.
* I did build the testing artifact with this branch, and the fact that the tests action finishes fine, shows that this fixes the underlying issue with make new.
* Don't really know how Sonar finds the refactoring to be a duplicate code, but it is what it is.


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-0000_insert_correct_branch`
  * `make fresh`
* Run `make drush-cr`
* ![image](https://github.com/user-attachments/assets/5c62098c-6501-43c8-acaa-8116769c8c9d)
No matter what I do, make fresh fails with above error.

I've tried clearing caches in different places, but nothing seems to fix this. When the process fails with above error, one can make shell into the container and run drush deploy there manually. This finishes the process and everything works.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run make new, see that site gets installed
* [ ] Run make fresh, probably will fail with the error above
* [ ] Make shell -> `drush cr && drush deploy`, watch process finish just fine.
* [ ] Check that code follows our standards

