### PR TITLE
UHF-13149: purpose field required

### DIFF
--- a/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_pienavustushake.yml
@@ -301,6 +301,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -389,6 +390,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
+++ b/conf/cmi/webform.webform.asukasosallisuus_yleis_ja_toimin.yml
@@ -419,6 +419,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -507,6 +508,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.hyte_yleisavustus.yml
+++ b/conf/cmi/webform.webform.hyte_yleisavustus.yml
@@ -344,6 +344,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.hyteed_pienavustus.yml
+++ b/conf/cmi/webform.webform.hyteed_pienavustus.yml
@@ -299,6 +299,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -387,6 +388,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.hyteed_yleis.yml
+++ b/conf/cmi/webform.webform.hyteed_yleis.yml
@@ -407,6 +407,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.iakkaiden_kulttuuri_ja_liikunta.yml
+++ b/conf/cmi/webform.webform.iakkaiden_kulttuuri_ja_liikunta.yml
@@ -489,6 +489,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -577,6 +578,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_toiminta_av.yml
@@ -348,6 +348,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
+++ b/conf/cmi/webform.webform.kasvatus_ja_koulutus_yleisavustu.yml
@@ -354,6 +354,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
+++ b/conf/cmi/webform.webform.kaupunginkanslia_tyollisyysavust.yml
@@ -353,6 +353,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -441,6 +442,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.kuva_projekti.yml
+++ b/conf/cmi/webform.webform.kuva_projekti.yml
@@ -422,6 +422,7 @@ elements: |-
             '#maxlength': 1000
             '#counter_type': character
             '#counter_maximum': 1000
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.kuva_toiminta.yml
+++ b/conf/cmi/webform.webform.kuva_toiminta.yml
@@ -473,6 +473,7 @@ elements: |-
             '#title': 'Kuvaus käyttötarkoituksesta'
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
+++ b/conf/cmi/webform.webform.liikunta_laitosavustushakemus.yml
@@ -355,6 +355,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -443,6 +444,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
+++ b/conf/cmi/webform.webform.liikunta_toiminta_ja_tilankaytto.yml
@@ -487,6 +487,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.liikuntaharrastamisen_avustus.yml
+++ b/conf/cmi/webform.webform.liikuntaharrastamisen_avustus.yml
@@ -499,6 +499,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -587,6 +588,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.nuorisotoiminta_projektiavustus.yml
+++ b/conf/cmi/webform.webform.nuorisotoiminta_projektiavustus.yml
@@ -391,6 +391,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -478,6 +479,7 @@ elements: |-
             '#maxlength': 1000
             '#counter_type': character
             '#counter_maximum': 1000
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
+++ b/conf/cmi/webform.webform.nuorisotoiminta_projektiavustush.yml
@@ -377,6 +377,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -464,6 +465,7 @@ elements: |-
             '#maxlength': 1000
             '#counter_type': character
             '#counter_maximum': 1000
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.nuortoimintapalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimintapalkka.yml
@@ -417,6 +417,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -505,6 +506,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.nuortoimpalkka.yml
+++ b/conf/cmi/webform.webform.nuortoimpalkka.yml
@@ -406,6 +406,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -494,6 +495,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.performance_test_webform.yml
+++ b/conf/cmi/webform.webform.performance_test_webform.yml
@@ -159,6 +159,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -247,6 +248,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.segregaation_ehkaisemisavustus.yml
+++ b/conf/cmi/webform.webform.segregaation_ehkaisemisavustus.yml
@@ -504,6 +504,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -592,6 +593,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.sotepe_yleis.yml
+++ b/conf/cmi/webform.webform.sotepe_yleis.yml
@@ -407,6 +407,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuri_kehittamisavu.yml
@@ -394,6 +394,7 @@ elements: |-
           purpose:
             '#type': textarea
             '#title': 'Kuvaus käyttötarkoituksesta'
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
+++ b/conf/cmi/webform.webform.taide_ja_kulttuuriavustukset_tai.yml
@@ -378,6 +378,7 @@ elements: |-
             '#title': 'Kuvaus käyttötarkoituksesta'
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.terveys_hyvinvointi_pienavustus.yml
+++ b/conf/cmi/webform.webform.terveys_hyvinvointi_pienavustus.yml
@@ -301,6 +301,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -389,6 +390,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.tyollisyys.yml
+++ b/conf/cmi/webform.webform.tyollisyys.yml
@@ -405,6 +405,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.yleisavustushakemus.yml
+++ b/conf/cmi/webform.webform.yleisavustushakemus.yml
@@ -345,6 +345,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large
@@ -433,6 +434,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large

--- a/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
+++ b/conf/cmi/webform.webform.ymparistopalvelut_yleisavustus.yml
@@ -349,6 +349,7 @@ elements: |-
             '#help': 'Anna lyhyt kuvaus, mihin tarkoitukseen avustus on myönnetty?'
             '#maxlength': 1000
             '#counter_type': character
+            '#required': true
             '#attributes':
               class:
                 - webform--large


### PR DESCRIPTION
# [UHF-13149](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13149)

"other grants" -fieldsets' purpose field was not actually required. Added required-flag to all fieldsets on all forms 

## What was done
Made the purpose field required 

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13149`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Run `drush gwi --force`
- Run `drush cr`
- Log in as an enduser
- Open any webform application with the "muut avustukst" -fieldset (for example ID48)
  -  /fi/uusi-hakemus/kuva_projekti
- Go to page 2 (bottom of page) and add new "Myönnetty avustus"
  - Fill all other fields `except` the purpose(käyttötarkoitus)
  - Try changing page, it should have been prevented by validation
- Fill the purpose -field
  - Should let you change the page

[UHF-13149]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ