### PR TITLE
UHF-11222: Add missing translations for content listing view

### DIFF
--- a/conf/cmi/language/fi/views.view.content.yml
+++ b/conf/cmi/language/fi/views.view.content.yml
@@ -4,6 +4,7 @@ display:
       fields:
         langcode:
           label: Kieli
+          separator: ', '
         title:
           label: Otsikko
         type:
@@ -53,8 +54,10 @@ display:
           group_info:
             label: Julkaisutila
             group_items:
-              1:
+              -
                 title: Julkaistu
+              -
+                title: Julkaisematon
         langcode:
           expose:
             label: Kieli


### PR DESCRIPTION
# [UHF-11222](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11222)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add missing translations for content listing view

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11222`
* Run `make drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Make sure your user has site language and admin language set to Finnish in here https://hel-fi-drupal-grant-applications.docker.so/fi/user
* [ ] Next go to https://hel-fi-drupal-grant-applications.docker.so/fi/admin/content and make sure that the "Julkaisutila" filter has options "Julkaistu" and "Julkaisematon". It used to have "Published" and "Julkaistu" which didn't make any sense.
* [ ] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/890
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1166
* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1630

[UHF-11222]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ