### PR TITLE
UHF-12777 React form E2E

### DIFF
--- a/e2e/utils/react/formFieldVerifier.ts
+++ b/e2e/utils/react/formFieldVerifier.ts
@@ -86,17 +86,19 @@ async function handleField(
     triggeredConditions.add(field.conditionField);
   }
 
-  // This field belongs to a repeatable list, like "Applied grants".
+  // The current field belongs to a repeatable list, like "Applied grants".
   if (field.isArrayItem && field.arrayField && !addedArrays.has(field.arrayField)) {
     const addText = field.addButtonTextKey ? t(field.addButtonTextKey) : undefined;
-    // Traverse up from the current field to its .field-array ancestor so we
-    // never touch items from a different array that has already been filled.
-    const arrayContainer = page
-      .locator(`#${fieldId}`)
-      .locator('xpath=ancestor::div[contains(@class,"field-array")][1]');
+    const fieldElement = page.locator(`#${fieldId}`);
 
-    // Remove all empty list items that were auto-added by the form before
-    // we add our own.
+    // Get the current scope by searching the ".field-array" element.
+    const arrayContainer = await fieldElement.count() > 0
+      ? fieldElement.locator('xpath=ancestor::div[contains(@class,"field-array")][1]')
+      : page.locator('.field-array').filter({
+          has: page.getByRole('button', { name: addText ?? /Add|Lisää|Lägg till/i }),
+        }).first();
+
+    // Remove auto-added empty rows left over from the error-gathering pass.
     let emptyItem = arrayContainer.locator('.array-item').filter({ has: page.locator('.has-error') }).first();
     while (await emptyItem.count() > 0) {
       logger('Found empty list item, removing it.');
@@ -105,7 +107,7 @@ async function handleField(
     }
 
     // Click "Add" to create a fresh list item to fill in.
-    await arrayContainer.getByRole('button', { name: addText ?? /Add|Lisää|Lägg till/i }).click();
+    await page.getByRole('button', { name: addText ?? /Add|Lisää|Lägg till/i }).first().click();
     addedArrays.add(field.arrayField);
     if (field.groupDescriptionKey) {
       await expect(

--- a/e2e/utils/react/formFieldVerifier.ts
+++ b/e2e/utils/react/formFieldVerifier.ts
@@ -88,16 +88,24 @@ async function handleField(
 
   // This field belongs to a repeatable list, like "Applied grants".
   if (field.isArrayItem && field.arrayField && !addedArrays.has(field.arrayField)) {
-    // Find and remove any empty list item that was auto-added by the
-    // form, since it would cause errors if left unfilled.
-    const emptyItem = page.locator('.array-item').filter({ has: page.locator('.has-error') }).first();
-    if (await emptyItem.count() > 0) {
+    const addText = field.addButtonTextKey ? t(field.addButtonTextKey) : undefined;
+    // Traverse up from the current field to its .field-array ancestor so we
+    // never touch items from a different array that has already been filled.
+    const arrayContainer = page
+      .locator(`#${fieldId}`)
+      .locator('xpath=ancestor::div[contains(@class,"field-array")][1]');
+
+    // Remove all empty list items that were auto-added by the form before
+    // we add our own.
+    let emptyItem = arrayContainer.locator('.array-item').filter({ has: page.locator('.has-error') }).first();
+    while (await emptyItem.count() > 0) {
+      logger('Found empty list item, removing it.');
       await emptyItem.getByRole('button', { name: /Remove|Poista|Ta bort/i }).click();
+      emptyItem = arrayContainer.locator('.array-item').filter({ has: page.locator('.has-error') }).first();
     }
 
-    // Click "Add" to create a new list item to fill in.
-    const addText = field.addButtonTextKey ? t(field.addButtonTextKey) : undefined;
-    await page.getByRole('button', { name: addText ?? /Add|Lisää|Lägg till/i }).first().click();
+    // Click "Add" to create a fresh list item to fill in.
+    await arrayContainer.getByRole('button', { name: addText ?? /Add|Lisää|Lägg till/i }).click();
     addedArrays.add(field.arrayField);
     if (field.groupDescriptionKey) {
       await expect(
@@ -126,7 +134,7 @@ async function handleField(
   }
 
   // Handle the radio buttons by selecting "Yes", to expand the extra
-  // questions.
+  // questions. Note! This might clash with conditional fields.
   if (field.widget === 'radio') {
     await expect(page.locator(`#${fieldId}_true`)).toBeVisible();
     await expect(page.locator(`#${fieldId}_false`)).toBeVisible();

--- a/e2e/utils/react/formFieldVerifier.ts
+++ b/e2e/utils/react/formFieldVerifier.ts
@@ -493,15 +493,12 @@ export async function fillFormFields(
   const tree = buildFormTree(formData as any);
   const filledFields:FilledFields = options.filledFields ?? new Map();
 
-  let missingInputs = {};
-
   // Submit the empty form first to trigger all required field errors.
   // This lets us verify that every required field shows an error message.
   await test.step('Gather form errors', async () => {
     if (!options.formURL) throw new Error(`The form URL is missing.`);
     await page.goto(options.formURL);
     await gatherRequiredFieldWarnings(page);
-    missingInputs = page.locator('[class*="notification_hds-notification--error__"] li');
     await assertMissingInputsVisible(page);
   });
 

--- a/e2e/utils/react/formFlow.ts
+++ b/e2e/utils/react/formFlow.ts
@@ -6,7 +6,7 @@ import {
   verifyFormFieldTranslations
 } from './formFieldVerifier';
 import { craftSchema } from './schemaFetcher';
-import { checkLoginStateAndLogin, Role, selectRole} from "../auth_helpers";
+import { Role, selectRole} from "../auth_helpers";
 import {
   captureApplicationNumber,
   waitForFormLoad
@@ -38,7 +38,6 @@ export async function executeFormFlow(
   const FORM_JSON = `/fi/application/preview/${FORM_ID}`;
 
   // Log in and select the role before opening the form.
-  await checkLoginStateAndLogin(page);
   await selectRole(page, FORM_ROLE);
   await page.goto(FORM_URL);
 


### PR DESCRIPTION
# [UHF-12777](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12777)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Added tests for the first React form

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-12777`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Go to `./e2e/` and run `npx playwright test --project forms-70`
* [ ] Check that the test pass and the the code follows our standards

<!--
Check list for the developer

Privacy
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.

E2E tests
- Make sure the tests pass when you run `make test-pw` on your local.
- Detailed instructions can be found here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/dev/e2e/README.md#environment-setup

Application that are no longer used
- Archive the webform applications after they are no longer used. This stops users from sending old drafts of the archived application.
- Archived webforms must also be removed from the E2E tests since they can't be tested after archiving.
-->


[UHF-12777]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ