### PR TITLE
UHF-13136: Allow users to access sent applications after window of ap…

### DIFF
--- a/public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
+++ b/public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
@@ -141,10 +141,6 @@ final class Application extends ResourceBase {
       return new JsonResponse(['error' => $this->t('Something went wrong')], 500);
     }
 
-    if (!$settings->isApplicationOpen()) {
-      return new JsonResponse(['error' => $this->t('The application is not currently open')], 400);
-    }
-
     try {
       $grants_profile_data = $this->userInformationService->getGrantsProfileContent();
       $selected_company = $this->userInformationService->getSelectedCompany();
@@ -209,6 +205,10 @@ final class Application extends ResourceBase {
     catch (\Throwable $e) {
       // @todo helfi_atv -module throws multiple exceptions, handle them accordingly.
       return new JsonResponse(['error' => $this->t('Unable to fetch your application. Please try again in a moment')], 500);
+    }
+
+    if (!$settings->isApplicationOpen() && $document->getStatus() === 'DRAFT') {
+      return new JsonResponse(['error' => $this->t('The application is not currently open')], 400);
     }
 
     $changeTime = new DrupalDateTime($document->getUpdatedAt());

--- a/public/modules/custom/grants_application/src/Plugin/rest/resource/DraftApplication.php
+++ b/public/modules/custom/grants_application/src/Plugin/rest/resource/DraftApplication.php
@@ -140,10 +140,6 @@ final class DraftApplication extends ResourceBase {
       return new JsonResponse([], 404);
     }
 
-    if (!$settings->isApplicationOpen()) {
-      return new JsonResponse(['error' => $this->t('The application is not currently open.')], 403);
-    }
-
     try {
       $grants_profile_data = $this->userInformationService->getGrantsProfileContent();
       $selected_company = $this->userInformationService->getSelectedCompany();
@@ -169,6 +165,10 @@ final class DraftApplication extends ResourceBase {
     catch (\Throwable $e) {
       // @todo helfi_atv -module throws multiple exceptions, handle them accordingly.
       return new JsonResponse([], 500);
+    }
+
+    if (!$settings->isApplicationOpen() && $document->getStatus() === 'DRAFT') {
+      return new JsonResponse(['error' => $this->t('The application is not currently open.')], 403);
     }
 
     // Side document bc.

--- a/public/modules/custom/grants_application/translations/fi.po
+++ b/public/modules/custom/grants_application/translations/fi.po
@@ -70,8 +70,8 @@ msgstr "Virhe tallentaessa lomaketta. Yritäthän hetken kuluttua uudelleen"
 msgid "Something went wrong"
 msgstr "Jokin meni pieleen"
 
-msgid "The application is not currently open"
-msgstr "Hakemus ei ole avoinna tällä hetkellä"
+msgid "The application is not currently open."
+msgstr "Hakemus ei ole avoinna tällä hetkellä."
 
 msgid "Unable to fetch your user information. Please try again in a moment"
 msgstr "Virhe noudettaessa käyttäjätietoja. Yritäthän hetken kuluttua uudelleen"


### PR DESCRIPTION
…plication is closed

# [UHF-13136](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13136)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Allow access to applications after they're closed if the application has been sent before deadline
* Fix tranlslation

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13136`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* Open up and submit a new application,  for example https://hel-fi-drupal-grant-applications.docker.so/fi/application/new/promoting_safer_club_activities/
* Change the `application_close` setting in the `settings.json` for the form to make the application closed
* You should be able to access and edit the sent application, but no longer able to make a new one

<!--
Check list for the developer

Privacy
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.

E2E tests
- Make sure the tests pass when you run `make test-pw` on your local.
- Detailed instructions can be found here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/dev/e2e/README.md#environment-setup

Application that are no longer used
- Archive the webform applications after they are no longer used. This stops users from sending old drafts of the archived application.
- Archived webforms must also be removed from the E2E tests since they can't be tested after archiving.
-->



[UHF-13136]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ