### PR TITLE
UHF-11631: redirect to oma-asiointi after saving as draft

### DIFF
--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1426,9 +1426,7 @@ submit the application only after you have provided all the necessary informatio
             )
           );
 
-        $redirectUrl = Url::fromRoute('grants_handler.view_application', [
-          'submission_id' => $this->applicationNumber,
-        ]);
+        $redirectUrl = Url::fromRoute('grants_oma_asiointi.front');
       }
       else {
         $redirectUrl = Url::fromRoute(

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1395,13 +1395,14 @@ submit the application only after you have provided all the necessary informatio
     }
     try {
       $applicationData = $this->applicationDataService->webformToTypedData(
-        $this->submittedFormData);
+        $this->submittedFormData
+      );
     }
     catch (ReadOnlyException $e) {
       // Fix here: https://helsinkisolutionoffice.atlassian.net/browse/AU-545
     }
     $redirectUrl = Url::fromRoute(
-      '<front>',
+      'grants_oma_asiointi.front',
       [
         'attributes' => [
           'data-drupal-selector' => 'application-saving-failed-link',
@@ -1425,13 +1426,13 @@ submit the application only after you have provided all the necessary informatio
             )
           );
 
-        $redirectUrl = Url::fromRoute('grants_handler.view_application', [
+        $redirectUrl = Url::fromRoute('grants_oma_asiointi.front', [
           'submission_id' => $this->applicationNumber,
         ]);
       }
       else {
         $redirectUrl = Url::fromRoute(
-          '<front>',
+          'grants_oma_asiointi.front',
           [
             'attributes' => [
               'data-drupal-selector' => 'application-saving-failed-link',

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1402,7 +1402,7 @@ submit the application only after you have provided all the necessary informatio
       // Fix here: https://helsinkisolutionoffice.atlassian.net/browse/AU-545
     }
     $redirectUrl = Url::fromRoute(
-      'grants_handler.view_application',
+      'grants_oma_asiointi.front',
       [
         'attributes' => [
           'data-drupal-selector' => 'application-saving-failed-link',
@@ -1426,7 +1426,7 @@ submit the application only after you have provided all the necessary informatio
             )
           );
 
-        $redirectUrl = Url::fromRoute('grants_oma_asiointi.front', [
+        $redirectUrl = Url::fromRoute('grants_handler.view_application', [
           'submission_id' => $this->applicationNumber,
         ]);
       }

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1402,7 +1402,7 @@ submit the application only after you have provided all the necessary informatio
       // Fix here: https://helsinkisolutionoffice.atlassian.net/browse/AU-545
     }
     $redirectUrl = Url::fromRoute(
-      'grants_oma_asiointi.front',
+      'grants_handler.view_application',
       [
         'attributes' => [
           'data-drupal-selector' => 'application-saving-failed-link',


### PR DESCRIPTION
# [UHF-11631](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11631)

## What was done
Redirect to oma asioiti after saving an application as a draft.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11631`
  * `make fresh`
* Run `make drush-cr`

## How to test

- Log in as enduser
- Start creating an application, save it as a draft
You should be redirected to oma-asiointi page.




[UHF-11631]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ