### PR TITLE
UHF-11127: Fix thrown error when user tries to get form with out uuid

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationGetterService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationGetterService.php
@@ -190,13 +190,22 @@ final class ApplicationGetterService {
         }
 
         $submissionData = $submission->getData();
+        $webform = $submission->getWebform();
+
+        // There's old applications w/o form_uuid, let's add it here
+        // Since we've already loaded webform for submission object the old way,
+        // we should have it here anyways. Just make sure it's in the metadata
+        // as well.
+        if (!isset($submissionData["metadata"]["form_uuid"])) {
+          $submissionData["metadata"]["form_uuid"] = $webform->uuid();
+        }
 
         $submissionData['messages'] = $this->grantsHandlerMessageService->parseMessages($submissionData);
         $submission = [
           '#theme' => $themeHook,
           '#submission' => $submissionData,
           '#document' => $document,
-          '#webform' => $submission->getWebform(),
+          '#webform' => $webform,
           '#submission_id' => $submission->id(),
         ];
 
@@ -390,7 +399,7 @@ final class ApplicationGetterService {
       throw new AtvDocumentNotFoundException('Document not found');
     }
 
-    $uuid = $document->getMetadata()['form_uuid'];
+    $uuid = $document->getMetadata()['form_uuid'] ?? NULL;
 
     if (!$uuid) {
       // And return webform loaded the old way.

--- a/public/modules/custom/grants_handler/src/ApplicationGetterService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationGetterService.php
@@ -260,6 +260,7 @@ final class ApplicationGetterService {
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    * @throws \Drupal\grants_mandate\CompanySelectException
+   * @throws \Drupal\helfi_atv\AtvDocumentNotFoundException
    */
   public function submissionObjectFromApplicationNumber(
     string $applicationNumber,
@@ -377,11 +378,24 @@ final class ApplicationGetterService {
    *
    * @return \Drupal\webform\Entity\Webform
    *   Webform object.
+   *
+   * @throws \Drupal\helfi_atv\AtvDocumentNotFoundException
    */
   public function getWebformFromApplicationNumber(string $applicationNumber): Webform {
     // We need the ATV document to get the form uuid.
     $document = $this->getAtvDocument($applicationNumber);
+
+    if (!$document) {
+      // No document, throw error.
+      throw new AtvDocumentNotFoundException('Document not found');
+    }
+
     $uuid = $document->getMetadata()['form_uuid'];
+
+    if (!$uuid) {
+      // And return webform loaded the old way.
+      return ApplicationHelpers::getWebformFromApplicationNumber($applicationNumber);
+    }
 
     try {
       // Try to load webform via UUID and return it.


### PR DESCRIPTION
# [UHF-11127](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11127)
<!-- What problem does this solve? -->

Old applications created before form_uuid was added do not load and they throw an error.

This affecta ALL applications created before the form_uuid was implemented.

## What was done
<!-- Describe what was done -->

* The handling was fixed so that the missing uuid does not skip old applications.

[UHF-11127]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ