### PR TITLE
UHF-11297: empty string on field meta caused a crash

### DIFF
--- a/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
+++ b/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
@@ -159,7 +159,8 @@ final class AtvPrintViewController extends ControllerBase {
    */
   private function transformField(mixed $field, array &$pages, bool &$isSubventionType, string &$subventionType, string $langcode): void {
     if (isset($field['ID'])) {
-      $labelData = json_decode($field['meta'], TRUE);
+      $meta = $field['meta'] ?? '';
+      $labelData = json_decode($meta, TRUE);
       if (!$labelData || $labelData['element']['hidden']) {
         return;
       }


### PR DESCRIPTION
# [UHF-11297](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11297)

Try fixing problem where opening the printing view for already sent application was empty

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11297`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Try with multiple browsers, this bug is hard to recreate
  - Only bug I managed to produce was a white screen caused by trying to json decode null.  
- Log in as end user
- Try opening the print view on all the sent applications
- The application print should be filled with the data always



[UHF-11297]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ