### PR TITLE
UHF-13042: Changed status information to have same structrue as in react

### DIFF
--- a/public/modules/custom/grants_application/templates/grants-application-view-status-information.html.twig
+++ b/public/modules/custom/grants_application/templates/grants-application-view-status-information.html.twig
@@ -31,16 +31,19 @@
     </div>
     <div>
       <h5>{{ "Application statuses"|t }}</h5>
-      {% for event in history %}
-        <div>{{ event }}</div>
-      {% endfor %}
+      <ul className='application-status-history'>
+        {% for event in history %}
+          <li>{{ event }}</li>
+        {% endfor %}
+      </ul>
     </div>
     <div>
       <h5>{{ "Application attachments"|t }}</h5>
-      {% for attachment in attachments %}
-        {{ attachment }}
-        {{ (attachment === attachments|last) ? '': '</br>'  }}
-      {% endfor %}
+      <ul className='application-attachment-list'>
+        {% for attachment in attachments %}
+          <li>{{ attachment }}</li>
+        {% endfor %}
+      </ul>
     </div>
   </div>
   {% if is_editable %}


### PR DESCRIPTION
# [UHF-13042](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13042)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Changed form summary to be in same format as in react

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13042`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Go view some sent react form and make sure Hakemuksen tilat and Hakemuksen liitteet has ul li structure, same as in react FormSummary.tsx
* [ ] You can check the react version if you edit the sent form


<img width="1505" height="805" alt="Screenshot 2026-06-04 at 15 50 56" src="https://github.com/user-attachments/assets/a0e0b1eb-af7c-4b55-8aed-132d429b35f2" />

* [ ] Check that the code follows our standards

<!--
Check list for the developer

Privacy
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.

E2E tests
- Make sure the tests pass when you run `make test-pw` on your local.
- Detailed instructions can be found here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/dev/e2e/README.md#environment-setup

Application that are no longer used
- Archive the webform applications after they are no longer used. This stops users from sending old drafts of the archived application.
- Archived webforms must also be removed from the E2E tests since they can't be tested after archiving.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
*


[UHF-13042]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ