### PR TITLE
UHF-11210

### DIFF
--- a/public/modules/custom/grants_attachments/grants_attachments.services.yml
+++ b/public/modules/custom/grants_attachments/grants_attachments.services.yml
@@ -1,4 +1,12 @@
 services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
+  logger.channel.grants_attachments:
+    parent: logger.channel_base
+    arguments: ['grants_attachments']
+
   grants_attachments.event_subscriber:
     class: Drupal\grants_attachments\EventSubscriber\GrantsAttachmentsSubscriber
     parent: form_ajax_subscriber

--- a/public/modules/custom/grants_attachments/src/AttachmentFixerService.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentFixerService.php
@@ -6,6 +6,8 @@ namespace Drupal\grants_attachments;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\helfi_atv\AtvDocument;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Service for fixing attachments.
@@ -13,6 +15,15 @@ use Drupal\helfi_atv\AtvDocument;
 final class AttachmentFixerService {
 
   use StringTranslationTrait;
+
+  /**
+   * Constructs a new instance.
+   */
+  public function __construct(
+    #[Autowire(service: 'logger.channel.grants_attachments')]
+    private LoggerInterface $logger,
+  ) {
+  }
 
   /**
    * Fix attachments on applications that has missing integration IDs.
@@ -265,22 +276,21 @@ final class AttachmentFixerService {
   }
 
   /**
-   * Check if filename extension is uppercase and fix it.
+   * Convert filename to lowercase.
    *
-   * If file extension is uppercase, it will cause trouble.
-   * Atv document will have the filename in 2 different formats,
-   * for example .PDF and _0.pdf.
+   * ATV, avustus2, or some other service converts all filenames to lowercase.
    * That breaks the integrationID fixer.
    *
    * @param string $filename
    *   The filename.
    *
    * @return string
-   *   A filename without uppercase extension.
+   *   A lowercase filename.
    */
   private function filenameExtensionFixer(string $filename): string {
-    // Check if extension has even one uppercase letter.
-    return strtolower($filename);
+    $newFilename = strtolower($filename);
+    $this->logger->info("Converting filename $filename to $newFilename");
+    return $newFilename;
   }
 
 }

--- a/public/modules/custom/grants_attachments/src/AttachmentFixerService.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentFixerService.php
@@ -279,11 +279,6 @@ final class AttachmentFixerService {
    *   A filename without uppercase extension.
    */
   private function filenameExtensionFixer(string $filename): string {
-    // Can't fix a string in wrong format.
-    if (!preg_match('/^[a-zA-Z]*\.[a-zA-Z]*$/', $filename)) {
-      return $filename;
-    }
-
     // Check if extension has even one uppercase letter.
     $extension = explode('.', $filename)[1];
     if (!preg_match('/^[a-z]*[A-Z]+[a-z]*$/', $extension)) {

--- a/public/modules/custom/grants_attachments/src/AttachmentFixerService.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentFixerService.php
@@ -280,13 +280,7 @@ final class AttachmentFixerService {
    */
   private function filenameExtensionFixer(string $filename): string {
     // Check if extension has even one uppercase letter.
-    $extension = explode('.', $filename)[1];
-    if (!preg_match('/^[a-z]*[A-Z]+[a-z]*$/', $extension)) {
-      return $filename;
-    }
-
-    $file = explode('.', $filename)[0];
-    return sprintf('%s%s%s', $file, '_0.', strtolower($extension));
+    return strtolower($filename);
   }
 
 }


### PR DESCRIPTION
# [UHF-11210](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11210)

If file extension is uppercase, it will cause trouble. document will have the filename in 2 different formats, for example .PDF and _0.pdf. That breaks the integrationID fixer.

This prevented the integration ID fixer from fixing the files since it thought that the file with uppercase extension did not exist and therefore did not need fixing.

## What was done

Fixed the fixer.


## How to reproduce the bug:

- Fill any application, upload a file with uppercase letters in extension. For example test.PDF
  - Send the application 
- Copy the application number and wait for Avus2 to say it has been received
- Go to the [application resender](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/tools/resend-applications) and get the application status
- Go at the bottom of the page. Check the file with bad filename: Without the fix at least Form OK and Handler OK should be NO 


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11210`
  * `make fresh`
* Run `make drush-cr`

## How to test

If you already have reproduced the bug, you should just be able to use the [application resender](https://hel-fi-drupal-grant-applications.docker.so/fi/admin/tools/resend-applications) (get status) and see that Form OK and HandlerOK === yes for those files with uppercase letters in file extensions.


[UHF-11210]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ