### PR TITLE
UHF-10139: Fixed internal links to look internal

### DIFF
--- a/public/sites/default/all.services.yml
+++ b/public/sites/default/all.services.yml
@@ -2,7 +2,6 @@
 parameters:
   helfi_api_base.internal_domains:
     - 'avustukset.hel.fi'
-    - 'www.avustukset.hel.fi'
     - 'hel-fi-drupal-grant-applications.docker.so'
     - 'avustukset.test.hel.ninja'
     - 'avustukset.dev.hel.ninja'


### PR DESCRIPTION
# [UHF-10139](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10139)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added internal domains to fix internal links across different environments

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10139`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] On the front page go edit the page and just click update for the link in the hero, no need to edit any content. The link should now look internal 
* [ ] Go to https://hel-fi-drupal-grant-applications.docker.so/fi/tietoa-avustuksista/asukasosallisuuden-avustukset and check the links in the accordion, they should now be internal (compare to production https://avustukset.hel.fi/fi/tietoa-avustuksista/asukasosallisuuden-avustukset)
    * [ ] The sidebar link on the page above should still look external since its a link to a pdf on an external site 
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10139]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ