### PR TITLE
UHF-12215 Logging user data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,9 @@
             },
             "drupal/externalauth": {
                 "Anonymize logging of user data.": "patches/externalauth-2.0.8-gdpr-anonymize-logging.patch"
+            },
+            "drupal/helfi_helsinki_profiili": {
+                "Anonymize logging of user data.": "patches/helfi_helsinki_profiili-0.9.30-gdpr-anonymize-logging.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,9 @@
             },
             "drupal/crop": {
                 "Fix encoded paths for files": "patches/AU-2225-fix-encoded-paths.patch"
+            },
+            "drupal/externalauth": {
+                "Anonymize logging of user data.": "patches/externalauth-2.0.8-gdpr-anonymize-logging.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,8 @@
                 "Anonymize logging of user data.": "patches/drupal_10.5.3-user-module-gdpr-anonymize-logging.patch"
             },
             "drupal/autologout": {
-                "Modal related issues": "https://www.drupal.org/files/issues/2023-04-25/autologout.2023-04-25.patch"
+                "Modal related issues": "https://www.drupal.org/files/issues/2023-04-25/autologout.2023-04-25.patch",
+                "Anonymize logging of user data.": "patches/autologout_2.0.0-gdpr-anonymize-logging.patch"
             },
             "drupal/crop": {
                 "Fix encoded paths for files": "patches/AU-2225-fix-encoded-paths.patch"

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,8 @@
             "drupal/core": {
                 "Fix missing wrapper from core form": "patches/fix-form-wrapper.patch",
                 "#3023228: Status messages show up twice": "https://www.drupal.org/files/issues/2023-07-19/3023228-39.patch",
-                "Asset resolver empty settings cache issue": "patches/assetresolver-settings.patch"
+                "Asset resolver empty settings cache issue": "patches/assetresolver-settings.patch",
+                "Anonymize logging of user data.": "patches/drupal_10.5.3-user-module-gdpr-anonymize-logging.patch"
             },
             "drupal/autologout": {
                 "Modal related issues": "https://www.drupal.org/files/issues/2023-04-25/autologout.2023-04-25.patch"

--- a/patches/autologout_2.0.0-gdpr-anonymize-logging.patch
+++ b/patches/autologout_2.0.0-gdpr-anonymize-logging.patch
@@ -1,0 +1,26 @@
+diff --git a/src/AutologoutManager.php b/src/AutologoutManager.php
+index 5c50f99..8574130 100644
+--- a/src/AutologoutManager.php
++++ b/src/AutologoutManager.php
+@@ -15,6 +15,7 @@ use Drupal\Core\Session\AccountInterface;
+ use Drupal\Core\Session\AnonymousUserSession;
+ use Drupal\Core\Session\SessionManager;
+ use Drupal\Core\StringTranslation\StringTranslationTrait;
++use Drupal\user\Entity\User;
+ use Drupal\user\UserData;
+ use Drupal\user\UserDataInterface;
+ use Drupal\user\UserInterface;
+@@ -189,10 +190,9 @@ class AutologoutManager implements AutologoutManagerInterface {
+   public function logout() {
+     $user = $this->currentUser;
+     if ($this->autoLogoutSettings->get('use_watchdog')) {
+-      $this->logger->info(
+-        'Session automatically closed for %name by autologout.',
+-        ['%name' => $user->getAccountName()]
+-      );
++      $this->logger->info('Session automatically closed for UUID %drupal_uuid by autologout.', [
++        '%drupal_uuid' => User::load($user->id())->get('uuid')->getString(),
++      ]);
+     }
+
+     // Destroy the current session.

--- a/patches/drupal_10.5.3-user-module-gdpr-anonymize-logging.patch
+++ b/patches/drupal_10.5.3-user-module-gdpr-anonymize-logging.patch
@@ -1,0 +1,28 @@
+diff --git a/core/modules/user/user.module b/modules/user/user.module
+index 9fafc8f63e..e8f62eb775 100644
+--- a/core/modules/user/user.module
++++ b/core/modules/user/user.module
+@@ -456,7 +456,9 @@ function template_preprocess_username(&$variables) {
+  */
+ function user_login_finalize(UserInterface $account) {
+   \Drupal::currentUser()->setAccount($account);
+-  \Drupal::logger('user')->info('Session opened for %name.', ['%name' => $account->getAccountName()]);
++  \Drupal::logger('user')->info('Session opened for UUID %drupal_uuid.', [
++    '%drupal_uuid' => $account->get('uuid')->getString(),
++  ]);
+   // Update the user table timestamp noting user has logged in.
+   // This is also used to invalidate one-time login links.
+   $account->setLastLoginTime(\Drupal::time()->getRequestTime());
+@@ -1237,9 +1239,9 @@ function user_toolbar() {
+  */
+ function user_logout() {
+   $user = \Drupal::currentUser();
+-
+-  \Drupal::logger('user')->info('Session closed for %name.', ['%name' => $user->getAccountName()]);
+-
++  \Drupal::logger('user')->info('Session closed for UUID %drupal_uuid.', [
++    '%drupal_uuid' => User::load($user->id())->get('uuid')->getString(),
++  ]);
+   \Drupal::moduleHandler()->invokeAll('user_logout', [$user]);
+
+   // Destroy the current session, and reset $user to the anonymous user.

--- a/patches/externalauth-2.0.8-gdpr-anonymize-logging.patch
+++ b/patches/externalauth-2.0.8-gdpr-anonymize-logging.patch
@@ -1,0 +1,47 @@
+diff --git a/src/ExternalAuth.php b/src/ExternalAuth.php
+index 8bd8247..3f22e63 100644
+--- a/src/ExternalAuth.php
++++ b/src/ExternalAuth.php
+@@ -102,7 +102,7 @@ class ExternalAuth implements ExternalAuthInterface {
+ 
+     $account_search = $entity_storage->loadByProperties(['name' => $authmap_event->getUsername()]);
+     if ($account = reset($account_search)) {
+-      throw new ExternalAuthRegisterException(sprintf('User could not be registered. There is already an account with username "%s"', $authmap_event->getUsername()));
++      throw new ExternalAuthRegisterException(sprintf('User could not be registered. There is already an account with UUID "%s"', $authname));
+     }
+ 
+     // Set up the account data to be used for the user entity.
+@@ -121,9 +121,8 @@ class ExternalAuth implements ExternalAuthInterface {
+     $account->save();
+     $this->authmap->save($account, $provider, $authmap_event->getAuthname(), $authmap_event->getData());
+     $this->eventDispatcher->dispatch(new ExternalAuthRegisterEvent($account, $provider, $authmap_event->getAuthname(), $authmap_event->getData()), ExternalAuthEvents::REGISTER);
+-    $this->logger->notice('External registration of user %name from provider %provider and authname %authname',
++    $this->logger->notice('External registration of user UUID %authname from provider %provider.',
+       [
+-        '%name' => $account->getAccountName(),
+         '%provider' => $provider,
+         '%authname' => $authname,
+       ]
+@@ -151,7 +150,7 @@ class ExternalAuth implements ExternalAuthInterface {
+    */
+   public function userLoginFinalize(UserInterface $account, string $authname, string $provider): UserInterface {
+     user_login_finalize($account);
+-    $this->logger->notice('External login of user %name', ['%name' => $account->getAccountName()]);
++    $this->logger->notice('External login of UUID %authname', ['%authname' => $authname]);
+     $this->eventDispatcher->dispatch(new ExternalAuthLoginEvent($account, $provider, $authname), ExternalAuthEvents::LOGIN);
+     return $account;
+   }
+@@ -169,12 +168,9 @@ class ExternalAuth implements ExternalAuthInterface {
+ 
+     // If we update the authmap entry, let's log the change.
+     if (!empty($current_authname)) {
+-      $this->logger->debug('Authmap change (%old => %new) for user %name with uid %uid from provider %provider', [
++      $this->logger->debug('Authmap change for UUID %old. New UUID %new.', [
+         '%old' => $current_authname,
+         '%new' => $authname,
+-        '%name' => $account->getAccountName(),
+-        '%uid' => $account->id(),
+-        '%provider' => $provider,
+       ]);
+     }
+ 

--- a/patches/externalauth-2.0.8-gdpr-anonymize-logging.patch
+++ b/patches/externalauth-2.0.8-gdpr-anonymize-logging.patch
@@ -1,22 +1,22 @@
 diff --git a/src/ExternalAuth.php b/src/ExternalAuth.php
-index 8bd8247..3f22e63 100644
+index 8bd8247..eadb339 100644
 --- a/src/ExternalAuth.php
 +++ b/src/ExternalAuth.php
 @@ -102,7 +102,7 @@ class ExternalAuth implements ExternalAuthInterface {
- 
+
      $account_search = $entity_storage->loadByProperties(['name' => $authmap_event->getUsername()]);
      if ($account = reset($account_search)) {
 -      throw new ExternalAuthRegisterException(sprintf('User could not be registered. There is already an account with username "%s"', $authmap_event->getUsername()));
-+      throw new ExternalAuthRegisterException(sprintf('User could not be registered. There is already an account with UUID "%s"', $authname));
++      throw new ExternalAuthRegisterException(sprintf('User could not be registered. There is already an account with mapped UUID "%s".', $authname));
      }
- 
+
      // Set up the account data to be used for the user entity.
 @@ -121,9 +121,8 @@ class ExternalAuth implements ExternalAuthInterface {
      $account->save();
      $this->authmap->save($account, $provider, $authmap_event->getAuthname(), $authmap_event->getData());
      $this->eventDispatcher->dispatch(new ExternalAuthRegisterEvent($account, $provider, $authmap_event->getAuthname(), $authmap_event->getData()), ExternalAuthEvents::REGISTER);
 -    $this->logger->notice('External registration of user %name from provider %provider and authname %authname',
-+    $this->logger->notice('External registration of user UUID %authname from provider %provider.',
++    $this->logger->notice('External registration of mapped UUID %authname from provider %provider.',
        [
 -        '%name' => $account->getAccountName(),
          '%provider' => $provider,
@@ -27,16 +27,16 @@ index 8bd8247..3f22e63 100644
    public function userLoginFinalize(UserInterface $account, string $authname, string $provider): UserInterface {
      user_login_finalize($account);
 -    $this->logger->notice('External login of user %name', ['%name' => $account->getAccountName()]);
-+    $this->logger->notice('External login of UUID %authname', ['%authname' => $authname]);
++    $this->logger->notice('External login of mapped UUID %authname.', ['%authname' => $authname]);
      $this->eventDispatcher->dispatch(new ExternalAuthLoginEvent($account, $provider, $authname), ExternalAuthEvents::LOGIN);
      return $account;
    }
 @@ -169,12 +168,9 @@ class ExternalAuth implements ExternalAuthInterface {
- 
+
      // If we update the authmap entry, let's log the change.
      if (!empty($current_authname)) {
 -      $this->logger->debug('Authmap change (%old => %new) for user %name with uid %uid from provider %provider', [
-+      $this->logger->debug('Authmap change for UUID %old. New UUID %new.', [
++      $this->logger->debug('Authmap change for UUID %old. New mapped UUID %new.', [
          '%old' => $current_authname,
          '%new' => $authname,
 -        '%name' => $account->getAccountName(),
@@ -44,4 +44,3 @@ index 8bd8247..3f22e63 100644
 -        '%provider' => $provider,
        ]);
      }
- 

--- a/patches/helfi_helsinki_profiili-0.9.30-gdpr-anonymize-logging.patch
+++ b/patches/helfi_helsinki_profiili-0.9.30-gdpr-anonymize-logging.patch
@@ -1,0 +1,15 @@
+diff --git a/src/HelsinkiProfiiliUserData.php b/src/HelsinkiProfiiliUserData.php
+index 892d944..8341895 100644
+--- a/src/HelsinkiProfiiliUserData.php
++++ b/src/HelsinkiProfiiliUserData.php
+@@ -360,8 +360,8 @@ class HelsinkiProfiiliUserData {
+         throw new ProfileDataException('No profile data found');
+       }
+       else {
+-        $this->logger->notice('User %user got their HelsinkiProfiili data form endpoint', [
+-          '%user' => $this->currentUser->getDisplayName(),
++        $this->logger->notice('User with UUID %drupal_uuid got their HelsinkiProfiili data form endpoint', [
++          '%drupal_uuid' => $this->currentUser->getAccount()->get('uuid')->getString(),
+         ]);
+       }
+ 


### PR DESCRIPTION
# [UHF-12215](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12215)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added a patches for the following modules to anonymise user data when logging user activities.
   * autologout
   * externalauth
   * helfi_helsinki_profiili
   * drupal core: user

## How to install

* Make sure your instance is up and running on dev branch.
  * `git checkout dev`
  * `make fresh`
* Checkout this branch and run composer install: 
   * `git checkout UHF-12215 && composer i`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] In terminal, run: `docker logs hel-fi-drupal-grant-applications-app -f`
   * Hit enter few times to add some spacing.. 
* [ ] [Log in](https://hel-fi-drupal-grant-applications.docker.so/fi/user/login) to your instance with demo user
* [ ] Check the logs for any details about logging in. They used to be something like the ones below. Now there should be only mentions about UUIDs.
```
External login of user <Real Name>
Session opened for <Real Name> .
External registration of user <Real Name> from provider openid_connect.tunnistamo and authname 00000000-0000-0000-0000-000000000000
User <Real Name> got their HelsinkiProfiili data form endpoint
Session automatically closed for <Real Name> by autologout.
Session closed for <Real Name>.
```
* [ ] Check that code follows our standards
