### PR TITLE
UHF-13321: updated form resender tool to fix missing field values fro…

### DIFF
--- a/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
@@ -434,6 +434,12 @@ class ResendApplicationsForm extends AtvFormBase {
       }
 
       $this->attachmentFixerService->fixAttachmentsOnApplication($atvDoc);
+
+      $updatedDocument = $this->fixedId67MemeberFields($atvDoc);
+      if ($updatedDocument) {
+        $atvDoc = $updatedDocument;
+      }
+
       $this->sendApplicationToIntegrations($atvDoc, $applicationId);
       $formState->setRebuild();
     }
@@ -653,6 +659,48 @@ class ResendApplicationsForm extends AtvFormBase {
     }
     // Return empty if no match is found.
     return [];
+  }
+
+  /**
+   * Allow resender tool to update broken values from ID67 form.
+   *
+   * @param \Drupal\helfi_atv\AtvDocument $atvDocument
+   *   The document.
+   *
+   * @return \Drupal\helfi_atv\AtvDocument|false
+   *   The document or FALSE if nothing is updated.
+   */
+  private function fixedId67MemeberFields(AtvDocument $atvDocument): AtvDocument|FALSE {
+    $applicationNumber = $atvDocument->getMetadata()['applicationnumber'] ?? FALSE;
+    if (!$applicationNumber || !str_contains($applicationNumber, '-067-')) {
+      return FALSE;
+    }
+
+    $dataChanged = FALSE;
+    $content = $atvDocument->getContent();
+
+    $activitiesInfoArray = $content['compensation']['activitiesInfoArray'] ?? [];
+    foreach ($activitiesInfoArray as &$item) {
+      if (!isset($item['ID']) || $item['valueType'] !== 'int') {
+        continue;
+      }
+
+      if (isset($item['value']) && $item['value'] !== NULL) {
+        continue;
+      }
+
+      // Null or missing value in int field is not allowed.
+      $item['value'] = "0";
+      $dataChanged = TRUE;
+    }
+
+    if (!$dataChanged) {
+      return FALSE;
+    }
+
+    $content['compensation']['activitiesInfoArray'] = $activitiesInfoArray;
+    $atvDocument->setContent($content);
+    return $atvDocument;
   }
 
 }

--- a/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
@@ -435,9 +435,15 @@ class ResendApplicationsForm extends AtvFormBase {
 
       $this->attachmentFixerService->fixAttachmentsOnApplication($atvDoc);
 
-      $updatedDocument = $this->fixedId67MemeberFields($atvDoc);
+      $updatedDocument = $this->fixedId67MemberFields($atvDoc);
       if ($updatedDocument) {
         $atvDoc = $updatedDocument;
+        try {
+          $this->atvService->patchDocument($atvDoc->getId(), $atvDoc->toArray());
+        }
+        catch (\Exception $e) {
+          $this->handleException("Error: Admin application forms - Resend error", $e);
+        }
       }
 
       $this->sendApplicationToIntegrations($atvDoc, $applicationId);
@@ -670,7 +676,7 @@ class ResendApplicationsForm extends AtvFormBase {
    * @return \Drupal\helfi_atv\AtvDocument|false
    *   The document or FALSE if nothing is updated.
    */
-  private function fixedId67MemeberFields(AtvDocument $atvDocument): AtvDocument|FALSE {
+  private function fixedId67MemberFields(AtvDocument $atvDocument): AtvDocument|FALSE {
     $applicationNumber = $atvDocument->getMetadata()['applicationnumber'] ?? FALSE;
     if (!$applicationNumber || !str_contains($applicationNumber, '-067-')) {
       return FALSE;
@@ -678,18 +684,19 @@ class ResendApplicationsForm extends AtvFormBase {
 
     $dataChanged = FALSE;
     $content = $atvDocument->getContent();
-
     $activitiesInfoArray = $content['compensation']['activitiesInfoArray'] ?? [];
+
     foreach ($activitiesInfoArray as &$item) {
       if (!isset($item['ID']) || $item['valueType'] !== 'int') {
         continue;
       }
 
+      // Correct value.
       if (isset($item['value']) && $item['value'] !== NULL) {
         continue;
       }
 
-      // Null or missing value in int field is not allowed.
+      // Null value in int field is not allowed.
       $item['value'] = "0";
       $dataChanged = TRUE;
     }

--- a/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
+++ b/public/modules/custom/grants_admin_applications/src/Form/ResendApplicationsForm.php
@@ -678,7 +678,7 @@ class ResendApplicationsForm extends AtvFormBase {
    */
   private function fixedId67MemberFields(AtvDocument $atvDocument): AtvDocument|FALSE {
     $applicationNumber = $atvDocument->getMetadata()['applicationnumber'] ?? FALSE;
-    if (!$applicationNumber || !str_contains($applicationNumber, '-067-')) {
+    if (!$applicationNumber || !str_contains($applicationNumber, '067-')) {
       return FALSE;
     }
 


### PR DESCRIPTION
# [UHF-13321](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13321)

## What was done
Modified application resender to fix broken ID67 applications. 


## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13321`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Start by commenting out default zeros from ID67-application
  - AsukasYleisToimDefinition.php lines: 32, 48, 60, 72
- Log in as an enduser, create and send the ID67 application
  - LEAVE AT LEAST ONE OF THE MEMBER COUNT FIELDS EMPTY!  
    - for example, `leave 2 empty`, add `0` to one and add `99` to another
  - /uusi-hakemus/asukasosallisuus_yleis_ja_toimin
- The submit should fail
  - Copy the application number 
- Log in as admin, go to resend tool and search for member-fields, they should be missing the `"value": "0" `completely
- Resend the application as admin by using the resender
- Reload the application data, the "value": "0" should have been added to the fields that were missing the value.


[UHF-13321]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ