### PR TITLE
UHF-11975: Updating local drupal/csp to allow the dependency version from helfi_platform_config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "drupal/content_access": "^2.0",
         "drupal/core": "^10.2",
         "drupal/core-composer-scaffold": "^10.0",
-        "drupal/csp": "^1.24",
         "drupal/datatables": "^2.0",
         "drupal/date_range_formatter": "^4.0",
         "drupal/devel": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "drupal/content_access": "^2.0",
         "drupal/core": "^10.2",
         "drupal/core-composer-scaffold": "^10.0",
+        "drupal/csp": "*",
         "drupal/datatables": "^2.0",
         "drupal/date_range_formatter": "^4.0",
         "drupal/devel": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f6108659603446744da93b1bb525f63",
+    "content-hash": "0c1bbbbb9fdb8ce938d89bc63bbd702d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3404,6 +3404,54 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/crop",
                 "issues": "https://www.drupal.org/project/issues/crop"
+            }
+        },
+        {
+            "name": "drupal/csp",
+            "version": "2.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/csp.git",
+                "reference": "2.2.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/csp-2.2.2.zip",
+                "reference": "2.2.2",
+                "shasum": "4ae305859e6997c62296ddbeee480ba619557fe8"
+            },
+            "require": {
+                "drupal/core": "^10.2 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.2.2",
+                    "datestamp": "1741822236",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "gapple",
+                    "homepage": "https://www.drupal.org/user/490940"
+                }
+            ],
+            "description": "Provide Content-Security-Policy headers",
+            "homepage": "https://www.drupal.org/project/csp",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/csp",
+                "issues": "https://www.drupal.org/project/issues/csp"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "802fbc47def5da01496fdb7ff8c6bf21",
+    "content-hash": "1f6108659603446744da93b1bb525f63",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3404,55 +3404,6 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/crop",
                 "issues": "https://www.drupal.org/project/issues/crop"
-            }
-        },
-        {
-            "name": "drupal/csp",
-            "version": "1.33.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/csp.git",
-                "reference": "8.x-1.33"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/csp-8.x-1.33.zip",
-                "reference": "8.x-1.33",
-                "shasum": "c923468c3cf077bbc89967ee7fa6c6e48c7254df"
-            },
-            "require": {
-                "drupal/core": "~10.0.0 || ^10.1.3 || ^11",
-                "ext-json": "*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.33",
-                    "datestamp": "1721292907",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "gapple",
-                    "homepage": "https://www.drupal.org/user/490940"
-                }
-            ],
-            "description": "Provide Content-Security-Policy headers",
-            "homepage": "https://www.drupal.org/project/csp",
-            "keywords": [
-                "Drupal"
-            ],
-            "support": {
-                "source": "https://git.drupalcode.org/project/csp",
-                "issues": "https://www.drupal.org/project/issues/csp"
             }
         },
         {


### PR DESCRIPTION
# [UHF-11975](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11975)

The dependency to `drupal/csp` was added to `helfi_platform_config` and the local version here was conflicting with that.

## What was done

* This PR updates the direct dependency to `drupal/csp` to not have version restrictions to allow installing the version set in `helfi_platform_config`.

## How to install and test

* See install and test instructions in https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1038

## Other PRs

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/1038


[UHF-11973]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UHF-11975]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ