### PR TITLE
UHF-13299: member field default zero

### DIFF
--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/AsukaPienaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/AsukaPienaDefinition.php
@@ -27,8 +27,8 @@ class AsukaPienaDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['members_applicant_person_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+      $info['members_applicant_person_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -39,7 +39,8 @@ class AsukaPienaDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonLocal',
         ]);
 
-      $info['members_applicant_person_global'] = DataDefinition::create('string')
+      $info['members_applicant_person_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -50,8 +51,8 @@ class AsukaPienaDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonGlobal',
         ]);
 
-      $info['members_applicant_community_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+      $info['members_applicant_community_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -62,7 +63,8 @@ class AsukaPienaDefinition extends ComplexDataDefinitionBase {
           'membersApplicantCommunityLocal',
         ]);
 
-      $info['members_applicant_community_global'] = DataDefinition::create('string')
+      $info['members_applicant_community_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/HyteedPienDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/HyteedPienDefinition.php
@@ -27,8 +27,8 @@ class HyteedPienDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['members_applicant_person_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+      $info['members_applicant_person_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -39,7 +39,8 @@ class HyteedPienDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonLocal',
         ]);
 
-      $info['members_applicant_person_global'] = DataDefinition::create('string')
+      $info['members_applicant_person_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -50,8 +51,8 @@ class HyteedPienDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonGlobal',
         ]);
 
-      $info['members_applicant_community_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+      $info['members_applicant_community_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -62,7 +63,8 @@ class HyteedPienDefinition extends ComplexDataDefinitionBase {
           'membersApplicantCommunityLocal',
         ]);
 
-      $info['members_applicant_community_global'] = DataDefinition::create('string')
+      $info['members_applicant_community_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/HyvinYleisDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/HyvinYleisDefinition.php
@@ -27,7 +27,8 @@ class HyvinYleisDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['members_applicant_person_local'] = DataDefinition::create('string')
+      $info['members_applicant_person_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -38,7 +39,8 @@ class HyvinYleisDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonLocal',
         ]);
 
-      $info['members_applicant_person_global'] = DataDefinition::create('string')
+      $info['members_applicant_person_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -49,7 +51,8 @@ class HyvinYleisDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonGlobal',
         ]);
 
-      $info['members_applicant_community_local'] = DataDefinition::create('string')
+      $info['members_applicant_community_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -60,7 +63,8 @@ class HyvinYleisDefinition extends ComplexDataDefinitionBase {
           'membersApplicantCommunityLocal',
         ]);
 
-      $info['members_applicant_community_global'] = DataDefinition::create('string')
+      $info['members_applicant_community_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoYleisavustusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoYleisavustusDefinition.php
@@ -27,7 +27,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['members_applicant_person_local'] = DataDefinition::create('string')
+      $info['members_applicant_person_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
@@ -39,7 +39,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonLocal',
         ]);
 
-      $info['members_applicant_person_global'] = DataDefinition::create('string')
+      $info['members_applicant_person_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
@@ -51,7 +51,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonGlobal',
         ]);
 
-      $info['members_applicant_community_local'] = DataDefinition::create('string')
+      $info['members_applicant_community_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
@@ -63,7 +63,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantCommunityLocal',
         ]);
 
-      $info['members_applicant_community_global'] = DataDefinition::create('string')
+      $info['members_applicant_community_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoYleisavustusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KaskoYleisavustusDefinition.php
@@ -28,7 +28,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
       }
 
       $info['members_applicant_person_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -40,7 +40,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_global'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -52,7 +52,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -64,6 +64,7 @@ class KaskoYleisavustusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_global'] = DataDefinition::create('string')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaKehaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaKehaDefinition.php
@@ -368,6 +368,7 @@ class KuvaKehaDefinition extends ComplexDataDefinitionBase {
       ]);
 
     $info['members_applicant_person_global'] = DataDefinition::create('integer')
+      ->setSetting('defaultValue', "0")
       ->setSetting('jsonPath', [
         'compensation',
         'communityInfo',
@@ -383,6 +384,7 @@ class KuvaKehaDefinition extends ComplexDataDefinitionBase {
       ]);
 
     $info['members_applicant_person_local'] = DataDefinition::create('integer')
+      ->setSetting('defaultValue', "0")
       ->setSetting('jsonPath', [
         'compensation',
         'communityInfo',
@@ -398,6 +400,7 @@ class KuvaKehaDefinition extends ComplexDataDefinitionBase {
       ]);
 
     $info['members_applicant_community_global'] = DataDefinition::create('integer')
+      ->setSetting('defaultValue', "0")
       ->setSetting('jsonPath', [
         'compensation',
         'communityInfo',
@@ -413,6 +416,7 @@ class KuvaKehaDefinition extends ComplexDataDefinitionBase {
       ]);
 
     $info['members_applicant_community_local'] = DataDefinition::create('integer')
+      ->setSetting('defaultValue', "0")
       ->setSetting('jsonPath', [
         'compensation',
         'communityInfo',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaPerusDefinition.php
@@ -47,6 +47,7 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
 
       // 3. Yhteisön tiedot.
       $info['members_applicant_person_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -62,6 +63,7 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -77,6 +79,7 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -92,6 +95,7 @@ class KuvaPerusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaProjektiDefinition.php
@@ -601,7 +601,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_local'] = DataDefinition::create('integer')
-        ->setSetting('defaultValue', '')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -617,7 +617,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_global'] = DataDefinition::create('integer')
-        ->setSetting('defaultValue', '')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -633,7 +633,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_local'] = DataDefinition::create('integer')
-        ->setSetting('defaultValue', '')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -649,7 +649,7 @@ class KuvaProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_global'] = DataDefinition::create('integer')
-        ->setSetting('defaultValue', '')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/KuvaToimintaDefinition.php
@@ -691,6 +691,7 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
         );
 
       $info['members_applicant_person_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -706,6 +707,7 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -721,6 +723,7 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_local'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',
@@ -736,6 +739,7 @@ class KuvaToimintaDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_global'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'communityInfo',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisotoimiProjektiDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/NuorisotoimiProjektiDefinition.php
@@ -60,6 +60,7 @@ class NuorisotoimiProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['jasenet_0_6_vuotiaat'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -74,6 +75,7 @@ class NuorisotoimiProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['0_6_joista_helsinkilaisia'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -88,6 +90,7 @@ class NuorisotoimiProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['jasenet_7_28_vuotiaat'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -102,6 +105,7 @@ class NuorisotoimiProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['7_28_joista_helsinkilaisia'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -116,6 +120,7 @@ class NuorisotoimiProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['muut_jasenet_tai_aktiiviset_osallistujat'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -130,6 +135,7 @@ class NuorisotoimiProjektiDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['muut_joista_helsinkilaisia'] = DataDefinition::create('integer')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/TyollisyysavustusHakemusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/TyollisyysavustusHakemusDefinition.php
@@ -27,7 +27,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['members_applicant_person_local'] = DataDefinition::create('string')
+      $info['members_applicant_person_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
@@ -35,7 +35,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonLocal',
         ]);
 
-      $info['members_applicant_person_global'] = DataDefinition::create('string')
+      $info['members_applicant_person_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
@@ -43,7 +43,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonGlobal',
         ]);
 
-      $info['members_applicant_community_local'] = DataDefinition::create('string')
+      $info['members_applicant_community_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
@@ -51,7 +51,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantCommunityLocal',
         ]);
 
-      $info['members_applicant_community_global'] = DataDefinition::create('string')
+      $info['members_applicant_community_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/TyollisyysavustusHakemusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/TyollisyysavustusHakemusDefinition.php
@@ -28,7 +28,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
       }
 
       $info['members_applicant_person_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -36,7 +36,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_global'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -44,7 +44,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -52,6 +52,7 @@ class TyollisyysavustusHakemusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_global'] = DataDefinition::create('string')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/YleisavustusHakemusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/YleisavustusHakemusDefinition.php
@@ -27,7 +27,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['members_applicant_person_local'] = DataDefinition::create('string')
+      $info['members_applicant_person_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
@@ -39,7 +39,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonLocal',
         ]);
 
-      $info['members_applicant_person_global'] = DataDefinition::create('string')
+      $info['members_applicant_person_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
@@ -51,7 +51,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantPersonGlobal',
         ]);
 
-      $info['members_applicant_community_local'] = DataDefinition::create('string')
+      $info['members_applicant_community_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
@@ -63,7 +63,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
           'membersApplicantCommunityLocal',
         ]);
 
-      $info['members_applicant_community_global'] = DataDefinition::create('string')
+      $info['members_applicant_community_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/YleisavustusHakemusDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/YleisavustusHakemusDefinition.php
@@ -28,7 +28,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
       }
 
       $info['members_applicant_person_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -40,7 +40,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_global'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -52,7 +52,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',
@@ -64,6 +64,7 @@ class YleisavustusHakemusDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_global'] = DataDefinition::create('string')
+        ->setSetting('defaultValue', "0")
         ->setSetting('valueCallback', [
           '\Drupal\grants_handler\Plugin\WebformHandler\GrantsHandler',
           'convertToInt',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/YmparistoYleisDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/YmparistoYleisDefinition.php
@@ -27,7 +27,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
         $info[$key] = $property;
       }
 
-      $info['members_applicant_person_local'] = DataDefinition::create('string')
+      $info['members_applicant_person_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
@@ -39,7 +39,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
           'convertToInt',
         ]);
 
-      $info['members_applicant_person_global'] = DataDefinition::create('string')
+      $info['members_applicant_person_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
@@ -51,7 +51,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
           'convertToInt',
         ]);
 
-      $info['members_applicant_community_local'] = DataDefinition::create('string')
+      $info['members_applicant_community_local'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
@@ -63,7 +63,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
           'convertToInt',
         ]);
 
-      $info['members_applicant_community_global'] = DataDefinition::create('string')
+      $info['members_applicant_community_global'] = DataDefinition::create('integer')
         ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',

--- a/public/modules/custom/grants_metadata/src/TypedData/Definition/YmparistoYleisDefinition.php
+++ b/public/modules/custom/grants_metadata/src/TypedData/Definition/YmparistoYleisDefinition.php
@@ -28,7 +28,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
       }
 
       $info['members_applicant_person_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -40,7 +40,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_person_global'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -52,7 +52,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_local'] = DataDefinition::create('string')
-        ->setSetting('defaultValue', "")
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',
@@ -64,6 +64,7 @@ class YmparistoYleisDefinition extends ComplexDataDefinitionBase {
         ]);
 
       $info['members_applicant_community_global'] = DataDefinition::create('string')
+        ->setSetting('defaultValue', "0")
         ->setSetting('jsonPath', [
           'compensation',
           'activitiesInfoArray',


### PR DESCRIPTION
Added the default value to all webform-applications

# [UHF-13299](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13299)

## What was done
Added default value to all 4 "members_applicant_*" fields on all webforms

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13299`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Log in as end user
- Create a new application for one of the webforms with bad fields
  - Leave the member-fields empty
- Submit (OR save as a draft)
- Log in as admin, use the resend tool to fetch the data
- Member fields should have "0" -value event when left empty on form.

[UHF-13299]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ