### PR TITLE
UHF-10629: Added rent income composite to webform print controller

### DIFF
--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -13,6 +13,7 @@ use Drupal\grants_members\Element\MembersComposite;
 use Drupal\grants_orienteering_map\Element\OrienteeringMapComposite;
 use Drupal\grants_place_of_operation\Element\PlaceOfOperationComposite;
 use Drupal\grants_premises\Element\PremisesComposite;
+use Drupal\grants_premises\Element\RentIncomeComposite;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\WebformTranslationManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -209,6 +210,7 @@ class GrantsWebformPrintController extends ControllerBase {
       case 'rented_premise_composite':
       case 'premises_composite':
       case 'members_composite':
+      case 'rent_income_composite':
       case 'club_section_composite':
       case 'orienteering_map_composite':
       case 'place_of_operation_composite':
@@ -385,6 +387,7 @@ class GrantsWebformPrintController extends ControllerBase {
       'club_section_composite' => ClubSectionComposite::getCompositeElements($element),
       'orienteering_map_composite' => OrienteeringMapComposite::getCompositeElements($element),
       'place_of_operation_composite' => PlaceOfOperationComposite::getCompositeElements($element),
+      'rent_income_composite' => RentIncomeComposite::getCompositeElements($element),
       'default' => [],
     };
 


### PR DESCRIPTION
# [UHF-10629](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10629)
<!-- What problem does this solve? -->

Fields under Seuran/yhdistyksen saamat vuokrat edellisen kalenterivuoden ajalta 1.1. - 31.12 were not visible ´

## What was done
<!-- Describe what was done -->

* Added rent income composite to webform print controller so that the fields are visible

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10629 `
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://hel-fi-drupal-grant-applications.docker.so/fi/tietoja-avustuksista/liikunta_toiminta_ja_tilankaytto/tulosta and make sure the fields are visible under Seuran/yhdistyksen saamat vuokrat edellisen kalenterivuoden ajalta 1.1. - 31.12
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


[UHF-10629]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ