### PR TITLE
fix: UHF-10884: Change postnumero field to textfield and apply pattern.

### DIFF
--- a/conf/cmi/language/en/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/en/webform.webform.kuva_projekti.yml
@@ -199,6 +199,7 @@ elements: |
     '#title': 'Premise name'
   postinumero:
     '#title': 'Postal code'
+    '#pattern_error': 'Please enter a valid 5-digit postal code.'
   kyseessa_on_kaupungin_omistama_tila:
     '#title': 'City owns the property'
     '#options':

--- a/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/language/sv/webform.webform.kuva_projekti.yml
@@ -202,6 +202,7 @@ elements: |
     '#title': Namn
   postinumero:
     '#title': Postnummer
+    '#pattern_error': 'Vänligen ange ett giltigt 5-siffrigt postnummer.'
   kyseessa_on_kaupungin_omistama_tila:
     '#title': 'Stadens eget utrymme'
     '#options':

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -682,12 +682,13 @@ elements: |-
             class:
               - webform--large
         postinumero:
-          '#type': number
+          '#type': textfield
           '#title': Postinumero
           '#attributes':
             class:
               - webform--small
-          '#input_mask': '99999'
+          '#pattern': '^[0-9]{5}$'
+          '#pattern_error': 'Syötä 5 numeroinen postinumero.'
           '#required': true
         kyseessa_on_kaupungin_omistama_tila:
           '#type': radios


### PR DESCRIPTION
# [UHF-10884](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10884)
<!-- What problem does this solve? -->

Somehow post code pattern stopped working in number fields. This makes the field textfield & applies pattern.

## What was done
<!-- Describe what was done -->

* postinumero field to textfield

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10884-fix-postinumero-field`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Checkout this PR
* [ ] Copy the form config via [config import](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/config/development/configuration/single/import)
* [ ] Create new [Kuva projekti](https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/kulttuurin-avustukset/taide-ja-kulttuuriavustukset-projektiavustukset) and see that postal code validation works on page 3
* [ ] Check that code follows our standards

