### PR TITLE
Uhf 13099 part 4: Simplify HelsinkiProfiiliUserData

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11801,16 +11801,6 @@ parameters:
 			path: public/modules/custom/helfi_av/tests/src/Unit/AntivirusServiceTest.php
 
 		-
-			message: "#^Function helfi_helsinki_profiili_openid_connect_post_authorize\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
-
-		-
-			message: "#^Function helfi_helsinki_profiili_user_logout\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
-
-		-
 			message: "#^Call to an undefined method Drupal\\\\Core\\\\Session\\\\AccountInterface\\:\\:get\\(\\)\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11811,11 +11811,6 @@ parameters:
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 
 		-
-			message: "#^Dead catch \\- Exception is never thrown in the try block\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:checkPrimaryFields\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5021,11 +5021,6 @@ parameters:
 			path: public/modules/custom/grants_handler/src/GrantsHandlerNavigationHelper.php
 
 		-
-			message: "#^Method Drupal\\\\grants_handler\\\\GrantsHandlerNavigationHelper\\:\\:logErrors\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: public/modules/custom/grants_handler/src/GrantsHandlerNavigationHelper.php
-
-		-
 			message: "#^Method Drupal\\\\grants_handler\\\\GrantsHandlerNavigationHelper\\:\\:logErrors\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/grants_handler/src/GrantsHandlerNavigationHelper.php
@@ -11832,11 +11827,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getApiAccessTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getCurrentUserRoles\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11836,11 +11836,6 @@ parameters:
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 
 		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:debugPrint\\(\\) has parameter \\$replacements with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:filterData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -11962,11 +11957,6 @@ parameters:
 
 		-
 			message: "#^Property Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:\\$openIdConfiguration type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\<string, string\\>\\|string\\|false and true will always evaluate to false\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11856,11 +11856,6 @@ parameters:
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 
 		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:setUserData\\(\\) has parameter \\$userData with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:verifyJwtToken\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11831,11 +11831,6 @@ parameters:
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 
 		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getAdminRoles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getApiAccessTokens\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -11852,11 +11847,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getHelsinkiProfiiliToken\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getHpUserRoles\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11841,37 +11841,7 @@ parameters:
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 
 		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getFromCache\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getHelsinkiProfiiliToken\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getJwks\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getOpenIdConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getOpenidConfigurationFromIssuer\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getTokenData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:getTunnistamoEnvUrl\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 
@@ -11902,36 +11872,6 @@ parameters:
 
 		-
 			message: "#^Method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:verifyJwtToken\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Parameter \\#1 \\$exception of method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:dispatchExceptionEvent\\(\\) expects Exception, Exception\\|GuzzleHttp\\\\Exception\\\\GuzzleException given\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Parameter \\#1 \\$exception of method Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:dispatchExceptionEvent\\(\\) expects Exception, GuzzleHttp\\\\Exception\\\\GuzzleException given\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Parameter \\#2 \\$uri of method GuzzleHttp\\\\ClientInterface\\:\\:request\\(\\) expects Psr\\\\Http\\\\Message\\\\UriInterface\\|string, string\\|false given\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Property Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:\\$hpAdminRoles type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Property Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:\\$hpUserRoles type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
-
-		-
-			message: "#^Property Drupal\\\\helfi_helsinki_profiili\\\\HelsinkiProfiiliUserData\\:\\:\\$openIdConfiguration type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
 

--- a/public/modules/custom/grants_audit_log/src/EventSubscriber/GrantsAuditLogEventSubscriber.php
+++ b/public/modules/custom/grants_audit_log/src/EventSubscriber/GrantsAuditLogEventSubscriber.php
@@ -68,12 +68,19 @@ class GrantsAuditLogEventSubscriber implements EventSubscriberInterface {
     $userId = $this->currentUser->id();
     // Get current user.
     if ($role == 'USER') {
-      $isAuthenticatedExternally = $this->helsinkiProfiiliUserData->isAuthenticatedExternally();
-      if ($isAuthenticatedExternally) {
+      try {
         $data = $this->helsinkiProfiiliUserData->getUserData();
-        if ($data !== NULL && $data['sid']) {
+
+        if (isset($data['sid'])) {
           $userId = $data['sid'];
         }
+      }
+      catch (\InvalidArgumentException) {
+        // If present, replace user id with sid field from tunnistamo jwt
+        // token. HelsinkiProfiiliUserData::getUserData throws if the helsinki
+        // profiili token is not available. In that case, something has
+        // probably gone very wrong already, but I don't think this should
+        // prevent logging here.
       }
     }
     $message = $event->getMessage();

--- a/public/modules/custom/grants_handler/src/GrantsHandlerNavigationHelper.php
+++ b/public/modules/custom/grants_handler/src/GrantsHandlerNavigationHelper.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
 use Drupal\webform\WebformInterface;
 use Drupal\webform\WebformSubmissionInterface;
@@ -51,6 +52,7 @@ class GrantsHandlerNavigationHelper {
     protected FormBuilderInterface $formBuilder,
     protected HelsinkiProfiiliUserData $helsinkiProfiiliUserData,
     protected TimeInterface $timeInterface,
+    protected AccountProxyInterface $currentUser,
   ) {
     $this->cache = [];
   }
@@ -273,7 +275,7 @@ class GrantsHandlerNavigationHelper {
         'operation' => self::PAGE_VISITED_OPERATION,
         'handler_id' => self::HANDLER_ID,
         'application_number' => $data['application_number'] ?? '',
-        'uid' => $this->helsinkiProfiiliUserData->getCurrentUser()->id(),
+        'uid' => $this->currentUser->id(),
         'user_uuid' => $userData['sub'] ?? '',
         'data' => $page,
         'page' => $page,
@@ -322,8 +324,7 @@ class GrantsHandlerNavigationHelper {
    *
    * @throws \Exception
    */
-  public function logErrors(WebformSubmissionInterface $webformSubmission, array $errors, string $page) {
-
+  public function logErrors(WebformSubmissionInterface $webformSubmission, array $errors, string $page): void {
     $wfId = $webformSubmission->id();
     // Get out from here if the submission hasn't been saved yet.
     if ($wfId == NULL) {
@@ -343,7 +344,7 @@ class GrantsHandlerNavigationHelper {
         'operation' => self::ERROR_OPERATION,
         'handler_id' => self::HANDLER_ID,
         'application_number' => $data['application_number'] ?? '',
-        'uid' => $this->helsinkiProfiiliUserData->getCurrentUser()->id(),
+        'uid' => $this->currentUser->id(),
         'user_uuid' => $userData['sub'] ?? '',
         'data' => serialize($errors),
         'page' => $page,

--- a/public/modules/custom/helfi_helsinki_profiili/README.md
+++ b/public/modules/custom/helfi_helsinki_profiili/README.md
@@ -6,7 +6,6 @@ Userdata is queried from graphql endpoint in Tunnistamo. Userdata is saved for r
 
 ## Before use ##
 - Make sure you have environment variables `GDPR_API_AUD_SERVICE` and `GDPR_API_AUD_HOST` set
-- Debug mode can be enabled setting `DEBUG` environment variable to `TRUE`
 
 ## Configuration
 

--- a/public/modules/custom/helfi_helsinki_profiili/config/schema/helfi_helsinki_profiili.schema.yml
+++ b/public/modules/custom/helfi_helsinki_profiili/config/schema/helfi_helsinki_profiili.schema.yml
@@ -14,3 +14,9 @@ helfi_helsinki_profiili.settings:
     clients:
       type: sequence
       label: 'Client ids used with helsinki profile.'
+    tunnistamo_environment_url:
+      type: string
+      label: 'Tunnistamo environment url.'
+    userinfo_profile_endpoint:
+      type: string
+      label: 'Userinfo profile endpoint url.'

--- a/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
+++ b/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
@@ -38,8 +38,6 @@ function helfi_helsinki_profiili_openid_connect_post_authorize(UserInterface $ac
   if (empty($context["user_data"]["ad_groups"])) {
     try {
       $profileDAO = \Drupal::service(HelsinkiProfiiliUserData::class);
-      // Set user data from openid.
-      $profileDAO->setUserData($context['user_data']);
       // Fetch HelsinkiProfile data.
       try {
         $data = $profileDAO->getUserProfileData();

--- a/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
+++ b/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
@@ -5,7 +5,6 @@
  * Primary module hooks for Helsinki-profiili module.
  */
 
-use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\TempStore\TempStoreException;
 use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
 use Drupal\helfi_helsinki_profiili\ProfileDataException;

--- a/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
+++ b/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
@@ -81,11 +81,3 @@ function helfi_helsinki_profiili_openid_connect_post_authorize(UserInterface $ac
   }
 
 }
-
-/**
- * Implements hook_user_logout().
- */
-function helfi_helsinki_profiili_user_logout(AccountProxyInterface $account): void {
-  \Drupal::service(HelsinkiProfiiliUserData::class)
-    ->clearCache();
-}

--- a/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
+++ b/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.module
@@ -3,14 +3,11 @@
 /**
  * @file
  * Primary module hooks for Helsinki-profiili module.
- *
- * @DCG
- * This file is no longer required in Drupal 8.
- * @see https://www.drupal.org/node/2217931
  */
 
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\TempStore\TempStoreException;
+use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
 use Drupal\helfi_helsinki_profiili\ProfileDataException;
 use Drupal\helfi_helsinki_profiili\TokenExpiredException;
 use Drupal\user\UserInterface;
@@ -22,20 +19,14 @@ use GuzzleHttp\Exception\GuzzleException;
  * This hook runs after a user has been authorized and claims have been mapped
  * to the user's account.
  *
- * A popular use case for this hook is saving token and additional identity
- * provider related information to the user's Drupal session (private temp
- * store).
- *
  * @param \Drupal\user\UserInterface $account
  *   User account object of the authorized user.
- * @param array $context
+ * @param array<mixed> $context
  *   An associative array with context information:
  *   - tokens:         An array of tokens.
  *   - user_data:      An array of user and session data.*
  *   - plugin_id:      The plugin identifier.
  *   - sub:            The remote user identifier.
- *
- * @ingroup openid_connect_api
  */
 function helfi_helsinki_profiili_openid_connect_post_authorize(UserInterface $account, array $context): void {
   $session = \Drupal::request()->getSession();
@@ -47,8 +38,7 @@ function helfi_helsinki_profiili_openid_connect_post_authorize(UserInterface $ac
 
   if (empty($context["user_data"]["ad_groups"])) {
     try {
-      /** @var Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData $profileDAO */
-      $profileDAO = \Drupal::service('helfi_helsinki_profiili.userdata');
+      $profileDAO = \Drupal::service(HelsinkiProfiiliUserData::class);
       // Set user data from openid.
       $profileDAO->setUserData($context['user_data']);
       // Fetch HelsinkiProfile data.
@@ -95,8 +85,7 @@ function helfi_helsinki_profiili_openid_connect_post_authorize(UserInterface $ac
 /**
  * Implements hook_user_logout().
  */
-function helfi_helsinki_profiili_user_logout(AccountProxyInterface $account) {
-  /** @var Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData */
-  $helsinkiProfiili = \Drupal::service('helfi_helsinki_profiili.userdata');
-  $helsinkiProfiili->clearCache();
+function helfi_helsinki_profiili_user_logout(AccountProxyInterface $account): void {
+  \Drupal::service(HelsinkiProfiiliUserData::class)
+    ->clearCache();
 }

--- a/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.services.yml
+++ b/public/modules/custom/helfi_helsinki_profiili/helfi_helsinki_profiili.services.yml
@@ -3,9 +3,9 @@ services:
     autowire: true
     autoconfigure: true
 
-  logger.channel.helsinki_profiili:
+  logger.channel.helfi_helsinki_profiili:
     parent: logger.channel_base
-    arguments: [ 'helsinki_profiili' ]
+    arguments: [ 'helfi_helsinki_profiili' ]
 
   helfi_helsinki_profiili.userdata:
     class: Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData

--- a/public/modules/custom/helfi_helsinki_profiili/src/Controller/HelfiGdprApiController.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/Controller/HelfiGdprApiController.php
@@ -11,6 +11,8 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\Core\Language\ContextProvider\CurrentLanguageContext;
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
+use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drupal\helfi_atv\AtvAuthFailedException;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvFailedToConnectException;
@@ -54,28 +56,6 @@ class HelfiGdprApiController extends ControllerBase {
    */
   protected array $audienceConfig;
 
-  /**
-   * Debug or not?
-   */
-  protected bool $debug;
-
-  /**
-   * Is debug on?
-   */
-  public function isDebug(): bool {
-    return $this->debug;
-  }
-
-  /**
-   * Set debug value.
-   *
-   * @param bool $debug
-   *   True / False?
-   */
-  public function setDebug(bool $debug): void {
-    $this->debug = $debug;
-  }
-
   public function __construct(
     protected RequestStack $request,
     protected HelsinkiProfiiliUserData $helsinkiProfiiliUserData,
@@ -84,17 +64,14 @@ class HelfiGdprApiController extends ControllerBase {
     #[Autowire(service: 'language.current_language_context')]
     protected CurrentLanguageContext $currentLanguageContext,
     protected Connection $connection,
+    private readonly EnvironmentResolverInterface $environmentResolver,
   ) {
     // @todo Fail if these variables are not set.
     $serviceName = getenv('GDPR_API_AUD_SERVICE') ?: '';
     $audienceHost = getenv('GDPR_API_AUD_HOST') ?: '';
 
     $this->audienceConfig = ['service_name' => $serviceName, 'audience_host' => $audienceHost];
-
-    $this->setDebug(getenv('DEBUG') == 'true' || getenv('DEBUG') == TRUE);
     $this->parseJwt();
-
-    $this->debug('Audience config: @config', ['@config' => Json::encode($this->audienceConfig)]);
   }
 
   /**
@@ -106,9 +83,8 @@ class HelfiGdprApiController extends ControllerBase {
     $decoded = NULL;
 
     try {
-      $this->debug('GDPR Api access called. JWT token: @token', ['@token' => $this->jwtToken], TRUE);
       $decoded = $this->helsinkiProfiiliUserData->verifyJwtToken($this->jwtToken);
-      $this->debug('GDPR Api access called. JWT token contents: @token', ['@token' => Json::encode($decoded)], TRUE);
+      $this->log('GDPR Api access called. JWT token contents: @token', ['@token' => Json::encode($decoded)]);
     }
     catch (\InvalidArgumentException $e) {
       $deniedReason = $e->getMessage();
@@ -158,26 +134,24 @@ class HelfiGdprApiController extends ControllerBase {
     $expectedAudience = $this->audienceConfig['service_name'];
 
     if ($decoded['sub'] !== $userId) {
-      $this->debug(
+      $this->log(
         'GDPR Api access failed: User ID mismatch - JWT value: @jwt Endpoint value: @endpoint',
         [
           '@jwt' => $decoded['sub'],
           '@endpoint' => $userId,
         ],
-        TRUE
       );
       return AccessResult::forbidden('User ID mismatch');
     }
 
     // If audience does not match, forbid access.
     if ($audience != $expectedAudience) {
-      $this->debug(
+      $this->log(
         'Access DENIED. Reason: @reason. JWT token: @token',
         [
           '@token' => $this->jwtToken,
           '@reason' => 'Audience mismatch',
         ],
-        TRUE
       );
       return AccessResult::forbidden('Audience mismatch');
     }
@@ -189,13 +163,12 @@ class HelfiGdprApiController extends ControllerBase {
     };
 
     if (in_array($hostkey, $decoded['authorization']->permissions[0]->scopes)) {
-      $this->debug(
+      $this->log(
         'Local access GRANTED. Reason: @reason. JWT token: @token',
         [
           '@token' => $this->jwtToken,
           '@reason' => 'All match..',
         ],
-        TRUE
       );
       return AccessResult::allowed();
     }
@@ -533,40 +506,23 @@ class HelfiGdprApiController extends ControllerBase {
   }
 
   /**
-   * Print to debug stream.
+   * Logs messages.
    *
    * @param string $msg
    *   Message.
    * @param array<mixed> $options
    *   Options.
-   * @param bool $sensitive
-   *   Does the debug msg contain sensitive information?
-   *   These will be removed in production environments.
    */
-  private function debug(string $msg, array $options = [], bool $sensitive = FALSE): void {
-    if ($sensitive && $this->isProduction()) {
-      $sensitiveValues = ['@jwt', '@token'];
-      foreach ($sensitiveValues as $sensitiveValue) {
-        if (isset($options[$sensitiveValue])) {
-          $options[$sensitiveValue] = '<redacted>';
-        }
+  private function log(string $msg, array $options = []): void {
+    if ($this->environmentResolver->getActiveEnvironmentName() === EnvironmentEnum::Prod->value) {
+
+      // Hide sensitive values in production environment.
+      if (isset($options['@token'])) {
+        $options['@token'] = '<redacted>';
       }
     }
 
-    if ($this->isDebug()) {
-      $this->getLogger('helf_gdpr_api')->debug($msg, $options);
-    }
-  }
-
-  /**
-   * Check if current environment is production.
-   *
-   * @return bool
-   *   Returns true if the environment is production.
-   */
-  private function isProduction(): bool {
-    $appEnv = getenv('APP_ENV');
-    return in_array($appEnv, ['production', 'PRODUCTION', 'prod', 'PROD']);
+    $this->getLogger('helf_gdpr_api')->info($msg, $options);
   }
 
 }

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -56,16 +56,6 @@ class HelsinkiProfiiliUserData implements LoggerAwareInterface {
   }
 
   /**
-   * Figure out if user is authed.
-   *
-   * @return bool
-   *   If user is authenticated externally.
-   */
-  public function isAuthenticatedExternally(): bool {
-    return !($this->openidConnectSession->retrieveIdToken() === NULL);
-  }
-
-  /**
    * Get user authentication level from suomifi / helsinkiprofile.
    *
    * @return string

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -477,27 +477,6 @@ class HelsinkiProfiiliUserData {
   /**
    * Whether or not we have made this query?
    *
-   * @param string $key
-   *   Used key for caching.
-   *
-   * @return bool
-   *   Is this cached?
-   */
-  public function clearCache($key = ''): bool {
-    try {
-      // $session = $this->requestStack->getCurrentRequest()->getSession();
-      // $session->clear();
-      return TRUE;
-    }
-    catch (\Exception $e) {
-      $this->dispatchExceptionEvent($e);
-      return FALSE;
-    }
-  }
-
-  /**
-   * Whether or not we have made this query?
-   *
    * @param string|null $key
    *   Used key for caching.
    *

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -83,16 +83,6 @@ class HelsinkiProfiiliUserData implements LoggerAwareInterface {
   }
 
   /**
-   * Set user data to private store.
-   *
-   * @param array $userData
-   *   Userdata retrieved from HP.
-   */
-  public function setUserData(array $userData): void {
-    $this->setToCache('userData', $userData);
-  }
-
-  /**
    * Get user data from tempstore.
    *
    * @return array

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -516,26 +516,6 @@ class HelsinkiProfiiliUserData implements LoggerAwareInterface {
   }
 
   /**
-   * Get current user data.
-   *
-   * @return \Drupal\Core\Session\AccountProxyInterface
-   *   Current user.
-   */
-  public function getCurrentUser(): AccountProxyInterface {
-    return $this->currentUser;
-  }
-
-  /**
-   * Get roles of the current user.
-   *
-   * @return array
-   *   Roles.
-   */
-  public function getCurrentUserRoles(): array {
-    return $this->currentUser->getRoles();
-  }
-
-  /**
    * Get openid configurations.
    *
    * @todo We should cache this response.

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -56,13 +56,6 @@ class HelsinkiProfiiliUserData {
   private array $openIdConfiguration = [];
 
   /**
-   * Debug status.
-   *
-   * @var bool
-   */
-  protected bool $debug;
-
-  /**
    * The module config.
    *
    * @var \Drupal\Core\Config\Config
@@ -96,15 +89,6 @@ class HelsinkiProfiiliUserData {
     }
     else {
       $this->hpAdminRoles = [];
-    }
-
-    $debug = getenv('DEBUG');
-
-    if ($debug == 'true' || $debug === TRUE) {
-      $this->debug = TRUE;
-    }
-    else {
-      $this->debug = FALSE;
     }
   }
 
@@ -827,43 +811,9 @@ class HelsinkiProfiiliUserData {
   public function verifyJwtToken(string $jwt): array {
     $jwks = $this->getJwks();
 
-    $this->debugPrint('JWKS -> @jwks', ['@jwks' => Json::encode($jwks)]);
+    $this->logger->debug('JWKS -> @jwks', ['@jwks' => Json::encode($jwks)]);
 
     return (array) JWT::decode($jwt, JWK::parseKeySet($this->getJwks()));
-  }
-
-  /**
-   * Print debug messages.
-   *
-   * @param string $message
-   *   Message.
-   * @param array $replacements
-   *   Replacements.
-   */
-  public function debugPrint(string $message, array $replacements = []): void {
-    if ($this->isDebug()) {
-      $this->logger->debug($message, $replacements);
-    }
-  }
-
-  /**
-   * Is debug on?
-   *
-   * @return bool
-   *   Debug boolean.
-   */
-  public function isDebug(): bool {
-    return $this->debug;
-  }
-
-  /**
-   * Set debug value.
-   *
-   * @param bool $debug
-   *   Debug boolean value.
-   */
-  public function setDebug(bool $debug): void {
-    $this->debug = $debug;
   }
 
   /**

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -63,13 +63,6 @@ class HelsinkiProfiiliUserData {
   protected bool $debug;
 
   /**
-   * Endpoint for api tokens.
-   *
-   * @var string
-   */
-  protected string $apiTokenEndpoint;
-
-  /**
    * The module config.
    *
    * @var \Drupal\Core\Config\Config
@@ -104,11 +97,6 @@ class HelsinkiProfiiliUserData {
     else {
       $this->hpAdminRoles = [];
     }
-
-    $apiTokenEndpoint = getenv('TUNNISTAMO_API_TOKEN_ENDPOINT') ?: '';
-
-    // Set api endpoint url.
-    $this->apiTokenEndpoint = $apiTokenEndpoint;
 
     $debug = getenv('DEBUG');
 
@@ -876,16 +864,6 @@ class HelsinkiProfiiliUserData {
    */
   public function setDebug(bool $debug): void {
     $this->debug = $debug;
-  }
-
-  /**
-   * Get api endpoint for apikeys.
-   *
-   * @return string
-   *   Endpoint url
-   */
-  public function getApiTokenEndpoint(): string {
-    return $this->apiTokenEndpoint;
   }
 
   /**

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -626,26 +626,6 @@ class HelsinkiProfiiliUserData {
   }
 
   /**
-   * Get user roles that have helsinki profile authentication.
-   *
-   * @return array
-   *   Helsinki profiili user roles.
-   */
-  public function getHpUserRoles(): array {
-    return $this->hpUserRoles;
-  }
-
-  /**
-   * Get admin roles.
-   *
-   * @return array
-   *   Helsinki profiili admin roles.
-   */
-  public function getAdminRoles(): array {
-    return $this->hpAdminRoles;
-  }
-
-  /**
    * Get openid configurations.
    *
    * @return array

--- a/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/HelsinkiProfiiliUserData.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Drupal\helfi_helsinki_profiili;
 
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\Xss;
 use Drupal\helfi_helsinki_profiili\Helper\JwtHelper;
-use Drupal\Core\Config\Config;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -24,72 +22,37 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use GuzzleHttp\Utils;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Integrate HelsinkiProfiili data to Drupal User.
  */
-class HelsinkiProfiiliUserData {
+class HelsinkiProfiiliUserData implements LoggerAwareInterface {
 
-  /**
-   * Store user roles for helsinki profile users.
-   *
-   * @var array
-   */
-  protected array $hpUserRoles;
-
-  /**
-   * User roles for form administration.
-   *
-   * @var array
-   */
-  protected array $hpAdminRoles;
+  use LoggerAwareTrait;
 
   /**
    * Store details about oidc issuer.
    *
-   * @var array
+   * @phpstan-var array<mixed>
    */
   private array $openIdConfiguration = [];
-
-  /**
-   * The module config.
-   *
-   * @var \Drupal\Core\Config\Config
-   */
-  protected Config $config;
 
   public function __construct(
     private readonly OpenIDConnectSessionInterface $openidConnectSession,
     private readonly ClientInterface $httpClient,
-    #[Autowire(service: 'logger.channel.helsinki_profiili')]
-    private readonly LoggerInterface $logger,
     private readonly AccountProxyInterface $currentUser,
     private readonly RequestStack $requestStack,
     private readonly EnvironmentResolverInterface $environmentResolver,
     private readonly EntityTypeManagerInterface $entityManager,
     private readonly EventDispatcherInterface $eventDispatcher,
-    ConfigFactoryInterface $configFactory,
+    private readonly ConfigFactoryInterface $configFactory,
     private readonly TimeInterface $time,
   ) {
-    $this->config = $configFactory->get('helfi_helsinki_profiili.settings');
-    $rolesConfig = $this->config->get('roles');
-
-    if (!empty($rolesConfig['hp_user_roles'])) {
-      $this->hpUserRoles = $rolesConfig['hp_user_roles'];
-    }
-    else {
-      $this->hpUserRoles = [];
-    }
-    if (!empty($rolesConfig['admin_user_roles'])) {
-      $this->hpAdminRoles = $rolesConfig['admin_user_roles'];
-    }
-    else {
-      $this->hpAdminRoles = [];
-    }
   }
 
   /**
@@ -130,28 +93,13 @@ class HelsinkiProfiiliUserData {
   }
 
   /**
-   * Return parsed JWT token data from openid.
-   *
-   * @return array
-   *   Token data for authenticated user.
-   */
-  public function getTokenData(): array {
-    $token = $this->openidConnectSession->retrieveIdToken();
-    if (empty($token)) {
-      return [];
-    }
-
-    return JwtHelper::parseToken($token);
-  }
-
-  /**
    * Set user data to private store.
    *
    * @param array $userData
    *   Userdata retrieved from HP.
    */
-  public function setUserData(array $userData): bool {
-    return $this->setToCache('userData', $userData);
+  public function setUserData(array $userData): void {
+    $this->setToCache('userData', $userData);
   }
 
   /**
@@ -161,7 +109,12 @@ class HelsinkiProfiiliUserData {
    *   Userdata from tempstore.
    */
   public function getUserData(): array {
-    return $this->getTokenData();
+    $token = $this->openidConnectSession->retrieveIdToken();
+    if (empty($token)) {
+      return [];
+    }
+
+    return JwtHelper::parseToken($this->openidConnectSession->retrieveIdToken());
   }
 
   /**
@@ -204,14 +157,22 @@ class HelsinkiProfiiliUserData {
       return NULL;
     }
 
-    if (!$refetch && $this->isCached('myProfile')) {
-      return $this->getFromCache('myProfile');
+    if (!$refetch) {
+      $cacheData = $this->requestStack
+        ->getCurrentRequest()
+        ->getSession()
+        ->get('myProfile');
+
+      // Return cached value if available.
+      if (!empty($cacheData)) {
+        return $cacheData;
+      }
     }
 
     // End point to access profile data.
-    $endpoint = getenv('USERINFO_PROFILE_ENDPOINT');
-    // Get query.
-    $query = $this->graphqlQuery();
+    $endpoint = $this->configFactory
+      ->get('helfi_helsinki_profiili.settings')
+      ->get('userinfo_profile_endpoint');
 
     try {
       // Use access token to fetch profiili token from token service.
@@ -233,13 +194,14 @@ class HelsinkiProfiiliUserData {
       $response = $this->httpClient->request('POST', $endpoint, [
         'headers' => $headers,
         'json' => [
-          'query' => $query,
+          'query' => self::graphqlQuery(),
         ],
       ]);
       $this->dispatchOperationEvent('PROFILE DATA FETCH');
 
       $json = $response->getBody()->getContents();
-      $body = Json::decode($json);
+      $body = Utils::jsonDecode($json, TRUE);
+      /** @var array<string, mixed> $body */
       $data = $body['data'];
 
       if (!empty($body['errors'])) {
@@ -276,8 +238,6 @@ class HelsinkiProfiiliUserData {
           '@error' => $e->getMessage(),
         ]
       );
-
-      return NULL;
     }
     catch (TempStoreException $e) {
       $this->dispatchExceptionEvent($e);
@@ -297,8 +257,6 @@ class HelsinkiProfiiliUserData {
       $this->logger->error(
         $e->getMessage()
       );
-
-      return NULL;
     }
 
     return NULL;
@@ -313,16 +271,11 @@ class HelsinkiProfiiliUserData {
    *   String array containing token parameters.
    */
   private function getProfileTokenParams(): array {
-    $appEnv = $this->environmentResolver->getActiveEnvironmentName();
-
-    $endpointAudience = 'profile-api-test';
-
-    if ($appEnv === EnvironmentEnum::Prod->value) {
-      $endpointAudience = 'profile-api';
-    }
-    if ($appEnv === EnvironmentEnum::Stage->value) {
-      $endpointAudience = 'profile-api-stage';
-    }
+    $endpointAudience = match ($this->environmentResolver->getActiveEnvironmentName()) {
+      EnvironmentEnum::Prod->value => 'profile-api',
+      EnvironmentEnum::Stage->value => 'profile-api-stage',
+      default => 'profile-api-test',
+    };
 
     return [
       'audience' => $endpointAudience,
@@ -352,19 +305,19 @@ class HelsinkiProfiiliUserData {
         ],
         'form_params' => $this->getProfileTokenParams(),
       ]);
-      $body = $response->getBody()->getContents();
 
-      if (strlen($body) < 5) {
-        throw new ProfileDataException('No data from profile endpoint');
+      $parsed = Utils::jsonDecode($response->getBody()->getContents(), TRUE);
+
+      if (!empty($parsed) && is_array($parsed)) {
+        return $parsed;
       }
-      return Json::decode($body);
-    }
-    catch (ProfileDataException $profileDataException) {
-      $this->dispatchExceptionEvent($profileDataException);
-      $this->logger->error('Trying to get tokens from api-tokens endpoint, got empty body: @error', ['@error' => $profileDataException->getMessage()]);
+
+      // Should we throw something here?
+      $this->dispatchExceptionEvent(new ProfileDataException('No data from profile endpoint'));
+      $this->logger->error('Trying to get tokens from api-tokens endpoint, got invalid body: @body');
       return NULL;
     }
-    catch (GuzzleException | \Exception $e) {
+    catch (GuzzleException $e) {
       $this->dispatchExceptionEvent($e);
       $this->logger->error(
         'Error retrieving access token %ecode: @error',
@@ -373,7 +326,8 @@ class HelsinkiProfiiliUserData {
           '@error' => $e->getMessage(),
         ]
       );
-      throw new TokenExpiredException($e->getMessage());
+
+      throw new TokenExpiredException($e->getMessage(), previous: $e);
     }
   }
 
@@ -383,7 +337,7 @@ class HelsinkiProfiiliUserData {
    * @return string
    *   Graphql query.
    */
-  protected function graphqlQuery(): string {
+  protected static function graphqlQuery(): string {
     return <<<'GRAPHQL'
       query MyProfileQuery {
         myProfile {
@@ -475,51 +429,17 @@ class HelsinkiProfiiliUserData {
   }
 
   /**
-   * Whether or not we have made this query?
-   *
-   * @param string|null $key
-   *   Used key for caching.
-   *
-   * @return bool
-   *   Is this cached?
-   */
-  private function isCached(?string $key): bool {
-    $session = $this->requestStack->getCurrentRequest()->getSession();
-
-    $cacheData = $session->get($key);
-    return !is_null($cacheData);
-  }
-
-  /**
-   * Get item from cache.
-   *
-   * @param string $key
-   *   Key to fetch from tempstore.
-   *
-   * @return array|null
-   *   Data in cache or null
-   */
-  private function getFromCache(string $key): array|null {
-    $session = $this->requestStack->getCurrentRequest()->getSession();
-    return !empty($session->get($key)) ? $session->get($key) : NULL;
-  }
-
-  /**
    * Add item to cache.
    *
    * @param string $key
    *   Used key for caching.
    * @param array $data
    *   Cached data.
-   *
-   * @return bool
-   *   Did save succeed?
    */
-  private function setToCache(string $key, array $data): bool {
-    $session = $this->requestStack->getCurrentRequest()->getSession();
-
-    $session->set($key, $data);
-    return TRUE;
+  private function setToCache(string $key, array $data): void {
+    $this->requestStack->getCurrentRequest()
+      ->getSession()
+      ->set($key, $data);
   }
 
   /**
@@ -590,7 +510,7 @@ class HelsinkiProfiiliUserData {
    * @return array
    *   Filtered data.
    */
-  public function filterData(array $data) {
+  public function filterData(array $data): array {
     // Make sure that data coming from HP is sanitized and does not contain
     // anything worth removing.
     array_walk_recursive(
@@ -628,49 +548,36 @@ class HelsinkiProfiiliUserData {
   /**
    * Get openid configurations.
    *
-   * @return array
+   * @todo We should cache this response.
+   *
+   * @return array<mixed>
    *   Open id config from endpoint.
    *
+   * @todo Improve exception type.
+   *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function getOpenIdConfiguration(): array {
+  private function getOpenIdConfiguration(): array {
     if (!$this->openIdConfiguration) {
-      $this->openIdConfiguration = $this->getOpenidConfigurationFromIssuer();
+      $url = $this->configFactory
+        ->get('helfi_helsinki_profiili.settings')
+        ->get('tunnistamo_environment_url');
+
+      if (empty($url)) {
+        throw new \UnexpectedValueException('No tunnistamo environment url set');
+      }
+
+      $response = $this->httpClient->request('GET', "$url/.well-known/openid-configuration/");
+
+      $parsed = Utils::jsonDecode($response->getBody()->getContents(), TRUE);
+      if (empty($parsed) || !is_array($parsed)) {
+        throw new \UnexpectedValueException('Could not parse openid configuration');
+      }
+
+      $this->openIdConfiguration = $parsed;
     }
+
     return $this->openIdConfiguration;
-  }
-
-  /**
-   * Get issuer configs from server.
-   *
-   * @return array
-   *   Config from env.
-   *
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getOpenidConfigurationFromIssuer(): array {
-    return Json::decode(
-      $this->httpClient->request(
-        'GET',
-        sprintf('%s/.well-known/openid-configuration/', $this->getTunnistamoEnvUrl())
-      )->getBody()->getContents()
-    );
-  }
-
-  /**
-   * Get jwks keys from issuer.
-   *
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function getJwks() {
-    $config = $this->getOpenIdConfiguration();
-
-    $response = $this->httpClient->request(
-      'GET',
-      $config["jwks_uri"]
-    );
-
-    return Json::decode($response->getBody()->getContents());
   }
 
   /**
@@ -765,23 +672,33 @@ class HelsinkiProfiiliUserData {
    * @return array
    *   Is token valid or not.
    *
+   * @todo Improve exception type.
+   *
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function verifyJwtToken(string $jwt): array {
-    $jwks = $this->getJwks();
+    $config = $this->getOpenIdConfiguration();
 
-    $this->logger->debug('JWKS -> @jwks', ['@jwks' => Json::encode($jwks)]);
+    $response = $this->httpClient->request(
+      'GET',
+      $config["jwks_uri"]
+    );
 
-    return (array) JWT::decode($jwt, JWK::parseKeySet($this->getJwks()));
+    $jwks = Utils::jsonDecode($response->getBody()->getContents(), TRUE);
+    if (!is_array($jwks)) {
+      throw new \UnexpectedValueException('Could not parse jwks');
+    }
+
+    return (array) JWT::decode($jwt, JWK::parseKeySet($jwks));
   }
 
   /**
    * Dispatches exception event.
    *
-   * @param \Exception $exception
+   * @param \Throwable $exception
    *   The exception.
    */
-  private function dispatchExceptionEvent(\Exception $exception): void {
+  private function dispatchExceptionEvent(\Throwable $exception): void {
     $event = new HelsinkiProfiiliExceptionEvent($exception);
     $this->eventDispatcher->dispatch($event);
   }
@@ -795,16 +712,6 @@ class HelsinkiProfiiliUserData {
   private function dispatchOperationEvent(string $message): void {
     $event = new HelsinkiProfiiliOperationEvent($message);
     $this->eventDispatcher->dispatch($event);
-  }
-
-  /**
-   * Get tunnistamo env url from env variable.
-   *
-   * @return string
-   *   The url or false.
-   */
-  public function getTunnistamoEnvUrl(): string {
-    return getenv('TUNNISTAMO_ENVIRONMENT_URL');
   }
 
 }

--- a/public/modules/custom/helfi_helsinki_profiili/tests/src/Unit/HelsinkiProfiiliUserDataTest.php
+++ b/public/modules/custom/helfi_helsinki_profiili/tests/src/Unit/HelsinkiProfiiliUserDataTest.php
@@ -6,7 +6,6 @@ namespace Drupal\Tests\helfi_helsinki_profiili\Unit;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
@@ -38,7 +37,6 @@ class HelsinkiProfiiliUserDataTest extends UnitTestCase {
     $service = new HelsinkiProfiiliUserData(
       $this->prophesize(OpenIDConnectSession::class)->reveal(),
       $this->prophesize(ClientInterface::class)->reveal(),
-      $this->prophesize(LoggerChannelInterface::class)->reveal(),
       $this->prophesize(AccountProxyInterface::class)->reveal(),
       $this->prophesize(RequestStack::class)->reveal(),
       $this->prophesize(EnvironmentResolverInterface::class)->reveal(),

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -15,6 +15,9 @@ $config['openid_connect.client.tunnistamoadmin']['settings']['client_id'] = gete
 $config['openid_connect.client.tunnistamoadmin']['settings']['client_secret'] = getenv('TUNNISTAMOADMIN_CLIENT_SECRET');
 $config['openid_connect.client.tunnistamoadmin']['settings']['client_scopes'] = getenv('TUNNISTAMOADMIN_CLIENT_SCOPES');
 
+$config['helfi_helsinki_profiili.settings']['tunnistamo_environment_url'] = getenv('TUNNISTAMO_ENVIRONMENT_URL');
+$config['helfi_helsinki_profiili.settings']['userinfo_profile_endpoint'] = getenv('USERINFO_PROFILE_ENDPOINT');
+
 $settings['error_page']['template_dir'] = '../error_templates';
 
 // Level of Assurance <-> Drupal roles mapping.

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -6,10 +6,7 @@ if (getenv('APP_ENV') == 'production') {
   $config['openid_connect.client.tunnistamoadmin']['settings']['is_production'] = TRUE;
 }
 
-if ($tunnistamo_environment_url = getenv('TUNNISTAMO_ENVIRONMENT_URL')) {
-  $config['openid_connect.client.tunnistamo']['settings']['environment_url'] = $tunnistamo_environment_url;
-}
-
+// The non-admin client is configured in settings.php.
 if ($tunnistamoAdmin_environment_url = getenv('TUNNISTAMOADMIN_ENVIRONMENT_URL')) {
   $config['openid_connect.client.tunnistamoadmin']['settings']['environment_url'] = $tunnistamoAdmin_environment_url;
 }


### PR DESCRIPTION
# [UHF-13099](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13099)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
Simplify HelsinkiProfiiliUserData. The class had a lot of dead code and multiple ways to do the same thing.
  - Simplify HelsinkiProfiiliUserData interface, removed variaous methods methods.                                                                                                                                                                                                                                                                  
  - Replace getenv() calls with Drupal config for TUNNISTAMO_ENVIRONMENT_URL and USERINFO_PROFILE_ENDPOINT
  - Replace custom debug logging code with standard logger 
  - Use EnvironmentResolverInterface instead of APP_ENV getenv
  - Replace Json::decode() with GuzzleHttp\Utils::jsonDecode() for better exception handling

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Check that the code follows our standards

<!--
Check list for the developer

Privacy
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.

E2E tests
- Make sure the tests pass when you run `make test-pw` on your local.
- Detailed instructions can be found here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/dev/e2e/README.md#environment-setup

Application that are no longer used
- Archive the webform applications after they are no longer used. This stops users from sending old drafts of the archived application.
- Archived webforms must also be removed from the E2E tests since they can't be tested after archiving.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
*


[UHF-13099]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ