### PR TITLE
UHF-X: Removing a local content_lock patch to allow automatic updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,9 +111,6 @@
                 "#3023228: Status messages show up twice": "https://www.drupal.org/files/issues/2023-07-19/3023228-39.patch",
                 "Asset resolver empty settings cache issue": "patches/assetresolver-settings.patch"
             },
-            "drupal/content_lock": {
-                "Fix missing types": "https://www.drupal.org/files/issues/2021-10-15/array_filter_issue-3243486-a.patch"
-            },
             "drupal/autologout": {
                 "Modal related issues": "https://www.drupal.org/files/issues/2023-04-25/autologout.2023-04-25.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64bb3293c8e0e2b8e1dd39d98abe9d46",
+    "content-hash": "802fbc47def5da01496fdb7ff8c6bf21",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## What was done

* Removed a local `content_lock` patch that was blocking automatic updates (https://github.com/City-of-Helsinki/hel-fi-drupal-grants/actions/runs/16569125935/job/46856420005#step:6:917)
