### PR TITLE
UHF-11430: Added alter hooks to use non-core navigation, branding and…

### DIFF
--- a/conf/cmi/language/fi/system.site.yml
+++ b/conf/cmi/language/fi/system.site.yml
@@ -1,1 +1,1 @@
-name: Avustusasiointi
+name: Avustukset

--- a/conf/cmi/language/sv/system.site.yml
+++ b/conf/cmi/language/sv/system.site.yml
@@ -1,1 +1,1 @@
-name: Bidragstjänsten
+name: Understöd

--- a/conf/cmi/system.site.yml
+++ b/conf/cmi/system.site.yml
@@ -2,7 +2,7 @@ _core:
   default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI
 langcode: en
 uuid: c7259448-db95-43bf-9851-b51cf95b0159
-name: 'Grants service'
+name: Grants
 mail: noreply@hel.fi
 slogan: ''
 page:

--- a/public/sites/default/all.services.yml
+++ b/public/sites/default/all.services.yml
@@ -1,0 +1,3 @@
+# Test services and overrides.
+parameters:
+  helfi_api_base.internal_domains: []

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -516,11 +516,11 @@ function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions, $variables):
 
   $element = $variables['elements'];
 
-  if($element['#plugin_id'] === 'system_branding_block') {
+  if ($element['#plugin_id'] === 'system_branding_block') {
     $suggestions[] = 'block__system_branding_block__non_core';
   }
 
-  if($element['#id'] === 'mainnavigation') {
+  if ($element['#id'] === 'mainnavigation') {
     $suggestions[] = 'block__mainnavigation__non_core';
   }
 }
@@ -529,7 +529,7 @@ function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions, $variables):
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function hdbt_subtheme_theme_suggestions_region_alter(array &$suggestions, array $variables) {
-  if($variables['elements']['#region'] === 'header_top') {
+  if ($variables['elements']['#region'] === 'header_top') {
     $suggestions[] = 'region__header_top__non_core';
   }
 }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -508,10 +508,29 @@ function hdbt_subtheme_preprocess_block(&$variables): void {
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
-function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions): void {
+function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions, $variables): void {
   // Load theme suggestions for blocks from parent theme.
   foreach ($suggestions as &$suggestion) {
     $suggestion = str_replace('hdbt_subtheme_', '', $suggestion);
+  }
+
+  $element = $variables['elements'];
+
+  if($element['#plugin_id'] === 'system_branding_block') {
+    $suggestions[] = 'block__system_branding_block__non_core';
+  }
+
+  if($element['#id'] === 'mainnavigation') {
+    $suggestions[] = 'block__mainnavigation__non_core';
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function hdbt_subtheme_theme_suggestions_region_alter(array &$suggestions, array $variables) {
+  if($variables['elements']['#region'] === 'header_top') {
+    $suggestions[] = 'region__header_top__non_core';
   }
 }
 


### PR DESCRIPTION
# [UHF-11430](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11430)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added alter hooks to use new non-core site branding, navigation etc
* Changed site name to be Avustukset, Grants, Understöd
* Fixed hel.fi links to be external

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11430 `
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-11429`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to frontpage and make sure that:
    * [x] There is now external city of helsinki link in the top header left side
    * [x] Next to Helsinki logo is Avustukset and the link goes to avustukset frontpage, the title should be visible in mobile view
    * [x] There isn't "Avustukset" text above main navigation any more
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1205


[UHF-11430]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ