### PR TITLE
UHF-10722: remove the visibility helper text

### DIFF
--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -185,6 +185,10 @@ class GrantsWebformPrintController extends ControllerBase {
     $element['#title'] = $element['#title'] ?? '';
     $element['#description'] = $element['#description'] ?? '';
 
+    if ($key === 'vuokra_avustushakemuksen_tiedot') {
+      unset($element['markup_01']);
+    }
+
     return $this->alterFieldTemplates($element, $translatedFields);
   }
 

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -185,6 +185,7 @@ class GrantsWebformPrintController extends ControllerBase {
     $element['#title'] = $element['#title'] ?? '';
     $element['#description'] = $element['#description'] ?? '';
 
+    // Remove visibility texts from nuortoimpalkk print form.
     if ($key === 'vuokra_avustushakemuksen_tiedot') {
       unset($element['markup_01']);
     }

--- a/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
+++ b/public/modules/custom/grants_webform_print/src/Controller/GrantsWebformPrintController.php
@@ -188,6 +188,9 @@ class GrantsWebformPrintController extends ControllerBase {
     if ($key === 'vuokra_avustushakemuksen_tiedot') {
       unset($element['markup_01']);
     }
+    if ($key === '4_palkkaustiedot') {
+      unset($element['markup_02']);
+    }
 
     return $this->alterFieldTemplates($element, $translatedFields);
   }


### PR DESCRIPTION
# [UHF-10722](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10722)

Removed the useless visibility text block from the print form: "You don't need to fill this because field Y is false"

[UHF-10722]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ