### PR TITLE
UHF-13099: Fix login for new accounts

### DIFF
--- a/public/modules/custom/helfi_helsinki_profiili/src/Hook/Hooks.php
+++ b/public/modules/custom/helfi_helsinki_profiili/src/Hook/Hooks.php
@@ -36,7 +36,8 @@ final class Hooks {
    * OpenID Connect pre-authorize hook.
    *
    * @param \Drupal\user\UserInterface $account
-   *   User account object of the authorized user.
+   *   User account identified using the "sub" provided by the identity
+   *   provider, or FALSE, if no such account exists.
    * @param array<mixed> $context
    *   An associative array with context information:
    *   - tokens:         An array of tokens.
@@ -45,7 +46,7 @@ final class Hooks {
    *   - sub:            The remote user identifier.
    */
   #[Hook('openid_connect_pre_authorize')]
-  public function preAuthorize(UserInterface $account, array $context): bool {
+  public function preAuthorize(UserInterface|bool $account, array $context): bool {
     // Don't do anything for entra users.
     if ($context['plugin_id'] !== 'tunnistamo') {
       return TRUE;


### PR DESCRIPTION
# [UHF-13099](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13099)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->

Hook argument is FALSE if user does not exist in local database.


[UHF-13099]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ