### PR TITLE
UHF-11734: Tooltip text changes for annual meeting attachment field

### DIFF
--- a/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -280,7 +280,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/en/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -280,7 +280,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/language/en/webform.webform.hyte_yleisavustus.yml
@@ -237,7 +237,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/language/en/webform.webform.hyte_yleisavustus.yml
@@ -237,7 +237,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.hyteed_yleis.yml
+++ b/conf/cmi/language/en/webform.webform.hyteed_yleis.yml
@@ -246,7 +246,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.hyteed_yleis.yml
+++ b/conf/cmi/language/en/webform.webform.hyteed_yleis.yml
@@ -246,7 +246,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -220,7 +220,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/en/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -220,7 +220,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/language/en/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -254,7 +254,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Please attach here the minutes of the association&rsquo;s last annual meeting. If the association has two annual meetings, include the minutes of the spring meeting. Attach the minutes of the latest autumn meeting to the field &ldquo;Other attachment&rdquo;.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/language/en/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -254,7 +254,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_laitosavustushakemus.yml
@@ -251,7 +251,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_laitosavustushakemus.yml
@@ -251,7 +251,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -288,7 +288,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/en/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -288,7 +288,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
@@ -272,7 +272,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/en/webform.webform.nuortoimpalkka.yml
@@ -272,7 +272,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': '<p>Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.</p>'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.sotepe_yleis.yml
+++ b/conf/cmi/language/en/webform.webform.sotepe_yleis.yml
@@ -246,7 +246,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.sotepe_yleis.yml
+++ b/conf/cmi/language/en/webform.webform.sotepe_yleis.yml
@@ -246,7 +246,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
@@ -253,7 +253,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/en/webform.webform.yleisavustushakemus.yml
@@ -253,7 +253,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -220,7 +220,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
+    '#help': "Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association's annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/en/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -220,7 +220,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Minutes of the annual meeting confirming the financial statements for the previous accounting period'
-    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability granted. For associations, the financial statements are always confirmed at the association&rsquo;s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability granted, this attachment does not need to be submitted.'
+    '#help': 'Append here the minutes of the community meeting in which the financial statements for the previous accounting period are confirmed and discharge from liability discussed. For associations, the financial statements are always confirmed at the association’s annual meeting. If the community is not required to have an annual meeting or other community meeting at which the financial statements should be approved and discharge from liability discussed, this attachment does not need to be submitted.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -296,7 +296,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/language/sv/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -296,7 +296,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.hyte_yleisavustus.yml
@@ -239,7 +239,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.hyte_yleisavustus.yml
@@ -239,7 +239,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.hyteed_yleis.yml
+++ b/conf/cmi/language/sv/webform.webform.hyteed_yleis.yml
@@ -248,7 +248,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.hyteed_yleis.yml
+++ b/conf/cmi/language/sv/webform.webform.hyteed_yleis.yml
@@ -248,7 +248,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -222,7 +222,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/language/sv/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -222,7 +222,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -256,7 +256,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/language/sv/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -256,7 +256,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n f&ouml;reningens senaste &aring;rsm&ouml;te h&auml;r. Om f&ouml;reningen har tv&aring; m&ouml;ten, bifoga protokollet fr&aring;n v&aring;rm&ouml;tet h&auml;r. Bifoga protokollet fr&aring;n h&ouml;stm&ouml;tet som Annan bilaga.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
@@ -253,7 +253,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_laitosavustushakemus.yml
@@ -253,7 +253,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -292,7 +292,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/language/sv/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -292,7 +292,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -272,7 +272,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': '<p>Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och ansvarsfrihet beviljats. Samfundens bokslut fastställs alltid vid samfundets medlemsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfrihet beviljas, behöver denna bilaga inte lämnas in.</p>'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/language/sv/webform.webform.nuortoimpalkka.yml
@@ -272,7 +272,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.sotepe_yleis.yml
+++ b/conf/cmi/language/sv/webform.webform.sotepe_yleis.yml
@@ -248,7 +248,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.sotepe_yleis.yml
+++ b/conf/cmi/language/sv/webform.webform.sotepe_yleis.yml
@@ -248,7 +248,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -257,7 +257,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/language/sv/webform.webform.yleisavustushakemus.yml
@@ -257,7 +257,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -223,7 +223,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
+    '#help': "Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in."
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/language/sv/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -223,7 +223,7 @@ elements: |
     '#isAttachmentNew__title': ''
   vuosikokouksen_poytakirja:
     '#title': 'Protokoll från årsstämman med det godkända bokslutet för den föregående räkenskapsperioden'
-    '#help': 'Bifoga protokollet fr&aring;n samfundets m&ouml;te h&auml;r, d&auml;r bokslutet f&ouml;r den f&ouml;reg&aring;ende avslutade r&auml;kenskapsperioden har godk&auml;nts och ansvarsfrihet beviljats. Samfundens bokslut fastst&auml;lls alltid vid samfundets medlemsm&ouml;te. Om samfundet inte &auml;r skyldigt att ha ett &aring;rsm&ouml;te eller annat samfundsm&ouml;te d&auml;r bokslutet b&ouml;r godk&auml;nnas och ansvarsfrihet beviljas, beh&ouml;ver denna bilaga inte l&auml;mnas in.'
+    '#help': 'Bifoga protokollet från samfundets möte här, där bokslutet för den föregående avslutade räkenskapsperioden har godkänts och beviljandet av ansvarsfrihet behandlats. Samfundens bokslut fastställs alltid vid samfundets årsmöte. Om samfundet inte är skyldigt att ha ett årsmöte eller annat samfundsmöte där bokslutet bör godkännas och ansvarsfriheten behandlas, behöver denna bilaga inte lämnas in.'
     '#attachmentName__title': ''
     '#fileStatus__title': ''
     '#fileType__title': ''

--- a/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -781,7 +781,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -781,7 +781,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/webform.webform.hyte_yleisavustus.yml
@@ -585,7 +585,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/webform.webform.hyte_yleisavustus.yml
@@ -585,7 +585,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.hyteed_yleis.yml
+++ b/conf/cmi/webform.webform.hyteed_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.hyteed_yleis.yml
+++ b/conf/cmi/webform.webform.hyteed_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -627,7 +627,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -627,7 +627,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -718,7 +718,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhdistyksen viimeisimm&auml;n vuosikokouksen p&ouml;yt&auml;kirja. Jos yhdistyksell&auml; on kaksi kokousta, liit&auml; t&auml;h&auml;n kev&auml;tkokouksen p&ouml;yt&auml;kirja. Liit&auml; syyskokouksen p&ouml;yt&auml;kirja kohtaan Muu liite.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -718,7 +718,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
@@ -585,7 +585,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
@@ -585,7 +585,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -939,7 +939,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -939,7 +939,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.sotepe_yleis.yml
+++ b/conf/cmi/webform.webform.sotepe_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.sotepe_yleis.yml
+++ b/conf/cmi/webform.webform.sotepe_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -710,7 +710,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -710,7 +710,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -628,7 +628,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -628,7 +628,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -697,7 +697,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -697,7 +697,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/config/install/webform.webform.hyte_yleisavustus.yml
@@ -586,7 +586,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/config/install/webform.webform.hyte_yleisavustus.yml
@@ -586,7 +586,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -631,7 +631,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -631,7 +631,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -724,7 +724,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhdistyksen viimeisimm&auml;n vuosikokouksen p&ouml;yt&auml;kirja. Jos yhdistyksell&auml; on kaksi kokousta, liit&auml; t&auml;h&auml;n kev&auml;tkokouksen p&ouml;yt&auml;kirja. Liit&auml; syyskokouksen p&ouml;yt&auml;kirja kohtaan Muu liite.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -724,7 +724,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -591,7 +591,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -591,7 +591,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/config/install/webform.webform.nuortoimpalkka.yml
@@ -933,7 +933,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/config/install/webform.webform.nuortoimpalkka.yml
@@ -933,7 +933,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/config/install/webform.webform.yleisavustushakemus.yml
@@ -721,7 +721,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/config/install/webform.webform.yleisavustushakemus.yml
@@ -721,7 +721,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/public/modules/custom/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -638,7 +638,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/public/modules/custom/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -638,7 +638,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -669,7 +669,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -669,7 +669,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.hyte_yleisavustus.yml
@@ -585,7 +585,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.hyte_yleisavustus.yml
@@ -585,7 +585,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.hyteed_yleis.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.hyteed_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.hyteed_yleis.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.hyteed_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -629,7 +629,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -629,7 +629,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -718,7 +718,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhdistyksen viimeisimm&auml;n vuosikokouksen p&ouml;yt&auml;kirja. Jos yhdistyksell&auml; on kaksi kokousta, liit&auml; t&auml;h&auml;n kev&auml;tkokouksen p&ouml;yt&auml;kirja. Liit&auml; syyskokouksen p&ouml;yt&auml;kirja kohtaan Muu liite.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -718,7 +718,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -586,7 +586,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -586,7 +586,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuortoimpalkka.yml
@@ -937,7 +937,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.nuortoimpalkka.yml
@@ -937,7 +937,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.sotepe_yleis.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.sotepe_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.sotepe_yleis.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.sotepe_yleis.yml
@@ -649,7 +649,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.yleisavustushakemus.yml
@@ -710,7 +710,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.yleisavustushakemus.yml
@@ -710,7 +710,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -628,7 +628,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_handler/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/public/modules/custom/grants_handler/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -628,7 +628,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -696,7 +696,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -696,7 +696,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.hyte_yleisavustus.yml
@@ -588,7 +588,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.hyte_yleisavustus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.hyte_yleisavustus.yml
@@ -588,7 +588,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -594,7 +594,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -594,7 +594,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -727,7 +727,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liit&auml; t&auml;h&auml;n yhdistyksen viimeisimm&auml;n vuosikokouksen p&ouml;yt&auml;kirja. Jos yhdistyksell&auml; on kaksi kokousta, liit&auml; t&auml;h&auml;n kev&auml;tkokouksen p&ouml;yt&auml;kirja. Liit&auml; syyskokouksen p&ouml;yt&auml;kirja kohtaan Muu liite.'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -727,7 +727,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -593,7 +593,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_laitosavustushakemus.yml
@@ -593,7 +593,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -957,7 +957,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -957,7 +957,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuortoimpalkka.yml
@@ -916,7 +916,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuortoimpalkka.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.nuortoimpalkka.yml
@@ -916,7 +916,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.yleisavustushakemus.yml
@@ -692,7 +692,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.yleisavustushakemus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.yleisavustushakemus.yml
@@ -692,7 +692,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -637,7 +637,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
+        '#help': "Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa."
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:

--- a/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/public/modules/custom/grants_test_base/modules/grants_test_webforms/config/install/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -637,7 +637,7 @@ elements: |-
         '#title': 'Vuosikokouksen pöytäkirja, jossa on vahvistettu edellisen päättyneen tilikauden tilinpäätös'
         '#multiple': false
         '#filetype': '8'
-        '#help': '<span style="font-size:11.0pt"><span style="line-height:107%"><span style="font-family:&quot;Calibri&quot;,sans-serif">Liit&auml; t&auml;h&auml;n yhteis&ouml;n kokouksen p&ouml;yt&auml;kirja, jossa edellisen p&auml;&auml;ttyneen tilikauden tilinp&auml;&auml;t&ouml;s on vahvistettu ja vastuuvapaus my&ouml;nnetty. Yhdistyksill&auml; tilinp&auml;&auml;t&ouml;s vahvistetaan aina yhdistyksen j&auml;senkokouksessa. Mik&auml;li yhteis&ouml;lt&auml; ei edellytet&auml; vuosikokousta tai muuta yhteis&ouml;n kokousta, jossa tilinp&auml;&auml;t&ouml;s tulisi vahvistaa ja vastuuvapaus my&ouml;nt&auml;&auml;, ei t&auml;t&auml; liitett&auml; tarvitse toimittaa.</span></span></span>'
+        '#help': 'Liitä tähän yhteisön kokouksen pöytäkirja, jossa edellisen päättyneen tilikauden tilinpäätös on vahvistettu ja vastuuvapauden myöntäminen käsitelty. Yhdistyksillä tilinpäätös vahvistetaan aina yhdistyksen kokouksessa. Mikäli yhteisöltä ei edellytetä vuosikokousta tai muuta yhteisön kokousta, jossa tilinpäätös tulisi vahvistaa ja vastuuvapaus käsitellä, ei tätä liitettä tarvitse toimittaa.'
         '#title_display': before
         '#description__access': false
       toimintasuunnitelma:


### PR DESCRIPTION
# [UHF-11734](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11734)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Tooltip text changes in three languages for annual meeting attachment field.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11734`
  * `make fresh`
* Run `make drush-cr`
* Go to shell `make shell` and run `drush grants-tools:webform-import --force` inside the shell to import new translations.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->
* [ ] Many of the forms have this field but one good example is https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/muut-avustukset/kaupunginhallitus-yleisavustus. I recommend checking some other as well since this is the one I checked on all languages. The field is on the Additional information and attachments step.
* [ ] Check that the annual meeting attachment fields tooltip has now correct texts on all of the three language versions. There is at least 11 forms that have this field so I don't think its required to check every one of them but some. After that check all of the config changes from github diff.
* [ ] Check that code follows our standards.

[UHF-11734]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ