### PR TITLE
UHF-11684: Disable form attachment cleaning

### DIFF
--- a/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
+++ b/public/modules/custom/grants_profile/src/Form/GrantsProfileFormBase.php
@@ -887,7 +887,11 @@ rtf, txt, xls, xlsx, zip.', [], $this->tOpts),
       ]);
 
     try {
-      $this->grantsProfileService->saveGrantsProfile($profileDataArray, cleanAttachments: TRUE);
+      // @todo re-enable cleanAttachments when React form refactoring is done.
+      // Enabling cleanAttachments here caused problems with form grants
+      // submitting. Some attachment submit code caused profile attachments to
+      // be deleted at the form submit when editing already submitted form.
+      $this->grantsProfileService->saveGrantsProfile($profileDataArray, cleanAttachments: FALSE);
 
       // Derived form might want to update something when grants profile
       // is successfully saved. The default implementation does nothing.


### PR DESCRIPTION
# [UHF-11684](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11684)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* This feature implemeneted https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1692 in caused a bug in editing already submitted forms

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11684-disable-profile-attachment-cleaning`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open https://hel-fi-drupal-grant-applications.docker.so/fi/oma-asiointi/hakuprofiili/muokkaa Add new bank account.
* [ ] Submit grants application with the selected bank account.
* [ ] Delete the bank account.
* [ ] Edit the already submitted form.
* [ ] Check form confirmation page. Attachments should be present.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


[UHF-11684]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ