### PR TITLE
UHF-12080: Fixed subvention type and status in application print view

### DIFF
--- a/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
+++ b/public/modules/custom/grants_handler/src/Controller/AtvPrintViewController.php
@@ -272,6 +272,7 @@ final class AtvPrintViewController extends ControllerBase {
     $this->handleLiitteetSection($field);
     $this->handleSubventionType($field, $labelData, $langcode, $isSubventionType, $subventionType);
     $this->handleRole($field);
+    $this->handleStatus($field);
     $this->handleBooleanValues($field, $langcode);
   }
 
@@ -404,6 +405,7 @@ final class AtvPrintViewController extends ControllerBase {
     if ($field['ID'] === 'subventionType') {
       $typeNames = CompensationsComposite::getOptionsForTypes($langcode);
       $subventionType = $typeNames[$field['value']];
+      $field['value'] = $subventionType;
       $isSubventionType = TRUE;
     }
     elseif ($isSubventionType) {
@@ -425,6 +427,20 @@ final class AtvPrintViewController extends ControllerBase {
       if ($role) {
         $field['value'] = $role;
       }
+    }
+  }
+
+  /**
+   * Handle status.
+   *
+   * @param array $field
+   *   Field.
+   */
+  private function handleStatus(array &$field): void {
+    if ($field['ID'] == 'status') {
+      // Transform status to be only capitalized and not all uppercase.
+      $normalized = ucfirst(strtolower($field['value']));
+      $field['value'] = $this->t($normalized, [], ['context' => 'Grants application: Status label']);
     }
   }
 


### PR DESCRIPTION
# [UHF-12080](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12080)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Fixed subvention type to have label instead of id
* Added translation for status

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12080`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Log in as some test user to the site
* [ ] Go to "omat hakemukset ja viestintä" and print an application that is sent
    * [ ] Make sure that "Hakemuksen tila" value is now translated (page 1, title "1. Hakijan tiedot")
    * [ ] Make sure "Avustuslajin koodi" has now an actual value instead of id number (page 3, title "2. Avustustiedot"
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Automatic- / Regression tests
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR makes no changes that effects any tests. (This will be caught in automatic testing later on, but please, please run regression tests always on PR before asking for a review)
* [ ] This PR passes regression tests. (`make test-pw`)


