### PR TITLE
fix: UHF-10656: Fix incorrectly copied transaltions

### DIFF
--- a/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
@@ -87,7 +87,7 @@ elements: |
         '#title': 'Grant issuer'
       issuer_name:
         '#title': 'Issuer''s name'
-        '#help': '<p>Indicate here only the grants received from somewhere other than the City of Helsinki in the current and two previous tax years.</p>'
+        '#help': '<p>Which body has granted the grant (e.g. name of the ministry).</p>'
       year:
         '#title': Year
         '#pattern_error': 'Only numbers'

--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -90,7 +90,7 @@ elements: |
         '#title': Bidragsgivare
       issuer_name:
         '#title': 'Emittentens namn'
-        '#help': '<p>Ange här endast de understöd som beviljats från annanstans än Helsingfors stad under det innevarande beskattningsåret eller de föregående två beskattningsåren.</p>'
+        '#help': '<p>Vilket organ har beviljat bidraget (t.ex. namnet på departementet).</p>'
       year:
         '#title': År
         '#pattern_error': 'Bara siffror'


### PR DESCRIPTION
# [UHF-10656](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10656)
<!-- What problem does this solve? -->

These texts were copied from incorrect place. This fixes that.

## What was done
<!-- Describe what was done -->

* issuer_name fields' tranlations were copied from correct place.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Maybe enough just to check the translations, that they're as [specification](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/KAN/pages/9024929793/Nuorisopalvelu+toiminta-+ja+palkkausavustushakemus#Muut-samaan-tarkoitukseen-my%C3%B6nnetyt-avustukset)


[UHF-10656]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ