### PR TITLE
UHF-11857 E2E tests

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -98,6 +98,7 @@ export default defineConfig({
     {
       name: 'forms-all',
       testMatch: '/forms/*',
+      grepInvert: /registered_community_68\.ts/,
       dependencies: ['profile-private_person', 'profile-unregistered_community', 'profile-registered_community']
     },
     /* Run all smoke tests. */
@@ -283,6 +284,7 @@ export default defineConfig({
     /* Form 68 tests. */
     // Disable test for 68:hyte_yleisavustus. It is used as a parent form for
     // form 71:HYTEEDYLEIS form which doesn't have a test yet.
+    // The test is excluded in "name: 'forms-all'" test.
     // {
     //   name: 'forms-68',
     //   testMatch: '/forms/registered_community_68.ts',

--- a/e2e/utils/data/application/application_data_48.ts
+++ b/e2e/utils/data/application/application_data_48.ts
@@ -1062,8 +1062,14 @@ const fieldSwapForm: FormDataWithRemoveOptionalProps = {
   title: 'Field swap form',
   testFieldSwap: true,
   formPages: {
-    "1_hakijan_tiedot": {
-      items: {},
+    '1_hakijan_tiedot': {
+      items: {
+        'edit-bank-account-account-number-select': {
+          role: 'select',
+          value: PROFILE_INPUT_DATA.iban,
+          viewPageSelector: '.form-item-bank-account',
+        },
+      },
       itemsToSwap: [
         {field: 'edit-bank-account-account-number-select', swapValue: PROFILE_INPUT_DATA.iban2},
       ]

--- a/e2e/utils/data/application/application_data_50.ts
+++ b/e2e/utils/data/application/application_data_50.ts
@@ -409,6 +409,7 @@ const baseFormRegisteredCommunity_50: FormData = {
               value: 'edit-helsingissa-jarjestettava-tila-add-submit',
               resultValue: 'edit-helsingissa-jarjestettava-tila-items-[INDEX]'
             },
+            //@ts-ignore
             items: {
               0: [
                 {

--- a/e2e/utils/data/application/application_data_52.ts
+++ b/e2e/utils/data/application/application_data_52.ts
@@ -1269,7 +1269,13 @@ const fieldSwapForm: FormDataWithRemoveOptionalProps = {
   testFieldSwap: true,
   formPages: {
     "1_hakijan_tiedot": {
-      items: {},
+      items: {
+        'edit-bank-account-account-number-select': {
+          role: 'select',
+          value: PROFILE_INPUT_DATA.iban,
+          viewPageSelector: '.form-item-bank-account',
+        },
+      },
       itemsToSwap: [
         {field: 'edit-bank-account-account-number-select', swapValue: PROFILE_INPUT_DATA.iban2},
       ]

--- a/e2e/utils/field_swap_helpers.ts
+++ b/e2e/utils/field_swap_helpers.ts
@@ -50,7 +50,17 @@ const swapFieldValues = async (
   }
 
   logger('Validating form with swapped values...');
-  await saveAsDraft(page);
+  const saveDraftLink: Selector = {
+    type: 'data-drupal-selector',
+    name: 'data-drupal-selector',
+    value: 'edit-actions-draft',
+  }
+  await clickButton(page, saveDraftLink);
+  await logCurrentUrl(page);
+  await page.waitForURL('/**/oma-asiointi');
+  logger('Form saved as draft.')
+  await goToSubmissionUrl(page, submissionUrl);
+  await navigateToApplicationPage(page, 'webform_preview');
   await validateFormData(page, 'viewPage', formDetails);
 }
 
@@ -92,27 +102,6 @@ const swapFieldValuesOnPage = async (
     itemField.value = itemToSwap.swapValue;
     await fillFormField(page, itemField, itemKey, true);
   }
-};
-
-/**
- * The saveAsDraft function.
- *
- * This function saves and application
- * as draft.
- *
- * @param page
- *   Page object from Playwright.
- */
-const saveAsDraft = async (page: Page) => {
-  const saveDraftLink: Selector = {
-    type: 'data-drupal-selector',
-    name: 'data-drupal-selector',
-    value: 'edit-actions-draft',
-  }
-  await clickButton(page, saveDraftLink);
-  await logCurrentUrl(page);
-  await page.waitForURL('**/oma-asiointi');
-  logger('Form saved as draft.')
 };
 
 export { swapFieldValues };


### PR DESCRIPTION
# [UHF-11857](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11857)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed obsolete saveAsDraft function and fixed the form validation after this redirection change: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1705
* Added the bank account number selection to field swap form, as it was not found when running tests for field swap validation.
* Excluded the 68:hyte_yleisavustus form test from forms-all.
* Allow the webform override method to override forms with a same ID, for example: webform.webform.asukasosallisuus_pienavustushake.yml and webform.webform.terveys_hyvinvointi_pienavustus.yml

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11857`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Run the tests and see that they pass
* [ ] Check that code follows our standards



[UHF-11857]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ