### PR TITLE
Fix as reported by Claude

### DIFF
--- a/public/modules/custom/grants_application/src/Mapper/Mappings/ID29/yleisavustushakemus.json
+++ b/public/modules/custom/grants_application/src/Mapper/Mappings/ID29/yleisavustushakemus.json
@@ -36,7 +36,7 @@
   },
   "compensation.compensationInfo.generalInfoArray.1": {
     "datasource": "form_data",
-    "source": "grant_info_step.other_compensations_section.have_received_other_compensations",
+    "source": "grant_info_step.prior_benefits_usage_section.have_received_prior_compensations",
     "mapping_type": "default",
     "data": {
       "ID": "compensationPreviousYear",

--- a/public/modules/custom/grants_application/src/Mapper/Mappings/ID71/hyteed_yleis.json
+++ b/public/modules/custom/grants_application/src/Mapper/Mappings/ID71/hyteed_yleis.json
@@ -36,7 +36,7 @@
   },
   "compensation.compensationInfo.generalInfoArray.1": {
     "datasource": "form_data",
-    "source": "grant_info_step.other_compensations_section.have_received_other_compensations",
+    "source": "grant_info_step.prior_benefits_usage_section.have_received_prior_compensations",
     "mapping_type": "default",
     "data": {
       "ID": "compensationPreviousYear",

--- a/public/modules/custom/grants_application/src/Mapper/Mappings/ID72/sotepe_yleis.json
+++ b/public/modules/custom/grants_application/src/Mapper/Mappings/ID72/sotepe_yleis.json
@@ -36,7 +36,7 @@
   },
   "compensation.compensationInfo.generalInfoArray.1": {
     "datasource": "form_data",
-    "source": "grant_info_step.other_compensations_section.have_received_other_compensations",
+    "source": "grant_info_step.prior_benefits_usage_section.have_received_prior_compensations",
     "mapping_type": "default",
     "data": {
       "ID": "compensationPreviousYear",


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* The Avus2 field compensation.compensationInfo.generalInfoArray.1 (ID: compensationPreviousYear, label: "Käyttöselvitys edellisenä vuonna saamastani avustuksesta") is wired to the wrong source field in 3 production-bound fixture mappers. Instead of reading the user's answer to the Helsinki käyttöselvitys radio (compensation_boolean in the old webform), it reads the unrelated "have you received non-Helsinki grants" boolean (olemme_saaneet_muita_avustuksia in the old webform).

Result: Avus2 receives the wrong boolean for the legally-significant käyttöselvitys field.

<img width="2088" height="1186" alt="image" src="https://github.com/user-attachments/assets/4ddd8fa2-0be4-4d40-b842-8edecba1ccad" />

<img width="2084" height="1546" alt="image" src="https://github.com/user-attachments/assets/000bc49a-686e-44bd-818a-7ac673545c43" />

<img width="2088" height="818" alt="image" src="https://github.com/user-attachments/assets/ca2a1c46-77ef-4ec0-8a59-1e71de8cf39a" />

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-X-obligation-tracking-bug`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Check if this is actually valid logic
* [ ] Check that the code follows our standards

<!--
Check list for the developer

Privacy
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.

E2E tests
- Make sure the tests pass when you run `make test-pw` on your local.
- Detailed instructions can be found here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/dev/e2e/README.md#environment-setup

Application that are no longer used
- Archive the webform applications after they are no longer used. This stops users from sending old drafts of the archived application.
- Archived webforms must also be removed from the E2E tests since they can't be tested after archiving.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
*
