### PR TITLE
UHF-11603: Changed configs for search api

### DIFF
--- a/conf/cmi/views.view.application_search_search_api.yml
+++ b/conf/cmi/views.view.application_search_search_api.yml
@@ -6,8 +6,10 @@ dependencies:
     - field.storage.node.field_application_continuous
     - field.storage.node.field_application_period
     - field.storage.node.field_avustuslaji
+    - field.storage.node.field_content
     - field.storage.node.field_errand_service
     - field.storage.node.field_hakijatyyppi
+    - field.storage.node.field_lead_in
     - field.storage.node.field_target_group
     - field.storage.node.field_webform
     - search_api.index.search_index
@@ -17,6 +19,7 @@ dependencies:
   module:
     - better_exposed_filters
     - datetime_range
+    - entity_reference_revisions
     - options
     - search_api
     - user
@@ -345,14 +348,15 @@ display:
               tpr_errand_service:
                 display_method: label
                 view_mode: default
-        search_api_excerpt:
-          id: search_api_excerpt
-          table: search_api_index_search_index
-          field: search_api_excerpt
+        field_lead_in:
+          id: field_lead_in
+          table: search_api_datasource_search_index_entity_node
+          field: field_lead_in
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: search_api
+          entity_type: node
+          plugin_id: search_api_field
           label: ''
           exclude: false
           alter:
@@ -372,14 +376,14 @@ display:
             suffix: ''
             target: ''
             nl2br: false
-            max_length: 0
+            max_length: 200
             word_boundary: true
             ellipsis: true
             more_link: false
             more_link_text: ''
             more_link_path: ''
             strip_tags: false
-            trim: false
+            trim: true
             preserve_tags: ''
             html: false
           element_type: ''
@@ -394,10 +398,97 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          link_to_item: false
-          use_highlighting: false
+          click_sort_column: value
+          type: basic_string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
           multi_type: separator
-          multi_separator: ', '
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+        field_content:
+          id: field_content
+          table: search_api_datasource_search_index_entity_node
+          field: field_content
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: true
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 200
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_revisions_entity_view
+          settings:
+            view_mode: default
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
         field_hakijatyyppi:
           id: field_hakijatyyppi
           table: search_api_datasource_search_index_entity_node
@@ -1218,15 +1309,16 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_application_continuous'
         - 'config:field.storage.node.field_application_period'
         - 'config:field.storage.node.field_avustuslaji'
+        - 'config:field.storage.node.field_content'
         - 'config:field.storage.node.field_errand_service'
         - 'config:field.storage.node.field_hakijatyyppi'
+        - 'config:field.storage.node.field_lead_in'
         - 'config:field.storage.node.field_target_group'
         - 'config:field.storage.node.field_webform'
         - 'config:search_api.index.search_index'
@@ -1259,15 +1351,16 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:
         - 'config:field.storage.node.field_application_continuous'
         - 'config:field.storage.node.field_application_period'
         - 'config:field.storage.node.field_avustuslaji'
+        - 'config:field.storage.node.field_content'
         - 'config:field.storage.node.field_errand_service'
         - 'config:field.storage.node.field_hakijatyyppi'
+        - 'config:field.storage.node.field_lead_in'
         - 'config:field.storage.node.field_target_group'
         - 'config:field.storage.node.field_webform'
         - 'config:search_api.index.search_index'

--- a/conf/cmi/views.view.application_search_search_api.yml
+++ b/conf/cmi/views.view.application_search_search_api.yml
@@ -348,6 +348,77 @@ display:
               tpr_errand_service:
                 display_method: label
                 view_mode: default
+        field_content:
+          id: field_content
+          table: search_api_datasource_search_index_entity_node
+          field: field_content
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: search_api_field
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: true
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 200
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: true
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_revisions_entity_view
+          settings:
+            view_mode: default
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 1
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
         field_lead_in:
           id: field_lead_in
           table: search_api_datasource_search_index_entity_node
@@ -394,7 +465,7 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: '{{ field_content }}'
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
@@ -402,77 +473,6 @@ display:
           type: basic_string
           settings: {  }
           group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          field_rendering: true
-          fallback_handler: search_api
-          fallback_options:
-            link_to_item: false
-            use_highlighting: false
-            multi_type: separator
-            multi_separator: ', '
-        field_content:
-          id: field_content
-          table: search_api_datasource_search_index_entity_node
-          field: field_content
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          plugin_id: search_api_field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: true
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 200
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: true
-            trim: true
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_revisions_entity_view
-          settings:
-            view_mode: default
-          group_column: ''
           group_columns: {  }
           group_rows: true
           delta_limit: 0


### PR DESCRIPTION
# [UHF-11603](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11603)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed search cards to use field_lead_in or field_content (if lead in isn't available) instead of the search excerpt

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11603`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://hel-fi-drupal-grant-applications.docker.so/fi/etsi-avustusta
* [x] Test the search with some word and make sure the description text on the card stays still the same and doesn't highlight the searched word in the description.
* [x] Make sure that lead in is used primarily and if it doesn't have content in the field, field_content is used
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)



[UHF-11603]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ