### PR TITLE
Add grants admin role to developers

### DIFF
--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -100,7 +100,7 @@ $config['openid_connect.client.tunnistamoadmin']['settings']['ad_roles'] = [
   // New mappings.
   [
     'ad_role' => '947058f4-697e-41bb-baf5-f69b49e5579a',
-    'roles' => ['super_administrator'],
+    'roles' => ['super_administrator', 'grants_admin'],
   ],
   [
     'ad_role' => 'Drupal_Helfi_kaupunkitaso_paakayttajat',


### PR DESCRIPTION
Apparently avustukset sometimes checks for role name instead of permission, so developer accounts do not get all permisions:

https://github.com/search?q=repo%3ACity-of-Helsinki%2Fhel-fi-drupal-grants%20%27grants_admin%27%2C&type=code

## How to test:
- Setup tunnistamo locally
- Log in as a admin
- You should get grants_admin role.