### PR TITLE
UHF-12151: Application custom access check code changes

### DIFF
--- a/public/modules/custom/grants_handler/src/ApplicationAccessHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationAccessHandler.php
@@ -20,7 +20,7 @@ final readonly class ApplicationAccessHandler {
    *
    * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
-  private \Drupal\Core\Logger\LoggerChannelInterface $logger;
+  private LoggerChannelInterface $logger;
 
   /**
    * Constructs an ApplicationAccessHandler object.

--- a/public/modules/custom/grants_handler/src/ApplicationAccessHandler.php
+++ b/public/modules/custom/grants_handler/src/ApplicationAccessHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\grants_handler;
 
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\grants_mandate\CompanySelectException;
 use Drupal\grants_profile\GrantsProfileService;
 use Drupal\webform\Entity\WebformSubmission;
@@ -14,12 +16,22 @@ use Drupal\webform\Entity\WebformSubmission;
 final readonly class ApplicationAccessHandler {
 
   /**
+   * The logger.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  private \Drupal\Core\Logger\LoggerChannelInterface $logger;
+
+  /**
    * Constructs an ApplicationAccessHandler object.
    */
   public function __construct(
     private GrantsProfileService $grantsProfileService,
     private ApplicationGetterService $applicationGetterService,
-  ) {}
+    private LoggerChannelFactoryInterface $loggerFactory,
+  ) {
+    $this->logger = $this->loggerFactory->get('grants_handler');
+  }
 
   /**
    * Gets webform & submission with data and determines access.
@@ -34,42 +46,79 @@ final readonly class ApplicationAccessHandler {
    * @throws \Drupal\grants_mandate\CompanySelectException
    */
   public function singleSubmissionAccess(WebformSubmission $webform_submission): bool {
-
     // If we have account number, load details.
     $selectedCompany = $this->grantsProfileService->getSelectedRoleData();
     if (empty($selectedCompany)) {
       throw new CompanySelectException('User not authorised');
     }
-    $grantsProfileDocument = $this->grantsProfileService->getGrantsProfile($selectedCompany);
+
+    try {
+      $grantsProfileDocument = $this->grantsProfileService->getGrantsProfile($selectedCompany);
+    }
+    catch (\Exception $e) {
+      $this->logger->error(
+        "Failed to load grants profile while checking access: @message",
+        ['@message' => $e->getMessage()],
+      );
+      return FALSE;
+    }
+
+    if (!$grantsProfileDocument) {
+      $this->logger->error("No grants profile found while checking access");
+      return FALSE;
+    }
+
     $profileContent = $grantsProfileDocument->getContent();
     $webformData = $webform_submission->getData();
     $companyType = $selectedCompany['type'] ?? NULL;
-    if (!$companyType || !$webformData) {
+    if (!$companyType) {
+      $this->logger->alert('Application access denied, missing companytype');
+      return FALSE;
+    }
+
+    if (!$webformData) {
+      $this->logger->alert('Application access denied, missing webformdata');
       return FALSE;
     }
 
     if (!isset($webformData['application_number'])) {
+      $this->logger->alert('Application access denied, webformdata missing application_number');
       return FALSE;
     }
 
-    $atvDoc = $this->applicationGetterService->getAtvDocument($webformData['application_number']);
+    try {
+      $atvDoc = $this->applicationGetterService->getAtvDocument($webformData['application_number']);
+    }
+    catch (\Exception $e) {
+      $this->logger->alert('Exception while checking application access: @message', ['@message' => $e->getMessage()]);
+      return FALSE;
+    }
 
     if (!$atvDoc) {
+      $this->logger->alert("Application access denied, missing ATV-document for application");
       return FALSE;
     }
 
     $atvMetadata = $atvDoc->getMetadata();
     // Mismatch between profile and application applicant type.
     if ($companyType !== $webformData['hakijan_tiedot']['applicantType']) {
+      $this->logger->alert("User is trying to access application without proper mandate:
+       Company type ($companyType) does not match the webform data.");
       return FALSE;
     }
     elseif ($companyType == "registered_community" && $profileContent['businessId'] !== $atvDoc->getBusinessId()) {
+      $this->logger->alert("User mandated as registered community is trying to access application,
+        but selected businessId does not match with the application.");
       return FALSE;
     }
     elseif ($companyType === "private_person" && $profileContent['businessId'] !== $atvDoc->getUserId()) {
+      $this->logger->alert("A private person is trying to access application,
+        but selected businessId does not match the application.");
       return FALSE;
     }
     elseif ($companyType === "unregistered_community" && $profileContent['businessId'] !== $atvMetadata['applicant_id']) {
+      $this->logger->alert("User mandated as unregistered_community is trying to access application,
+        but selected businessId does not match the application.");
       return FALSE;
     }
 

--- a/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
@@ -141,9 +141,22 @@ final class ApplicationController extends ControllerBase {
       $webform_submission = $this->applicationGetterService->submissionObjectFromApplicationNumber($submission_id);
     }
     catch (
-    EntityStorageException |
-    CompanySelectException $e) {
-      return AccessResult::forbidden('Submission gettting failed');
+      EntityStorageException |
+      CompanySelectException $e
+    ) {
+      $this->getLogger('grant_access')
+        ->error(
+          'Unable to load entity or company selection failed: @message',
+          ['@message' => $e->getMessage()],
+        );
+      return AccessResult::forbidden('Submission getting failed');
+    }
+    catch (\Exception $e) {
+      $this->getLogger('grant_access')->error(
+        'Unexpected unhandled exception: @message',
+        ['@message' => $e->getMessage()],
+      );
+      return AccessResult::forbidden('Submission getting failed');
     }
 
     if ($webform_submission == NULL) {

--- a/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_handler/src/Controller/ApplicationController.php
@@ -106,7 +106,7 @@ final class ApplicationController extends ControllerBase {
           "Unable to resolve single submission access due to exception: @message",
           ['@message' => $e->getMessage()]
         );
-      return AccessResult::forbidden("Unable to resolve single submission access: {$e->getMessage()}");
+      return AccessResult::forbidden("Unable to resolve single submission access");
     }
 
     // Parameters from the route and/or request as needed.


### PR DESCRIPTION
One user is unable to edit applications and only visible thing is 403-response in kibana (hakemus/7050/muokkaa with message: "").

Handle the unhandled exceptions in application access checks.
Added logging to catch possibly bad access-check cases (for example user's business id doesn't match application's business id sounds more like an erroneous situation than anything else)

# [UHF-12151](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12151)

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12151`
  * `make fresh`
* Run `make drush-cr`

## How to test
The code should not break anything.
- Log in as enduser
- Create a new application or edit existing
- It should work as before



[UHF-12151]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ