### PR TITLE
UHF-11289: add new button to hakuprofiili page which allows user to go back

### DIFF
--- a/public/modules/custom/grants_handler/js/grants-dialog.js
+++ b/public/modules/custom/grants_handler/js/grants-dialog.js
@@ -7,11 +7,13 @@
      * @param {string} dialogContent - The title displayed at the top of the
      *   dialog.
      * @param {string} actionButtonText - The text for the "leave" button.
+     * @param {string} switchRoleButtonText - The text for the "Switch role" button.
      * @param {string} backButtonText - The text for the "back" button.
      * @param {string} closeButtonText - The text for the "close" button that
      *   closes the dialog.
      * @param {Function} actionButtonCallback - The function to execute when
      *   the "action" button is clicked.
+     * @param {Function} switchRoleButtonCallback - The function for switch role button.
      * @param dialogTitle
      *  If we want to override the default title
      * @param {Function} closeButtonCallback
@@ -26,16 +28,19 @@
     createDialog: ({
       dialogContent,
       actionButtonText,
+      switchRoleButtonText = '',
       backButtonText,
       closeButtonText,
       dialogTitle = Drupal.t('Attention', {}, { context: 'grants_handler' }),
       actionButtonCallback = null,
+      switchRoleButtonCallback = null,
       closeButtonCallback = null,
       backButtonCallback = null,
       escapeButtonCallback = null,
       customSelector = '',
     }) => {
       const actionButtonHTML = actionButtonText && `<button class="dialog__action-button" id="helfi-dialog__action-button" data-hds-component="button" data-hds-variant="primary">${actionButtonText}</button>`;
+      const switchRoleButtonHTML = switchRoleButtonText && `<button class="dialog__action-button" id="helfi-dialog__role-button" data-hds-component="button" data-hds-variant="primary">${switchRoleButtonText}</button>`;
       const backButtonHTML = backButtonText && `<button class="dialog__action-button" id="helfi-dialog__back-button" data-hds-component="button" data-hds-variant="secondary">${backButtonText}</button>`;
       const closeButtonHTML = closeButtonText && `<button class="dialog__close-button" id="helfi-dialog__close-button"><span class="is-hidden">${closeButtonText}</span></button>`;
 
@@ -53,6 +58,7 @@
         <div class="dialog__actions">
           ${actionButtonHTML}
           ${backButtonHTML}
+          ${switchRoleButtonHTML}
         </div>
       </dialog>
     </div>
@@ -70,6 +76,7 @@
       Drupal.dialogFunctions.toggleNoScroll(true);
 
       const actionButton = document.getElementById('helfi-dialog__action-button');
+      const switchRoleButton = document.getElementById('helfi-dialog__role-button');
       const backButton = document.getElementById('helfi-dialog__back-button');
       const closeButton = document.getElementById('helfi-dialog__close-button');
       const dialog = document.getElementById('helfi-dialog__container');
@@ -83,6 +90,10 @@
       // Add click event listener to action button
       if (actionButtonCallback && actionButtonText) {
         actionButton.addEventListener('click', actionButtonCallback);
+      }
+
+      if (switchRoleButtonHTML) {
+        switchRoleButton.addEventListener('click', switchRoleButtonCallback);
       }
 
       // Add click event listener to back button

--- a/public/modules/custom/grants_profile/js/profile_dialog.js
+++ b/public/modules/custom/grants_profile/js/profile_dialog.js
@@ -44,10 +44,13 @@
               closeButtonText: Drupal.t('Close', {}, { context: 'grants_profile' }),
             });
           } else if (($('[data-drupal-selector="edit-isnewprofile"]').val() === 'initialSave') && !containingElement.contains(event.target)) {
+            // Hakuprofiili.
             event.preventDefault();
             return Drupal.dialogFunctions.createDialog({
               dialogContent: Drupal.t('You have not saved your profile. Please save your profile before leaving the form.', {}, { context: 'grants_profile' }),
               actionButtonText: '',
+              switchRoleButtonText: Drupal.t('Switch role', {}, { context: 'grants_profile' }),
+              switchRoleButtonCallback: () => { window.location = Drupal.url('asiointirooli-valtuutus') },
               backButtonText: Drupal.t('Back to profile', {}, { context: 'grants_profile' }),
               closeButtonText: Drupal.t('Close', {}, { context: 'grants_profile' }),
             });

--- a/public/modules/custom/grants_profile/js/profile_dialog.js
+++ b/public/modules/custom/grants_profile/js/profile_dialog.js
@@ -49,7 +49,7 @@
             return Drupal.dialogFunctions.createDialog({
               dialogContent: Drupal.t('You have not saved your profile. Please save your profile before leaving the form.', {}, { context: 'grants_profile' }),
               actionButtonText: '',
-              switchRoleButtonText: Drupal.t('Switch role', {}, { context: 'grants_profile' }),
+              switchRoleButtonText: Drupal.t('Switch role'),
               switchRoleButtonCallback: () => { window.location = Drupal.url('asiointirooli-valtuutus') },
               backButtonText: Drupal.t('Back to profile', {}, { context: 'grants_profile' }),
               closeButtonText: Drupal.t('Close', {}, { context: 'grants_profile' }),


### PR DESCRIPTION
# [UHF-11289](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11289)
Allow user to leave the profile page on first time without closing the browser.

## What was done
Added a button to the dialog which redirects user to role switch page.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11289`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Create a new end user (login using different test-hetu)
- Select rekisteröity yhdistys as your asiointirooli
- Instead of filling the information, try clicking any link on the page
  - The dialog should now have 2 buttons instead of 1.
  -  The second button should be "Vaihda rooli" or "Switch role" or something like that
  - The switch role -button should redirect the user to role switching page.  


[UHF-11289]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ