### PR TITLE
UHF-10571: Change the order of questions on kuva_projekti webform

### DIFF
--- a/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
+++ b/public/modules/custom/grants_budget_components/src/Element/GrantsBudgetCostStatic.php
@@ -92,7 +92,6 @@ class GrantsBudgetCostStatic extends GrantsBudgetStaticBase {
     $tOpts = ['context' => 'grants_budget_components'];
     return [
       "salaries" => t("Salaries (€)", [], $tOpts),
-      "personnelSideCosts" => t("Personnel costs from salaries and fees (approx. 30%) (€)", [], $tOpts),
       "personnelSocialSecurityCosts" => t("personnelSocialSecurityCosts (€)", [], $tOpts),
       "rentSum" => t("Rents (€)", [], $tOpts),
       "materials" => t("Materials (€)", [], $tOpts),
@@ -119,6 +118,7 @@ class GrantsBudgetCostStatic extends GrantsBudgetStaticBase {
       "netCosts" => t("netCosts (€)", [], $tOpts),
       "performerFees" => t("Salaries and fees for performers and artists (€)", [], $tOpts),
       "otherFees" => t("Other salaries and fees (production, technology, etc.) (€)", [], $tOpts),
+      "personnelSideCosts" => t("Personnel costs from salaries and fees (approx. 30%) (€)", [], $tOpts),
       "generalCosts" => t("generalCosts (€)", [], $tOpts),
       "permits" => t("permits (€)", [], $tOpts),
       "setsAndCostumes" => t("setsAndCostumes (€)", [], $tOpts),


### PR DESCRIPTION
# [UHF-10571](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10571)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Modify the order where questions are asked in budget_cost_static webform element

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10571`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Log in with test user and go to application https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/kulttuurin-avustukset/taide-ja-kulttuuriavustukset-projektiavustukset. Click on the "New application" link on the bottom left corner of the page.
* [x] Skip straight to the step "6. Talous".
* [x] On this page the "Suunnitellut menot" section should have first Palkat ja palkkiot esiintyjille ja taiteilijoille (€), then Muut palkat ja palkkiot (tuotanto, tekniikka jne) (€) and after that Henkilöstösivukulut palkoista ja palkkioista (n. 30%) (€). This is the correct order after this change.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

[UHF-10571]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ