### PR TITLE
UHF-11273: Prevent overriding messages and events

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,6 @@ parameters:
   excludePaths:
     - vendor
   level: 3
-  checkMissingIterableValueType: false
   treatPhpDocTypesAsCertain: false
   scanFiles:
     - ./public/core/themes/engines/twig/twig.engine

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -148,6 +148,7 @@ final class ApplicationUploaderService {
     catch (\Exception $e) {
     }
 
+    // Make sure the form submission won't override ATV-messages or events.
     if ($preventOverride) {
       $atvDocument->mergeWebformContent($appDocumentContent);
     }

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -152,6 +152,7 @@ final class ApplicationUploaderService {
 
     // Make sure the form submission won't override ATV-messages or events.
     if ($preventOverride) {
+      // @phpstan-ignore-next-line
       $atvDocument->mergeWebformContent($appDocumentContent);
     }
     else {

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -130,9 +130,9 @@ final class ApplicationUploaderService {
     $webform_submission = $this->applicationGetterService->submissionObjectFromApplicationNumber($applicationNumber);
 
     $appDocumentContent = $this->helfiAtvAtvSchema->typedDataToDocumentContent(
-        $applicationData,
-        $webform_submission,
-        $submittedFormData
+      $applicationData,
+      $webform_submission,
+      $submittedFormData,
     );
 
     // Make sure we have most recent version of the document.
@@ -151,13 +151,16 @@ final class ApplicationUploaderService {
     }
 
     // Make sure the form submission won't override ATV-messages or events.
-    if ($preventOverride) {
-      // @phpstan-ignore-next-line
-      $atvDocument->mergeWebformContent($appDocumentContent);
+    if (
+      $preventOverride &&
+      isset($appDocumentContent['messages']) &&
+      isset($appDocumentContent['events'])
+    ) {
+      $appDocumentContent['messages'] = $atvDocument->getContent()['messages'];
+      $appDocumentContent['events'] = $atvDocument->getContent()['events'];
     }
-    else {
-      $atvDocument->setContent($appDocumentContent);
-    }
+
+    $atvDocument->setContent($appDocumentContent);
 
     // Try to fix all possibly missing items in attachments.
     $atvDocument = $this->attachmentFixerService->fixAttachmentsOnApplication($atvDocument);

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -305,8 +305,12 @@ final class ApplicationUploaderService {
       }
     }
     catch (\Exception $e) {
-      $tOpts = ['context' => 'grants_handler'];
-      $this->messenger->addError($this->t('Application saving failed, error has been logged.', [], $tOpts));
+      $this->messenger->addError(
+        $this->t('Application saving failed, error has been logged.',
+        [],
+        ['context' => 'grants_handler']),
+      );
+      
       $this->logger->error('Error saving application: %msg', ['%msg' => $e->getMessage()]);
 
       \Sentry\captureException($e);

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -136,7 +136,9 @@ final class ApplicationUploaderService {
     );
 
     // Make sure we have most recent version of the document.
+    /** @var \Drupal\helfi_atv\AtvDocument $atvDocument */
     $atvDocument = $this->applicationGetterService->getAtvDocument($applicationNumber, TRUE);
+
     // Set language for the application.
     $language = $this->languageManager->getCurrentLanguage()->getId();
     $atvDocument->addMetadata('language', $language);

--- a/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationUploaderService.php
@@ -310,9 +310,7 @@ final class ApplicationUploaderService {
         [],
         ['context' => 'grants_handler']),
       );
-      
       $this->logger->error('Error saving application: %msg', ['%msg' => $e->getMessage()]);
-
       \Sentry\captureException($e);
 
       return FALSE;

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1515,7 +1515,8 @@ submit the application only after you have provided all the necessary informatio
 
       // Build application data for sending to Avus2.
       $applicationData = $this->applicationDataService->webformToTypedData(
-        $this->submittedFormData);
+        $this->submittedFormData
+      );
 
       // Upload application via integration.
       $applicationUploadStatus = $this->applicationUploaderService->handleApplicationUploadViaIntegration(

--- a/public/modules/custom/grants_metadata/src/AtvSchema.php
+++ b/public/modules/custom/grants_metadata/src/AtvSchema.php
@@ -12,8 +12,6 @@ use Drupal\webform\Entity\WebformSubmission;
 
 /**
  * Map ATV documents to typed data.
- *
- * Try to trigger SonarCloud with change..
  */
 class AtvSchema {
 


### PR DESCRIPTION
# [UHF-11273](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11273)
Editing and saving an application which is already received by avus2 can lead into a situation where saving the form overrides messages and/or events saved to integration. (since both Avus2 and Drupal writes to ATV)

## What was done
Added a flag which prevents overriding latest ATV changes when saving through integration.


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11273`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Create a new application and wait until it has been received
- Edit the application and save it
  - Save should not override messages or events



[UHF-11273]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ