### PR TITLE
UHF-13295: ID67, zero as default value

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/AsukasYleisToimDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/AsukasYleisToimDefinition.php
@@ -29,7 +29,7 @@ class AsukasYleisToimDefinition extends ComplexDataDefinitionBase {
     }
 
     $info['members_applicant_person_local'] = DataDefinition::create('integer')
-      ->setSetting('defaultValue', "")
+      ->setSetting('defaultValue', "0")
       ->setSetting('valueCallback', [
         '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
         'convertToInt',
@@ -45,7 +45,7 @@ class AsukasYleisToimDefinition extends ComplexDataDefinitionBase {
       ]);
 
     $info['members_applicant_person_global'] = DataDefinition::create('integer')
-      ->setSetting('defaultValue', "")
+      ->setSetting('defaultValue', "0")
       ->setSetting('valueCallback', [
         '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
         'convertToInt',
@@ -57,7 +57,7 @@ class AsukasYleisToimDefinition extends ComplexDataDefinitionBase {
       ]);
 
     $info['members_applicant_community_local'] = DataDefinition::create('integer')
-      ->setSetting('defaultValue', "")
+      ->setSetting('defaultValue', "0")
       ->setSetting('valueCallback', [
         '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
         'convertToInt',
@@ -69,6 +69,7 @@ class AsukasYleisToimDefinition extends ComplexDataDefinitionBase {
       ]);
 
     $info['members_applicant_community_global'] = DataDefinition::create('integer')
+      ->setSetting('defaultValue', "0")
       ->setSetting('valueCallback', [
         '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
         'convertToInt',


### PR DESCRIPTION
…efault value if the field is left empty.

# [UHF-13295](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13295)

## What was done
Member count -int field default value to "0" on ID67 asukasosallisuus_yleis_ja_toimin


## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13295`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Log in as an enduser
- create a new webform-application: https://hel-fi-drupal-grant-applications.docker.so/fi/uusi-hakemus/asukasosallisuus_yleis_ja_toimin
- Start filling the application
- On page3, go through the member count -int fields, remove the default zero value from one or two of the member count fields, add something to one or two of them
- Fill & Send the application
  - Should go through 
- Log in as admin
- Check the avus2-json
- All member count -fields should have a value, even if you emptied the field.


[UHF-13295]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ