### PR TITLE
UHF-11529: Updating CSP configuration

### DIFF
--- a/conf/cmi/csp.settings.yml
+++ b/conf/cmi/csp.settings.yml
@@ -28,5 +28,24 @@ enforce:
       base: self
       sources:
         - palvelukartta.hel.fi
+        - 'https://*.youtube-nocookie.com'
+        - 'https://*.youtube.com'
+        - 'https://*.youtu.be'
+        - 'https://*.vimeo.com'
+        - 'https://suite.icareus.com'
+        - 'https://players.icareus.com'
+        - 'https://*.helsinkikanava.fi'
+        - 'https://*.powerbi.com'
+    object-src:
+      base: self
+      sources:
+        - palvelukartta.hel.fi
+        - 'https://*.youtube-nocookie.com'
+        - 'https://*.youtube.com'
+        - 'https://*.youtu.be'
+        - 'https://*.vimeo.com'
+        - 'https://suite.icareus.com'
+        - 'https://players.icareus.com'
+        - 'https://*.helsinkikanava.fi'
   reporting:
     plugin: none

--- a/conf/cmi/oembed_providers.settings.yml
+++ b/conf/cmi/oembed_providers.settings.yml
@@ -1,0 +1,1 @@
+external_fetch: true


### PR DESCRIPTION
# [UHF-11529](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11529)

The active content security policy didn't allow iframe embeds from Youtube, Helsinki-kanava or PowerBI.

## What was done

* `frame-src` and `object-src` -directives were updated with relevant domains. Only video embeds require the `object-src`-directive as Drupal embeds them via a local iframe path where `<object>`-tag is eventually used for the actual embedding. This is why the two directives aren't identical.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11529_csp`
  * `make fresh`
* Run `make drush-cr`

## How to test

* Test embedding content from Youtube, Vimeo, Helsinki-kanava and PowerBI
  * Edit an existing regular page or create a new one
  * [ ] Add a video embed, use any video from Youtube; video should be displayed after saving
  * [x] Add a video embed from Helsinki-kanava, for example https://players.icareus.com/helsinkikanava/embed/vod/252887681 ; video should be displayed after saving
  * [x] Add a graph embed, you can use https://app.powerbi.com/view?r=eyJrIjoiMjEzOTMyNzEtZTU2Zi00YzBiLWE1ZDYtNjE0MGIxMjEwMTYzIiwidCI6IjNmZWI2YmMxLWQ3MjItNDcyNi05NjZjLTViNThiNjRkZjc1MiIsImMiOjh9 ; graph should display after save


## Automatic- / Regression tests

* [x] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)


[UHF-11529]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ