### PR TITLE
UHF-11688: update company name on login

### DIFF
--- a/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
+++ b/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
@@ -230,14 +230,14 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
 
       $grantsProfileContent['businessId'] = $companyData['businessId'];
       $grantsProfileContent['companyHome'] = $companyData['companyHome'];
-
-      // UHF-10845 Update and refetch the company data after mandating.
-      // Uncomment to test changing company data.
-      // phpcs:ignore
-      // $grantsProfileContent['companyHome'] .= ' test-override-'.random_int(1, 100);
-
+      $grantsProfileContent['companyName'] = $companyData['companyName'];
       $grantsProfileContent['registrationDate'] = $companyData['registrationDate'];
 
+      // phpcs:ignore
+      // UHF-10845, UHF-11688 Update and refetch the company data after mandating.
+      // Uncomment to test changing company data.
+      // $grantsProfileContent['companyHome'] .= ' test-override-'.random_int(1, 100);
+      // $grantsProfileContent['companyName'] .= ' name-override';
       $this->grantsProfileService->saveGrantsProfile($grantsProfileContent);
 
       $selectedCompany = $this->grantsProfileService->getSelectedRoleData();

--- a/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
+++ b/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
@@ -233,10 +233,11 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
       $grantsProfileContent['companyName'] = $companyData['companyName'];
       $grantsProfileContent['registrationDate'] = $companyData['registrationDate'];
 
-      // phpcs:ignore
       // UHF-10845, UHF-11688 Update and refetch the company data after mandating.
       // Uncomment to test changing company data.
-      // $grantsProfileContent['companyHome'] .= ' test-override-'.random_int(1, 100);
+      // phpcs:ignore
+      // $grantsProfileContent['companyHome'] .= ' test-override';
+      // phpcs:ignore
       // $grantsProfileContent['companyName'] .= ' name-override';
       $this->grantsProfileService->saveGrantsProfile($grantsProfileContent);
 

--- a/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
+++ b/public/modules/custom/grants_mandate/src/Controller/GrantsMandateController.php
@@ -233,7 +233,7 @@ class GrantsMandateController extends ControllerBase implements ContainerInjecti
       $grantsProfileContent['companyName'] = $companyData['companyName'];
       $grantsProfileContent['registrationDate'] = $companyData['registrationDate'];
 
-      // UHF-10845, UHF-11688 Update and refetch the company data after mandating.
+      // UHF-10845, UHF-11688 Update the company data after mandating.
       // Uncomment to test changing company data.
       // phpcs:ignore
       // $grantsProfileContent['companyHome'] .= ' test-override';


### PR DESCRIPTION
# [UHF-11688](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11688)

## What was done
Update company name after every mandating request (when you select rekisteröity yhdistys-asiointirooli)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11688`
  * `make fresh`
* Run `make drush-cr`

## How to test

- Log in as enduser
- Select rekisteröity yhdistys as asiointirooli
- Create a new draft application, no need to fill it completely
  - Check the company name on the first page of the draft-application
- Uncomment the company name override -code which was added in the PR
- Log out
- Log in as same user, same asiointirooli
- Open the same application
- On the first page, the company name should be updated



[UHF-11688]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ