### PR TITLE
UHF-12793: Fixed attachments in form preview

### DIFF
--- a/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
@@ -322,8 +322,6 @@ final class GrantsAttachments extends WebformCompositeBase {
       }
     }
 
-    dump($lines);
-
     return $lines;
   }
 

--- a/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
+++ b/public/modules/custom/grants_attachments/src/Plugin/WebformElement/GrantsAttachments.php
@@ -269,10 +269,10 @@ final class GrantsAttachments extends WebformCompositeBase {
     if (isset($value["integrationID"]) && !empty($value["integrationID"])) {
       // Add filename if it has been uploaded earlier.
       if (isset($value["fileName"]) && !empty($value["fileName"]) && !in_array($value["fileName"], $lines)) {
-        $lines[] = '<strong>' . $value["fileName"] . '</strong>';
+        $lines[] = ['#markup' => '<strong>' . $value["fileName"] . '</strong>'];
       }
       elseif (isset($value["attachmentName"]) && !empty($value["attachmentName"]) && !in_array($value["attachmentName"], $lines)) {
-        $lines[] = '<strong>' . $value["attachmentName"] . '</strong>';
+        $lines[] = ['#markup' => '<strong>' . $value["attachmentName"] . '</strong>'];
       }
     }
 
@@ -307,20 +307,22 @@ final class GrantsAttachments extends WebformCompositeBase {
     if ((isset($value["fileName"]) && !empty($value["fileName"])) || (isset($value["attachmentName"]) &&
         !empty($value["attachmentName"]))) {
       if (isset($value["attachmentName"]) && in_array($value["attachmentName"], $attachmentEvents["event_targets"])) {
-        $lines[] = '<span class="upload-ok-icon">' . $this->t('Upload OK', [], $tOpts) . '</span>';
+        $lines[] = ['#markup' => '<span class="upload-ok-icon">' . $this->t('Upload OK', [], $tOpts) . '</span>'];
       }
       elseif (isset($value["fileName"]) && in_array($value["fileName"], $attachmentEvents["event_targets"])) {
-        $lines[] = '<span class="upload-ok-icon">' . $this->t('Upload OK', [], $tOpts) . '</span>';
+        $lines[] = ['#markup' => '<span class="upload-ok-icon">' . $this->t('Upload OK', [], $tOpts) . '</span>'];
       }
       // If we have integrationID & status is justuploaded then we know
       // upload was fine.
       elseif (isset($value["integrationID"]) && $value['fileStatus'] == 'justUploaded') {
-        $lines[] = '<span class="upload-ok-icon">' . $this->t('Upload OK', [], $tOpts) . '</span>';
+        $lines[] = ['#markup' => '<span class="upload-ok-icon">' . $this->t('Upload OK', [], $tOpts) . '</span>'];
       }
       else {
-        $lines[] = '<span class="upload-fail-icon">' . $this->t('Upload pending / File missing', [], $tOpts) . '</span>';
+        $lines[] = ['#markup' => '<span class="upload-fail-icon">' . $this->t('Upload pending / File missing', [], $tOpts) . '</span>'];
       }
     }
+
+    dump($lines);
 
     return $lines;
   }


### PR DESCRIPTION
# [UHF-12793](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12793)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fixed rendering of attachments in webform preview

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12793`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Log in as end user and create a new application (webform) for example this one https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/iakkaiden_kulttuuri_ja_liikunta
* [ ] Go to attachments page and add more than one attachment just to see that the styles work properly
* [ ] Go preview the form and make sure there isn't anymore html tags visible 
* [ ] Check that the code follows our standards

<!--
Check list for the developer

Privacy
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.

E2E tests
- Make sure the tests pass when you run `make test-pw` on your local.
- Detailed instructions can be found here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/dev/e2e/README.md#environment-setup

Application that are no longer used
- Archive the webform applications after they are no longer used. This stops users from sending old drafts of the archived application.
- Archived webforms must also be removed from the E2E tests since they can't be tested after archiving.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
*


[UHF-12793]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ