### PR TITLE
UHF-11018: prevent duplicate when copying

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationInitService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationInitService.php
@@ -170,7 +170,7 @@ class ApplicationInitService {
       /** @var \Drupal\grants_budget_components\TypedData\Definition\GrantsBudgetInfoDefinition $budgetInfoDefinition */
       $budgetInfoDefinition = $propertyDefinitions['budgetInfo'] ?? NULL;
       if ($budgetInfoDefinition) {
-        // UHF-11018 duplicate values when copying on budget fields.
+        // UHF-11018 duplicate values when copying budget fields.
         // If this array has both budget_other_income and talous_tulon_tyyppi OR
         // budget_other_cost and talous_menon_tyyppi,
         // the copy will have duplicates.

--- a/public/modules/custom/grants_handler/src/ApplicationInitService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationInitService.php
@@ -170,7 +170,14 @@ class ApplicationInitService {
       /** @var \Drupal\grants_budget_components\TypedData\Definition\GrantsBudgetInfoDefinition $budgetInfoDefinition */
       $budgetInfoDefinition = $propertyDefinitions['budgetInfo'] ?? NULL;
       if ($budgetInfoDefinition) {
-        return array_keys($budgetInfoDefinition->getPropertyDefinitions()) ?? [];
+        // UHF-11018 duplicate values when copying on budget fields.
+        // If this array has both budget_other_income and talous_tulon_tyyppi OR
+        // budget_other_cost and talous_menon_tyyppi,
+        // the copy will have duplicates.
+        $budgetFieldsToCopy = $budgetInfoDefinition->getPropertyDefinitions();
+        unset($budgetFieldsToCopy['budget_other_income']);
+        unset($budgetFieldsToCopy['budget_other_cost']);
+        return array_keys($budgetFieldsToCopy) ?? [];
       }
     }
     catch (\Exception $e) {


### PR DESCRIPTION
# [UHF-11018](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11018)

Prevent duplicates on budget component when copying existing application.

## What was done

- Removed the part which caused the duplication. 
  - Not sure if some other application copying breaks after this change.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11018`
  * `make fresh`
* Run `make drush-cr`

## How to test

- If you have prefilled segregation application, copy it
  - If not, fill a segregation form and add data to all field (especially the "talous" section)
- Copy the application
- Check that the "talous" fields won't have duplicate values (tulon tyyppi, meno)



[UHF-11018]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ