### PR TITLE
UHF-13012 Allow marking messages as read

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -736,46 +736,6 @@ parameters:
 			path: public/modules/custom/grants_application/src/Avus2DataParser.php
 
 		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getHandlers\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getHistory\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getReadMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getStatusStrings\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getSubmittedAttachments\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getUnreadMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getUploadedAttachments\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
-			message: "#^Method Drupal\\\\grants_application\\\\Avus2DataParser\\:\\:getUploadedAttachmentsFilenames\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Avus2DataParser.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$uid\\.$#"
 			count: 2
 			path: public/modules/custom/grants_application/src/Controller/ApplicationController.php

--- a/public/modules/custom/grants_application/grants_application.routing.yml
+++ b/public/modules/custom/grants_application/grants_application.routing.yml
@@ -154,3 +154,11 @@ entity.application_metadata.delete_form:
     _title: 'Delete application metadata'
   requirements:
     _entity_access: 'application_metadata.delete'
+
+helfi_grants.message_read:
+  path: '/application/{submission_id}/message/{message_id}/read'
+  defaults:
+    _title: 'Mark message read'
+    _controller: '\Drupal\grants_application\Controller\ApplicationController::markMessageRead'
+  requirements:
+    _role: helsinkiprofiili

--- a/public/modules/custom/grants_application/grants_application.routing.yml
+++ b/public/modules/custom/grants_application/grants_application.routing.yml
@@ -156,7 +156,7 @@ entity.application_metadata.delete_form:
     _entity_access: 'application_metadata.delete'
 
 helfi_grants.message_read:
-  path: '/application/{submission_id}/message/{message_id}/read'
+  path: '/application/{application_number}/message/{message_id}/read'
   defaults:
     _title: 'Mark message read'
     _controller: '\Drupal\grants_application\Controller\ApplicationController::markMessageRead'

--- a/public/modules/custom/grants_application/src/Avus2DataParser.php
+++ b/public/modules/custom/grants_application/src/Avus2DataParser.php
@@ -31,8 +31,8 @@ final class Avus2DataParser {
    * @param \Drupal\helfi_atv\AtvDocument $document
    *   The value to validate, a result of json_decode function call.
    *
-   * @return array
-   *   Messages array.
+   * @return mixed[]
+   *   Handlers array.
    */
   public function getHandlers(AtvDocument $document): array {
     $content = $document->getContent();
@@ -71,7 +71,7 @@ final class Avus2DataParser {
           $message['messageStatus'] = 'READ';
         }
 
-        // An url which is shown to end user, allows marking message as read.
+        // A url which is shown to end user, allows marking message as read.
         if (
           $message['sentBy'] === 'Avustusten kasittelyjarjestelma' &&
           !$this->hasMatchingReadEvent($events, $message['messageId'])
@@ -125,7 +125,7 @@ final class Avus2DataParser {
    *   The atv document.
    *
    * @return array
-   *   The history.
+   *   The status history.
    */
   public function getHistory(AtvDocument $document): array {
     $content = $document->getContent();
@@ -152,7 +152,7 @@ final class Avus2DataParser {
    * @param \Drupal\helfi_atv\AtvDocument $document
    *   The atv document.
    *
-   * @return array
+   * @return mixed[]
    *   The submitted attachments.
    */
   public function getSubmittedAttachments(AtvDocument $document): array {
@@ -189,7 +189,7 @@ final class Avus2DataParser {
    * @param \Drupal\helfi_atv\AtvDocument $document
    *   The document.
    *
-   * @return array
+   * @return mixed[]
    *   Uploaded files.
    */
   public function getUploadedAttachments(AtvDocument $document): array {
@@ -202,7 +202,7 @@ final class Avus2DataParser {
    * @param \Drupal\helfi_atv\AtvDocument $document
    *   The document.
    *
-   * @return array
+   * @return mixed[]
    *   Array of filenames.
    */
   public function getUploadedAttachmentsFilenames(AtvDocument $document): array {
@@ -247,7 +247,7 @@ final class Avus2DataParser {
    * @param string $langcode
    *   The langcode.
    *
-   * @return array|null
+   * @return mixed[]|null
    *   The status string array or null.
    */
   public function getStatusStrings(string $langcode): ?array {

--- a/public/modules/custom/grants_application/src/Avus2DataParser.php
+++ b/public/modules/custom/grants_application/src/Avus2DataParser.php
@@ -124,7 +124,7 @@ final class Avus2DataParser {
    * @param \Drupal\helfi_atv\AtvDocument $document
    *   The atv document.
    *
-   * @return array
+   * @return mixed[]
    *   The status history.
    */
   public function getHistory(AtvDocument $document): array {

--- a/public/modules/custom/grants_application/src/Avus2DataParser.php
+++ b/public/modules/custom/grants_application/src/Avus2DataParser.php
@@ -4,19 +4,24 @@ namespace Drupal\grants_application;
 
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Link;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\grants_handler\MessageService;
 use Drupal\helfi_atv\AtvDocument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Parse the handlers, states, files etc.
  */
-final readonly class Avus2DataParser {
+final class Avus2DataParser {
+
+  use StringTranslationTrait;
 
   public function __construct(
     #[Autowire(service: 'grants_handler.message_service')]
     private MessageService $messageService,
     private LanguageManagerInterface $languageManager,
+    private RequestStack $requestStack,
   ) {
   }
 
@@ -46,24 +51,32 @@ final readonly class Avus2DataParser {
    * @param \Drupal\helfi_atv\AtvDocument $document
    *   The atv document.
    *
-   * @return array
-   *   Read messages.
+   * @return mixed[]
+   *   All messages.
    */
   public function getMessages(AtvDocument $document): array {
     $content = $document->getContent();
     $events = $content['events'] ?? [];
 
     $messages = [];
+
     if (isset($content['messages']) && is_array($content['messages'])) {
       $submissionMessages = $this->messageService->parseMessages($content);
 
       foreach ($submissionMessages as $message) {
         $message['messageStatus'] = 'UNREAD';
-        $message['markReadLink'] = $this->createMarkReadLink($message['caseId'], $message['messageId']);
+        $message['markReadLink'] = '';
 
         if ($this->hasMatchingReadEvent($events, $message['messageId'])) {
           $message['messageStatus'] = 'READ';
-          $message['markReadLink'] = '';
+        }
+
+        // An url which is shown to end user, allows marking message as read.
+        if (
+          $message['sentBy'] === 'Avustusten kasittelyjarjestelma' &&
+          !$this->hasMatchingReadEvent($events, $message['messageId'])
+        ) {
+          $message['markReadLink'] = $this->createMarkReadLink($message['caseId'], $message['messageId']);
         }
 
         $messages[] = $message;
@@ -75,9 +88,9 @@ final readonly class Avus2DataParser {
   /**
    * Does message have a matching read event?
    *
-   * @param array $events
+   * @param mixed[] $events
    *   The events.
-   * @param $messageId
+   * @param string $messageId
    *   The messageId from a message.
    *
    * @return bool
@@ -209,14 +222,14 @@ final readonly class Avus2DataParser {
    *   The link to the "mark as read" method
    */
   private function createMarkReadLink(string $applicationNumber, string $messageId): Link {
-    $currentUri = \Drupal::request()->getUri();
-    $currentHost = \Drupal::request()->getSchemeAndHttpHost();
+    $currentUri = $this->requestStack->getCurrentRequest()->getUri();
+    $currentHost = $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost();
     $currentDestination = str_replace($currentHost, '', $currentUri);
 
-    return Link::createFromRoute(t('Mark as read', [], []), 'helfi_grants.message_read',
+    return Link::createFromRoute($this->t('Mark as read', [], []), 'helfi_grants.message_read',
       [
         'message_id' => $messageId,
-        'submission_id' => $applicationNumber,
+        'application_number' => $applicationNumber,
       ],
       [
         'query' => [

--- a/public/modules/custom/grants_application/src/Avus2DataParser.php
+++ b/public/modules/custom/grants_application/src/Avus2DataParser.php
@@ -3,6 +3,7 @@
 namespace Drupal\grants_application;
 
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Link;
 use Drupal\grants_handler\MessageService;
 use Drupal\helfi_atv\AtvDocument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -40,37 +41,7 @@ final readonly class Avus2DataParser {
   }
 
   /**
-   * Get unread messages.
-   *
-   * @param \Drupal\helfi_atv\AtvDocument $document
-   *   The atv document.
-   *
-   * @return array
-   *   Messages array.
-   */
-  public function getUnreadMessages(AtvDocument $document): array {
-    $content = $document->getContent();
-
-    // grants_handler_preprocess_webform_submission_messages.
-    $unreadMsg = [];
-    foreach ($content['messages'] as $msg) {
-      if (!isset($msg["messageStatus"]) || !$msg["messageStatus"]) {
-        continue;
-      }
-
-      if ($msg["messageStatus"] == 'UNREAD' && $msg["sentBy"] == 'Avustusten kasittelyjarjestelma') {
-        $unreadMsg[] = [
-          '#theme' => 'message_notification_item',
-          '#message' => $msg,
-        ];
-      }
-    }
-
-    return $unreadMsg;
-  }
-
-  /**
-   * Get the read messages.
+   * Get the messages.
    *
    * @param \Drupal\helfi_atv\AtvDocument $document
    *   The atv document.
@@ -78,17 +49,42 @@ final readonly class Avus2DataParser {
    * @return array
    *   Read messages.
    */
-  public function getReadMessages(AtvDocument $document): array {
+  public function getMessages(AtvDocument $document): array {
     $content = $document->getContent();
+    $events = $content['events'] ?? [];
 
     $messages = [];
     if (isset($content['messages']) && is_array($content['messages'])) {
       $submissionMessages = $this->messageService->parseMessages($content);
+
       foreach ($submissionMessages as $message) {
+        $message['messageStatus'] = 'UNREAD';
+        $message['markReadLink'] = $this->createMarkReadLink($message['caseId'], $message['messageId']);
+
+        if ($this->hasMatchingReadEvent($events, $message['messageId'])) {
+          $message['messageStatus'] = 'READ';
+          $message['markReadLink'] = '';
+        }
+
         $messages[] = $message;
       }
     }
     return $messages;
+  }
+
+  /**
+   * Does message have a matching read event?
+   *
+   * @param array $events
+   *   The events.
+   * @param $messageId
+   *   The messageId from a message.
+   *
+   * @return bool
+   *   Message has a matching read event.
+   */
+  private function hasMatchingReadEvent(array $events, string $messageId): bool {
+    return (bool) array_find($events, fn ($event) => $event['eventType'] == 'MESSAGE_READ' && $event['eventTarget'] === $messageId);
   }
 
   /**
@@ -199,6 +195,37 @@ final readonly class Avus2DataParser {
   public function getUploadedAttachmentsFilenames(AtvDocument $document): array {
     $files = $this->getUploadedAttachments($document);
     return array_map(fn($file) => $file['filename'], $files);
+  }
+
+  /**
+   * Triggers ajax which marks message as read.
+   *
+   * @param string $applicationNumber
+   *   The application number.
+   * @param string $messageId
+   *   The message link.
+   *
+   * @return \Drupal\Core\Link
+   *   The link to the "mark as read" method
+   */
+  private function createMarkReadLink(string $applicationNumber, string $messageId): Link {
+    $currentUri = \Drupal::request()->getUri();
+    $currentHost = \Drupal::request()->getSchemeAndHttpHost();
+    $currentDestination = str_replace($currentHost, '', $currentUri);
+
+    return Link::createFromRoute(t('Mark as read', [], []), 'helfi_grants.message_read',
+      [
+        'message_id' => $messageId,
+        'submission_id' => $applicationNumber,
+      ],
+      [
+        'query' => [
+          'destination' => $currentDestination,
+        ],
+        'attributes' => [
+          'class' => ['hds-button', 'hds-button--secondary', 'use-ajax'],
+        ],
+      ]);
   }
 
   /**

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -778,27 +778,33 @@ final class ApplicationController extends ControllerBase {
   public function markMessageRead(string $application_number, string $message_id): AjaxResponse {
     $ajaxResponse = new AjaxResponse();
     $isError = FALSE;
+    $render = [
+      '#theme' => 'status_messages',
+      '#message_list' => [],
+      '#status_headings' => [
+        'status' => $this->t('Status message'),
+        'error' => $this->t('Error message'),
+        'warning' => $this->t('Warning message'),
+      ],
+    ];
+    $dataSelector = "[data-message-id=\"$message_id\"]";
+    $renderedHtml = '';
 
     try {
       $grants_profile_data = $this->userInformationService->getGrantsProfileContent();
       $user_information = $this->userInformationService->getUserData();
-    }
-    catch (\Exception $e) {
-      die();
-    }
-
-    try {
       $this->getSubmissionEntity($user_information->sub, $application_number, $grants_profile_data->getBusinessId());
-    }
-    catch (\Exception $e) {
-      die();
-    }
-
-    try {
       $atvDocument = $this->helfiAtvService->getDocument($application_number);
+      $renderedHtml = $this->renderer->render($render);
     }
     catch (\Exception $e) {
-      die();
+      $this->getLogger('grants_application')
+        ->error("User data fetch error when marking message as read: {$e->getMessage()}");
+
+      $prependCommand = new PrependCommand($dataSelector, (string) $renderedHtml);
+      $ajaxResponse->addCommand($prependCommand);
+
+      return $ajaxResponse;
     }
 
     $submissionData = $atvDocument->getContent();
@@ -839,7 +845,6 @@ final class ApplicationController extends ControllerBase {
       $message = $this->t('Message already read.');
     }
 
-    $dataSelector = "[data-message-id=\"$message_id\"]";
     if (!$isError) {
       $replaceMessageContainerCommand = new ReplaceCommand(
         $dataSelector . ' .webform-submission-messages__new-message',
@@ -853,19 +858,8 @@ final class ApplicationController extends ControllerBase {
     }
 
     $messageType = $isError ? 'error' : 'status';
-    $render = [
-      '#theme' => 'status_messages',
-      '#message_list' => [],
-      '#status_headings' => [
-        'status' => $this->t('Status message'),
-        'error' => $this->t('Error message'),
-        'warning' => $this->t('Warning message'),
-      ],
-    ];
-
     $render['#message_list'][$messageType][] = $message;
 
-    $renderedHtml = '';
     try {
       $renderedHtml = $this->renderer->render($render);
     }

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -790,7 +790,7 @@ final class ApplicationController extends ControllerBase {
     try {
       $this->getSubmissionEntity($user_information->sub, $application_number, $grants_profile_data->getBusinessId());
     }
-    catch (\Exception) {
+    catch (\Exception $e) {
       die();
     }
 
@@ -802,11 +802,12 @@ final class ApplicationController extends ControllerBase {
     }
 
     $submissionData = $atvDocument->getContent();
-    $thisEvent = array_filter($submissionData['events'], function ($event) use ($message_id) {
+    $messageType = 'MESSAGE_READ';
+    $thisEvent = array_filter($submissionData['events'], function ($event) use ($message_id, $messageType) {
       if (
         isset($event['eventTarget']) &&
         $event['eventTarget'] == $message_id &&
-        $event['eventType'] == $this->eventsService->getEventTypes()['MESSAGE_READ']
+        $event['eventType'] == $messageType
       ) {
         return TRUE;
       }
@@ -815,10 +816,10 @@ final class ApplicationController extends ControllerBase {
 
     if (empty($thisEvent)) {
       try {
-        // Log event will send request..
+        // EventsService::logEvent will send a request.
         $this->eventsService->logEvent(
           $application_number,
-          $this->eventsService->getEventTypes()['MESSAGE_READ'],
+          $messageType,
           (string) $this->t('Message marked as read'),
           $message_id
         );

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -800,10 +800,11 @@ final class ApplicationController extends ControllerBase {
       $this->getLogger('grants_application')
         ->error("User data fetch error when marking message as read: {$e->getMessage()}");
 
+      $render['#message_list']['error'][] =  $this->t('Message marking as read failed.');
       $renderedHtml = $this->renderer->render($render);
       $prependCommand = new PrependCommand($dataSelector, (string) $renderedHtml);
       $ajaxResponse->addCommand($prependCommand);
-
+      $ajaxResponse->setStatusCode(500);
       return $ajaxResponse;
     }
 
@@ -855,6 +856,9 @@ final class ApplicationController extends ControllerBase {
 
       $ajaxResponse->addCommand($replaceMessageContainerCommand);
       $ajaxResponse->addCommand($replaceButtonCommand);
+    }
+    else {
+      $ajaxResponse->setStatusCode(500);
     }
 
     $messageType = $isError ? 'error' : 'status';

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -772,7 +772,7 @@ final class ApplicationController extends ControllerBase {
    * @param string $message_id
    *   The message id.
    *
-   * @return AjaxResponse
+   * @return \Drupal\Core\Ajax\AjaxResponse
    *   The ajax response.
    */
   public function markMessageRead(string $application_number, string $message_id): AjaxResponse {

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -7,6 +7,9 @@ namespace Drupal\grants_application\Controller;
 use Drupal\Component\Transliteration\TransliterationInterface;
 use Drupal\content_lock\ContentLock\ContentLockInterface;
 use Drupal\Core\Access\CsrfTokenGenerator;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\PrependCommand;
+use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -21,6 +24,7 @@ use Drupal\grants_application\User\UserInformationService;
 use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationGetterService;
 use Drupal\grants_handler\ApplicationStatusService;
+use Drupal\grants_handler\EventException;
 use Drupal\grants_handler\MessageService;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvService;
@@ -338,8 +342,7 @@ final class ApplicationController extends ControllerBase {
     $submitted = $this->avus2DataParser->getSubmitted($document);
     $history = $this->avus2DataParser->getHistory($document);
     $handlers = $this->avus2DataParser->getHandlers($document);
-    // $unreadMsg = $this->avus2DataParser->getUnreadMessages($document);
-    $messages = $this->avus2DataParser->getReadMessages($document);
+    $messages = $this->avus2DataParser->getMessages($document);
 
     $langCode = $this->languageManager()->getCurrentLanguage()->getId();
     $statusStrings = $this->avus2DataParser->getStatusStrings($langCode);
@@ -755,6 +758,126 @@ final class ApplicationController extends ControllerBase {
     ] + $settings->toArray();
 
     return new JsonResponse($response);
+  }
+
+  /**
+   * Allow user marking message as "Read".
+   *
+   * Copied from original implementation (MessageController::markMessageRead)
+   *
+   * @param string $application_number
+   *   The application number.
+   * @param string $message_id
+   *   The message id.
+   *
+   * @return AjaxResponse
+   *   The ajax response.
+   */
+  public function markMessageRead(string $application_number, string $message_id): AjaxResponse {
+    try {
+      $grants_profile_data = $this->userInformationService->getGrantsProfileContent();
+      $user_information = $this->userInformationService->getUserData();
+    }
+    catch (\Exception $e) {
+      // Unable to fetch user information.
+      throw new NotFoundHttpException();
+    }
+
+    try {
+      $submission = $this->getSubmissionEntity($user_information->sub, $application_number, $grants_profile_data->getBusinessId());
+    }
+    catch (\Exception) {
+      throw new NotFoundHttpException();
+    }
+
+    if (!$submission) {
+      die('ajax response');
+      return new AjaxResponse();
+    }
+
+    try {
+      $atvDocument = $this->helfiAtvService->getDocument($application_number);
+    }
+    catch(\Exception $e) {
+      die('ajax respons');
+      return new AjaxResponse();
+    }
+
+    $submissionData = $atvDocument->getContent();
+    $thisEvent = array_filter($submissionData['events'], function ($event) use ($message_id) {
+      if (
+        isset($event['eventTarget']) &&
+        $event['eventTarget'] == $message_id &&
+        $event['eventType'] == $this->eventsService->getEventTypes()['MESSAGE_READ']
+      ) {
+        return TRUE;
+      }
+      return FALSE;
+    });
+
+    if (empty($thisEvent)) {
+      try {
+        $this->eventsService->logEvent(
+          $application_number,
+          $this->eventsService->getEventTypes()['MESSAGE_READ'],
+          (string) $this->t('Message marked as read'),
+          $message_id
+        );
+        $message = $this->t('Message marked as read');
+        $this->atvService->clearCache($application_number);
+      }
+      catch (EventException $ee) {
+        $this->getLogger('message_controller')->error('Error: %error', [
+          '%error' => $ee->getMessage(),
+        ]);
+        $isError = TRUE;
+        $message = $this->t('Message marking as read failed.');
+      }
+    }
+    else {
+      $message = $this->t('Message already read.');
+    }
+
+    $ajaxResponse = new AjaxResponse();
+
+    $dataSelector = str_replace(
+      '@message_id',
+      $message_id,
+      '[data-message-id="@message_id"]'
+    );
+
+    if (!$isError) {
+      // New message container.
+      $replaceMessageContainerCommand = new ReplaceCommand(
+        $dataSelector . ' .webform-submission-messages__new-message',
+        NULL
+      );
+      // Mark as read button.
+      $replaceButtonCommand = new ReplaceCommand($dataSelector . ' .use-ajax', NULL);
+
+      $ajaxResponse->addCommand($replaceMessageContainerCommand);
+      $ajaxResponse->addCommand($replaceButtonCommand);
+    }
+
+    $render = [
+      '#theme' => 'status_messages',
+      '#message_list' => [],
+      '#status_headings' => [
+        'status' => $this->t('Status message'),
+        'error' => $this->t('Error message'),
+        'warning' => $this->t('Warning message'),
+      ],
+    ];
+
+    $messageType = $isError ? 'error' : 'status';
+    $render['#message_list'][$messageType][] = $message;
+
+    $renderedHtml = $this->renderer->render($render);
+    $prependCommand = new PrependCommand($dataSelector, $renderedHtml);
+
+    $ajaxResponse->addCommand($prependCommand);
+
+    return $ajaxResponse;
   }
 
   /**

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -344,7 +344,7 @@ final class ApplicationController extends ControllerBase {
     $submitted = $this->avus2DataParser->getSubmitted($document);
     $history = $this->avus2DataParser->getHistory($document);
     $handlers = $this->avus2DataParser->getHandlers($document);
-    $messages = $this->avus2DataParser->getMessages($document, $application_number);
+    $messages = $this->avus2DataParser->getMessages($document);
 
     $langCode = $this->languageManager()->getCurrentLanguage()->getId();
     $statusStrings = $this->avus2DataParser->getStatusStrings($langCode);
@@ -864,13 +864,14 @@ final class ApplicationController extends ControllerBase {
 
     $render['#message_list'][$messageType][] = $message;
 
+    $renderedHtml = '';
     try {
       $renderedHtml = $this->renderer->render($render);
     }
     catch (\Exception $e) {
     }
 
-    $prependCommand = new PrependCommand($dataSelector, $renderedHtml);
+    $prependCommand = new PrependCommand($dataSelector, (string) $renderedHtml);
     $ajaxResponse->addCommand($prependCommand);
 
     return $ajaxResponse;

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -800,7 +800,7 @@ final class ApplicationController extends ControllerBase {
       $this->getLogger('grants_application')
         ->error("User data fetch error when marking message as read: {$e->getMessage()}");
 
-      $render['#message_list']['error'][] =  $this->t('Message marking as read failed.');
+      $render['#message_list']['error'][] = $this->t('Message marking as read failed.');
       $renderedHtml = $this->renderer->render($render);
       $prependCommand = new PrependCommand($dataSelector, (string) $renderedHtml);
       $ajaxResponse->addCommand($prependCommand);

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -12,6 +12,7 @@ use Drupal\Core\Ajax\PrependCommand;
 use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Render\Renderer;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\Url;
 use Drupal\file\Entity\File;
@@ -24,7 +25,6 @@ use Drupal\grants_application\User\UserInformationService;
 use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationGetterService;
 use Drupal\grants_handler\ApplicationStatusService;
-use Drupal\grants_handler\EventException;
 use Drupal\grants_handler\MessageService;
 use Drupal\helfi_atv\AtvDocumentNotFoundException;
 use Drupal\helfi_atv\AtvService;
@@ -69,6 +69,8 @@ final class ApplicationController extends ControllerBase {
     #[Autowire(service: 'transliteration')]
     private readonly TransliterationInterface $transliteration,
     private readonly Avus2DataParser $avus2DataParser,
+    #[Autowire(service: 'Drupal\Core\Render\RendererInterface')]
+    private readonly Renderer $renderer,
   ) {
   }
 
@@ -342,7 +344,7 @@ final class ApplicationController extends ControllerBase {
     $submitted = $this->avus2DataParser->getSubmitted($document);
     $history = $this->avus2DataParser->getHistory($document);
     $handlers = $this->avus2DataParser->getHandlers($document);
-    $messages = $this->avus2DataParser->getMessages($document);
+    $messages = $this->avus2DataParser->getMessages($document, $application_number);
 
     $langCode = $this->languageManager()->getCurrentLanguage()->getId();
     $statusStrings = $this->avus2DataParser->getStatusStrings($langCode);
@@ -774,33 +776,29 @@ final class ApplicationController extends ControllerBase {
    *   The ajax response.
    */
   public function markMessageRead(string $application_number, string $message_id): AjaxResponse {
+    $ajaxResponse = new AjaxResponse();
+    $isError = FALSE;
+
     try {
       $grants_profile_data = $this->userInformationService->getGrantsProfileContent();
       $user_information = $this->userInformationService->getUserData();
     }
     catch (\Exception $e) {
-      // Unable to fetch user information.
-      throw new NotFoundHttpException();
+      die();
     }
 
     try {
-      $submission = $this->getSubmissionEntity($user_information->sub, $application_number, $grants_profile_data->getBusinessId());
+      $this->getSubmissionEntity($user_information->sub, $application_number, $grants_profile_data->getBusinessId());
     }
     catch (\Exception) {
-      throw new NotFoundHttpException();
-    }
-
-    if (!$submission) {
-      die('ajax response');
-      return new AjaxResponse();
+      die();
     }
 
     try {
       $atvDocument = $this->helfiAtvService->getDocument($application_number);
     }
-    catch(\Exception $e) {
-      die('ajax respons');
-      return new AjaxResponse();
+    catch (\Exception $e) {
+      die();
     }
 
     $submissionData = $atvDocument->getContent();
@@ -817,18 +815,20 @@ final class ApplicationController extends ControllerBase {
 
     if (empty($thisEvent)) {
       try {
+        // Log event will send request..
         $this->eventsService->logEvent(
           $application_number,
           $this->eventsService->getEventTypes()['MESSAGE_READ'],
           (string) $this->t('Message marked as read'),
           $message_id
         );
+
         $message = $this->t('Message marked as read');
         $this->atvService->clearCache($application_number);
       }
-      catch (EventException $ee) {
+      catch (\Exception $e) {
         $this->getLogger('message_controller')->error('Error: %error', [
-          '%error' => $ee->getMessage(),
+          '%error' => $e->getMessage(),
         ]);
         $isError = TRUE;
         $message = $this->t('Message marking as read failed.');
@@ -838,27 +838,20 @@ final class ApplicationController extends ControllerBase {
       $message = $this->t('Message already read.');
     }
 
-    $ajaxResponse = new AjaxResponse();
-
-    $dataSelector = str_replace(
-      '@message_id',
-      $message_id,
-      '[data-message-id="@message_id"]'
-    );
-
+    $dataSelector = "[data-message-id=\"$message_id\"]";
     if (!$isError) {
-      // New message container.
       $replaceMessageContainerCommand = new ReplaceCommand(
         $dataSelector . ' .webform-submission-messages__new-message',
-        NULL
+        ''
       );
       // Mark as read button.
-      $replaceButtonCommand = new ReplaceCommand($dataSelector . ' .use-ajax', NULL);
+      $replaceButtonCommand = new ReplaceCommand($dataSelector . ' .use-ajax', '');
 
       $ajaxResponse->addCommand($replaceMessageContainerCommand);
       $ajaxResponse->addCommand($replaceButtonCommand);
     }
 
+    $messageType = $isError ? 'error' : 'status';
     $render = [
       '#theme' => 'status_messages',
       '#message_list' => [],
@@ -869,12 +862,15 @@ final class ApplicationController extends ControllerBase {
       ],
     ];
 
-    $messageType = $isError ? 'error' : 'status';
     $render['#message_list'][$messageType][] = $message;
 
-    $renderedHtml = $this->renderer->render($render);
-    $prependCommand = new PrependCommand($dataSelector, $renderedHtml);
+    try {
+      $renderedHtml = $this->renderer->render($render);
+    }
+    catch (\Exception $e) {
+    }
 
+    $prependCommand = new PrependCommand($dataSelector, $renderedHtml);
     $ajaxResponse->addCommand($prependCommand);
 
     return $ajaxResponse;

--- a/public/modules/custom/grants_application/src/Controller/ApplicationController.php
+++ b/public/modules/custom/grants_application/src/Controller/ApplicationController.php
@@ -795,12 +795,12 @@ final class ApplicationController extends ControllerBase {
       $user_information = $this->userInformationService->getUserData();
       $this->getSubmissionEntity($user_information->sub, $application_number, $grants_profile_data->getBusinessId());
       $atvDocument = $this->helfiAtvService->getDocument($application_number);
-      $renderedHtml = $this->renderer->render($render);
     }
     catch (\Exception $e) {
       $this->getLogger('grants_application')
         ->error("User data fetch error when marking message as read: {$e->getMessage()}");
 
+      $renderedHtml = $this->renderer->render($render);
       $prependCommand = new PrependCommand($dataSelector, (string) $renderedHtml);
       $ajaxResponse->addCommand($prependCommand);
 

--- a/public/modules/custom/grants_application/src/Controller/CompletionController.php
+++ b/public/modules/custom/grants_application/src/Controller/CompletionController.php
@@ -91,8 +91,6 @@ class CompletionController extends ControllerBase {
     $statusStrings = $config->get('statusStrings');
     $humanReadableStatus = $statusStrings[$langCode][$status] ?? '';
 
-    // @todo UHF-12685 viewApplicationLink requires a separate page.
-    // The react form opened on preview page would be optimal (no controls).
     $build = [
       '#theme' => 'grants_application_completion',
       '#applicationTimestamp' => date('Y-m-d h:i:s', (int) $entity->get('created')->value),

--- a/public/modules/custom/grants_application/templates/grants-application-view-messages.html.twig
+++ b/public/modules/custom/grants_application/templates/grants-application-view-messages.html.twig
@@ -6,7 +6,7 @@
   <div class="webform-submission-messages">
     <h4>{{ 'Sent messages'|t({}, {'context': 'grants_handler'})}}</h4>
     <hr/>
-    <div{{ attributes.addClass(classes) }}>
+    <div class="webform-submission-data webform-submission-data--webform-">
       {% if isDraft %}
         <p>{{ 'You cannot send messages to an incomplete application.'|t({}, {'context': 'grants_handler'}) }}</p>
       {% endif %}
@@ -14,16 +14,18 @@
         <p>{{ 'Messages cannot be sent to a resolved application.'|t({}, {'context': 'grants_handler'}) }}</p>
       {% endif %}
       {% if messages %}
+      <ul class="webform-submission-messages__messages-list">
         {% for message in messages %}
+          <li data-message-id="{{ message.messageId }}" class="webform-submission-messages__message">
           {% if (message.messageStatus == 'UNREAD' and message.sentBy == 'Avustusten kasittelyjarjestelma') %}
             <div class="webform-submission-messages__new-message">
-              <i class="hds-icon icon hds-icon--alert-circle hel-icon--size-s vertical-align-small-or-medium-icon" aria-hidden="true"></i>
+              <i class="hel-icon icon hel-icon--alert-circle hel-icon--size-s vertical-align-small-or-medium-icon" aria-hidden="true"></i>
               <span>{{ "New message"|t({}, {'context': 'grants_handler'})}}</span>
             </div>
           {% endif %}
           <h5 class="webform-submission-messages__message-sender hdbt-react-form__message__sender"><strong>{{ message.sentBy }}</strong> - {{ message.sendDateTime|date('d.m.Y H:i:s') }}</h5>
           <div class="webform-submission-messages__message-body">{{ message.body }}</div>
-          {{ markReadLink }}
+          {{ message.markReadLink }}
           {% if message.attachments %}
             <ul class="webform-submission-messages__message__attachments hdbt-react-form__message__attachments">
               {% for attachment in message.attachments %}
@@ -34,8 +36,10 @@
               {% endfor %}
             </ul>
           {% endif %}
+          <hr>
+        </li>
         {% endfor %}
-        <hr/>
+      </ul>
       {% endif %}
     </div>
     <div{{ attributes.addClass(classes) }}>

--- a/public/modules/custom/grants_application/tests/src/Kernel/Avus2DataParserTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Avus2DataParserTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\grants_application\Kernel;
+
+use Drupal\Core\Link;
+use Drupal\grants_application\Avus2DataParser;
+use Drupal\Tests\grants_application\Trait\AtvDocumentTrait;
+
+/**
+ * @coversDefaultClass \Drupal\grants_application\Avus2DataParser
+ *
+ * @group grants_application
+ */
+final class Avus2DataParserTest extends KernelTestBase {
+
+  use AtvDocumentTrait;
+
+  /**
+   * The application number.
+   *
+   * @var string
+   */
+  private string $applicationNumber = "KERNELTEST-058-0000001";
+
+  /**
+   * Test message parsing.
+   */
+  public function testMessageParsing() {
+    $document = $this->getAtvDocument($this->applicationNumber);
+    $messages = $this->container->get(Avus2DataParser::class)->getMessages($document);
+
+    $this->assertCount(2, $messages);
+
+    // Unread message.
+    $this->assertInstanceOf(Link::class, $messages[0]['markReadLink']);
+    $this->assertEquals('UNREAD', $messages[0]['messageStatus']);
+
+    // Read message.
+    $this->assertEquals('', $messages[1]['markReadLink']);
+    $this->assertEquals('READ', $messages[1]['messageStatus']);
+  }
+
+}

--- a/public/modules/custom/grants_application/tests/src/Kernel/Avus2DataParserTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Avus2DataParserTest.php
@@ -27,7 +27,7 @@ final class Avus2DataParserTest extends KernelTestBase {
   /**
    * Test message parsing.
    */
-  public function testMessageParsing() {
+  public function testMessageParsing(): void {
     $document = $this->getAtvDocument($this->applicationNumber);
     $messages = $this->container->get(Avus2DataParser::class)->getMessages($document);
 

--- a/public/modules/custom/grants_application/tests/src/Kernel/Controller/ApplicationControllerTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Controller/ApplicationControllerTest.php
@@ -301,6 +301,7 @@ final class ApplicationControllerTest extends KernelTestBase {
     $controller = ApplicationController::create($this->container);
     $response = $controller->markMessageRead($this->applicationNumber, $this->messageId);
     $this->assertInstanceOf(AjaxResponse::class, $response);
+    $this->assertEquals(200, $response->getStatusCode());
   }
 
 }

--- a/public/modules/custom/grants_application/tests/src/Kernel/Controller/ApplicationControllerTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Controller/ApplicationControllerTest.php
@@ -20,6 +20,7 @@ use Drupal\helfi_atv\AtvDocument;
 use Drupal\helfi_atv\AtvService;
 use Drupal\helfi_av\AntivirusService;
 use Drupal\Tests\grants_application\Kernel\KernelTestBase;
+use Drupal\Tests\grants_application\Trait\AtvDocumentTrait;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -31,6 +32,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * @group grants_application
  */
 final class ApplicationControllerTest extends KernelTestBase {
+
+  use AtvDocumentTrait;
 
   /**
    * The application submission.
@@ -105,46 +108,7 @@ final class ApplicationControllerTest extends KernelTestBase {
     ]);
     $this->applicationSubmission->save();
 
-    $this->atvDocument = AtvDocument::create([
-      'id' => 'test-id',
-      'type' => 'type',
-      'status' => [
-        'value' => 'DRAFT',
-      ],
-      'status_histories' => [
-        'DRAFT',
-      ],
-      'transaction_id' => '1234567890',
-      'business_id' => '1234567-1',
-      'tos_function_id' => '12345',
-      'tos_record_id' => '54321',
-      'draft' => TRUE,
-      'human_readable_type' => ['humanType'],
-      'metadata' => '{"name": "Name", "value": "Value"}',
-      'content' => '{"data": "content"}',
-      'created_at' => '2024-06-06',
-      'updated_at' => '2024-06-07',
-      'user_id' => 'userId',
-      'locked_after' => '2024-06-08',
-      'deletable' => TRUE,
-      'delete_after' => '2075-01-01',
-      'document_language' => 'fi',
-      'content_schema_url' => 'schemaURL',
-    ]);
-    $this->atvDocument->setContent([
-      'compensation' => [],
-      'formUpdate' => FALSE,
-      'events' => [],
-      'messages' => [
-        [
-          'caseId' => $this->applicationNumber,
-          'messageId' => 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbbb',
-          'body' => 'viesti viesti viesti',
-          'sentBy' => 'Avustusten kasittelyjarjestelma',
-          'sendDateTime' => '2026-05-06T08:40:37',
-        ],
-      ],
-    ]);
+    $this->atvDocument = $this->getAtvDocument($this->applicationNumber);
 
     $applicationGetterService = $this->createMock(ApplicationGetterService::class);
     $applicationGetterService->expects($this->any())->method('getAtvDocument')->willReturn($this->atvDocument);

--- a/public/modules/custom/grants_application/tests/src/Kernel/Controller/ApplicationControllerTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Controller/ApplicationControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\grants_application\Kernel\Controller;
 
+use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\grants_application\Atv\HelfiAtvService;
 use Drupal\grants_application\Controller\ApplicationController;
 use Drupal\grants_application\Entity\ApplicationSubmission;
@@ -44,6 +45,13 @@ final class ApplicationControllerTest extends KernelTestBase {
    * @var string
    */
   private string $applicationNumber = "KERNELTEST-058-0000001";
+
+  /**
+   * The message id.
+   *
+   * @var string
+   */
+  private string $messageId = 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbbb';
 
   /**
    * The atv document.
@@ -122,6 +130,20 @@ final class ApplicationControllerTest extends KernelTestBase {
       'delete_after' => '2075-01-01',
       'document_language' => 'fi',
       'content_schema_url' => 'schemaURL',
+    ]);
+    $this->atvDocument->setContent([
+      'compensation' => [],
+      'formUpdate' => FALSE,
+      'events' => [],
+      'messages' => [
+        [
+          'caseId' => $this->applicationNumber,
+          'messageId' => 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbbb',
+          'body' => 'viesti viesti viesti',
+          'sentBy' => 'Avustusten kasittelyjarjestelma',
+          'sendDateTime' => '2026-05-06T08:40:37',
+        ],
+      ],
     ]);
 
     $applicationGetterService = $this->createMock(ApplicationGetterService::class);
@@ -292,6 +314,29 @@ final class ApplicationControllerTest extends KernelTestBase {
     $response = $controller->formPreview($this->applicationNumber);
     $this->assertEquals(404, $response->getStatusCode());
     $this->assertEquals([], json_decode($response->getContent(), TRUE));
+  }
+
+  /**
+   * Test updating a message as "read".
+   */
+  public function testUpdateMessageAsRead(): void {
+    $grantsProfile = new GrantsProfile(['businessId' => 'no-match']);
+    $userInformationService = $this->createMock(UserInformationService::class);
+    $userInformationService->method('getUserData')->willReturn(new HelsinkiProfiiliUser(sub: 'abcdefg-1234-5678-9012-hijklmnopqro', loa: AuthenticationLevel::Strong, name: 'Test User', given_name: 'Test', family_name: 'User', email: 'test@test.com'));
+    $userInformationService->method('getGrantsProfileContent')->willReturn($grantsProfile);
+    $this->container->set(UserInformationService::class, $userInformationService);
+
+    $helfiAtvService = $this->createMock(HelfiAtvService::class);
+    $helfiAtvService->method('getDocument')->willReturn($this->atvDocument);
+    $this->container->set(HelfiAtvService::class, $helfiAtvService);
+
+    $eventsService = $this->createMock(EventsService::class);
+    $eventsService->method('logEvent')->willReturn([]);
+    $this->container->set(EventsService::class, $eventsService);
+
+    $controller = ApplicationController::create($this->container);
+    $response = $controller->markMessageRead($this->applicationNumber, $this->messageId);
+    $this->assertInstanceOf(AjaxResponse::class, $response);
   }
 
 }

--- a/public/modules/custom/grants_application/tests/src/Trait/AtvDocumentTrait.php
+++ b/public/modules/custom/grants_application/tests/src/Trait/AtvDocumentTrait.php
@@ -6,6 +6,9 @@ namespace Drupal\Tests\grants_application\Trait;
 
 use Drupal\helfi_atv\AtvDocument;
 
+/**
+ * A test trait for atv document creation.
+ */
 trait AtvDocumentTrait {
 
   /**

--- a/public/modules/custom/grants_application/tests/src/Trait/AtvDocumentTrait.php
+++ b/public/modules/custom/grants_application/tests/src/Trait/AtvDocumentTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\grants_application\Trait;
+
+use Drupal\helfi_atv\AtvDocument;
+
+trait AtvDocumentTrait {
+
+  /**
+   * Default atv document for testing.
+   *
+   * @param string $application_number
+   *   The application number.
+   *
+   * @return \Drupal\helfi_atv\AtvDocument
+   *   Atv document for testing.
+   */
+  public function getAtvDocument(string $application_number): AtvDocument {
+    $document = AtvDocument::create([
+      'id' => 'test-id',
+      'type' => 'type',
+      'status' => [
+        'value' => 'DRAFT',
+      ],
+      'status_histories' => [
+        'DRAFT',
+      ],
+      'transaction_id' => '1234567890',
+      'business_id' => '1234567-1',
+      'tos_function_id' => '12345',
+      'tos_record_id' => '54321',
+      'draft' => TRUE,
+      'human_readable_type' => ['humanType'],
+      'metadata' => '{"name": "Name", "value": "Value"}',
+      'content' => '{"data": "content"}',
+      'created_at' => '2024-06-06',
+      'updated_at' => '2024-06-07',
+      'user_id' => 'userId',
+      'locked_after' => '2024-06-08',
+      'deletable' => TRUE,
+      'delete_after' => '2075-01-01',
+      'document_language' => 'fi',
+      'content_schema_url' => 'schemaURL',
+    ]);
+    $document->setContent([
+      'compensation' => [],
+      'formUpdate' => FALSE,
+      'events' => [
+        [
+          "caseId" => $application_number,
+          "eventType" => "MESSAGE_READ",
+          "eventCode" => 0,
+          "eventSource" => "GrantsApplications",
+          "timeUpdated" => "2026-05-06T12:02:09",
+          "timeCreated" => "2026-05-06T12:02:09",
+          "eventDescription" => "Viesti merkitty luetuksi",
+          "eventID" => "9355d811-d81b-4f66-bfda-15affd07734b",
+          // Event target matches the second message messageId.
+          "eventTarget" => "bbbbbbbb-4444-5555-6666-cccccccccccc",
+        ],
+      ],
+      'messages' => [
+        [
+          'caseId' => $application_number,
+          'messageId' => 'aaaaaaaa-1111-2222-3333-bbbbbbbbbbbbb',
+          'body' => 'viesti viesti viesti',
+          'sentBy' => 'Avustusten kasittelyjarjestelma',
+          'sendDateTime' => '2026-05-06T08:40:37',
+        ],
+        [
+          'caseId' => $application_number,
+          'messageId' => 'bbbbbbbb-4444-5555-6666-cccccccccccc',
+          'body' => 'Luettu viesti, jolla on mätsäävä eventti',
+          'sentBy' => 'Avustusten kasittelyjarjestelma',
+          'sendDateTime' => '2026-05-07T08:40:37',
+        ],
+      ],
+    ]);
+    return $document;
+  }
+
+}


### PR DESCRIPTION
# [UHF-13012](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13012)

Messages can be sent from Avus2 to Drupal. 
- The messages are inside ATV-documents content
- The read-status for message is set by adding a 'MESSAGE_READ' -event to the document's content's events-array.
- The message and event must be in specific format (ask author for details)

## What was done
Allow end user to mark messages as "read"

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13012`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test

- Log in as end user
- Select one of the submitted react-applications, it must have messages from Avus2
  - If you don't have such applications: 
    - Ask PO to send a message OR
    -  alter the atv-document manually OR
    - hardcode a message and an event to  ApplicationController::viewApplication line 347
- Click the "view application" link (on oma-asiointi -page)
  - Messages sent by you (as an end user) should contain contain only the basic message related data.
  - Unread messages from avus2 should also have a "NEW"-label and "Mark as read" -button above and below the basic message data.
  - Message from avus2 marked as read should have only the basic message data
  - "Mark as read" -button should trigger an ajax-call which will update the message's status and should update the html after finishing.


[UHF-13012]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ