### PR TITLE
UHF-11419: disable copy

### DIFF
--- a/conf/cmi/webform.webform.liikuntaharrastamisen_avustus.yml
+++ b/conf/cmi/webform.webform.liikuntaharrastamisen_avustus.yml
@@ -23,7 +23,7 @@ third_party_settings:
       2025: '2025'
     applicationActingYearsNextCount: ''
     applicationContinuous: 0
-    disableCopying: 0
+    disableCopying: 1
     status: development
     parent: d6a6681d-87e8-4a48-aa5a-cb1c12bd160f
     avus2BreakingChange: 0

--- a/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-information.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/webform/webform-submission-information.html.twig
@@ -40,14 +40,16 @@
     </h4>
     <div class="webform-submission-information__supportlinks">
       {{ printApplicationLink }}
-      <a href="#"
-         class=" hds-button hds-button--supplementary"
-         id="copy-application-button">
-        <span class="hds-button__label_wrapper">
-          <span class="hel-icon hel-icon--copy " role="img" aria-hidden="true"></span>
-          <span class="hds-button__label">{{ copyText }}</span>
-        </span>
-      </a>
+      {% if copyText | render %}
+        <a href="#"
+           class=" hds-button hds-button--supplementary"
+           id="copy-application-button">
+          <span class="hds-button__label_wrapper">
+            <span class="hel-icon hel-icon--copy " role="img" aria-hidden="true"></span>
+            <span class="hds-button__label">{{ copyText }}</span>
+          </span>
+        </a>
+      {% endif %}
     </div>
   </div>
   <div class="webform-submission-information__row webform-submission-information__row-main">


### PR DESCRIPTION
# [UHF-11419](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11419)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Copy was supposed to be disabled for this grant application. This issue was raised in [Jira comment](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11419?focusedCommentId=134270). 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11419-disable-copy`
  * `make fresh`
* Run `make drush-cr`
* Run `drush grants-tools:webform-import`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Copy button should not be visible when looking at a submitted form page.
      
     ![image](https://github.com/user-attachments/assets/683435be-25a0-48f4-af6b-744d70452f31)

* [x] Check that code follows our standards

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1653

[UHF-11419]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ