### PR TITLE
UHF-11076

### DIFF
--- a/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
+++ b/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
@@ -89,7 +89,12 @@ final class AtvPrintViewController extends ControllerBase {
       }
     }
 
-    // Sort the fields based on weight.
+    // Sort the sections inside a page based on section weight.
+    foreach ($newPages as $pageKey => $page) {
+      usort($newPages[$pageKey]['sections'], fn($a, $b) => $a['weight'] > $b['weight']);
+    }
+
+    // Sort the fields inside the sections based on weight.
     foreach ($newPages as $pageKey => $page) {
       foreach ($page['sections'] as $sectionKey => $section) {
         usort($newPages[$pageKey]['sections'][$sectionKey]['fields'], function ($fieldA, $fieldB) {
@@ -122,14 +127,6 @@ final class AtvPrintViewController extends ControllerBase {
         'id' => 'additionalInformationPage',
         'sections' => $sections,
       ];
-    }
-
-    // Reorder the first section of the form in weight order.
-    if (isset($newPages[1]['sections'])) {
-      usort(
-        $newPages[1]['sections'],
-        fn($a, $b) => $a['weight'] > $b['weight']
-      );
     }
 
     // Set correct template.

--- a/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
+++ b/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
@@ -124,6 +124,14 @@ final class AtvPrintViewController extends ControllerBase {
       ];
     }
 
+    // Reorder the first section of the form in weight order.
+    if (isset($newPages[1]['sections'])) {
+      usort(
+        $newPages[1]['sections'],
+        fn($a, $b) => $a['weight'] > $b['weight']
+      );
+    }
+
     // Set correct template.
     return [
       '#theme' => 'grants_handler_print_atv_document',

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -371,12 +371,14 @@ class AtvSchema {
       if (in_array($key, $keys) && !in_array($key, $values)) {
         $values[$key] = $item;
       }
-      if (is_numeric($key) &&
-          !AtvSchema::numericKeys($item) &&
-          isset($item['ID']) &&
-          in_array($item['ID'], $keys) &&
-          !in_array($item['ID'], $values)) {
-        $values[$item['ID']] = $item['value'];
+      if (
+        is_numeric($key) &&
+        !AtvSchema::numericKeys($item) &&
+        isset($item['ID']) &&
+        in_array($item['ID'], $keys) &&
+        !in_array($item['ID'], $values)
+      ) {
+        $values[$item['ID']] = htmlspecialchars_decode($item['value']);
       }
     }
   }

--- a/public/modules/custom/grants_metadata/src/DocumentValueExtractor.php
+++ b/public/modules/custom/grants_metadata/src/DocumentValueExtractor.php
@@ -155,10 +155,12 @@ class DocumentValueExtractor {
       $itemValue = self::processNestedArrayItem($v, $itemPropertyDefinitions);
       if (array_key_exists('value', $v)) {
         $meta = isset($v['meta']) ? json_decode($v['meta'], TRUE) : NULL;
-        $retval[$key][$v['ID']] = InputmaskHandler::convertPossibleInputmaskValue(
-        $itemValue ?? $v['value'],
-        $meta ?? []
+        $value = InputmaskHandler::convertPossibleInputmaskValue(
+          $itemValue ?? $v['value'],
+          $meta ?? []
         );
+
+        $retval[$key][$v['ID']] = htmlspecialchars_decode($value);
       }
       else {
         $retval[$key][$key2] = $itemValue ?? $v;

--- a/public/modules/custom/grants_metadata/src/DocumentValueExtractor.php
+++ b/public/modules/custom/grants_metadata/src/DocumentValueExtractor.php
@@ -212,7 +212,7 @@ class DocumentValueExtractor {
     if ($valueExtractorConfig) {
       $valueExtractorService = self::getDynamicService($valueExtractorConfig['service']);
       $method = $valueExtractorConfig['method'];
-      return $valueExtractorService->$method($item);
+      return htmlspecialchars_decode($valueExtractorService->$method($item));
     }
     return NULL;
   }
@@ -241,7 +241,7 @@ class DocumentValueExtractor {
       if ($valueExtractorConfig) {
         $valueExtractorService = self::getDynamicService($valueExtractorConfig['service']);
         $method = $valueExtractorConfig['method'];
-        return $valueExtractorService->$method($item);
+        return htmlspecialchars_decode($valueExtractorService->$method($item));
       }
     }
     return NULL;

--- a/public/modules/custom/grants_premises/src/GrantsPremisesService.php
+++ b/public/modules/custom/grants_premises/src/GrantsPremisesService.php
@@ -195,7 +195,7 @@ class GrantsPremisesService {
             $value2value = 0;
           }
         }
-        $temp[$value2['ID']] = $value2value;
+        $temp[$value2['ID']] = htmlspecialchars_decode($value2value);
       }
       $returnValueArray[$key] = $temp;
     }


### PR DESCRIPTION
# [UHF-11076](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11076)

Data from ATV printed on text fields had &-signs encoded and showing as &amp;
The actual paper print feature had section 1 fields in incorrect order

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11076`
  * `make fresh`
* Run `make drush-cr`


### `&amp;` to `&`
The &-error was reported from [this form](https://hel-fi-drupal-grant-applications.docker.so/fi/form/nuortoimpalkka)

- Login as a customer
- Add & signs to all text fields possible
- Save as a draft
- Reload the form
- &-signs should be printed instead of the encoded version (&amp;)

### Print layout field order
- Login as a customer (Hopefully you have sent one form submission earlier)
- Try to print one of the sent forms
- The first fields of section 1 should be `form id` and  `status`





[UHF-11076]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ