### PR TITLE
UHF-13131: Bank file attachment error handling

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2156,16 +2156,6 @@ parameters:
 			path: public/modules/custom/grants_attachments/src/AttachmentHandler.php
 
 		-
-			message: "#^Method Drupal\\\\grants_attachments\\\\AttachmentHandler\\:\\:getSelectedAccount\\(\\) has parameter \\$profileContent with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_attachments/src/AttachmentHandler.php
-
-		-
-			message: "#^Method Drupal\\\\grants_attachments\\\\AttachmentHandler\\:\\:getSelectedAccount\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: public/modules/custom/grants_attachments/src/AttachmentHandler.php
-
-		-
 			message: "#^Method Drupal\\\\grants_attachments\\\\AttachmentHandler\\:\\:handleAttachment\\(\\) has parameter \\$attachment with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: public/modules/custom/grants_attachments/src/AttachmentHandler.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1471,11 +1471,6 @@ parameters:
 			path: public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
 
 		-
-			message: "#^Property Drupal\\\\grants_application\\\\Plugin\\\\rest\\\\resource\\\\Application\\:\\:\\$attachmentHandler is never read, only written\\.$#"
-			count: 1
-			path: public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
-
-		-
 			message: "#^Property Drupal\\\\grants_application\\\\Plugin\\\\rest\\\\resource\\\\Application\\:\\:\\$languageManager is never read, only written\\.$#"
 			count: 1
 			path: public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php

--- a/public/modules/custom/grants_application/src/Avus2Exception.php
+++ b/public/modules/custom/grants_application/src/Avus2Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\grants_application;
+
+/**
+ * Exception type for avus2 integration.
+ */
+class Avus2Exception extends \Exception {
+}

--- a/public/modules/custom/grants_application/src/Avus2Integration.php
+++ b/public/modules/custom/grants_application/src/Avus2Integration.php
@@ -125,7 +125,7 @@ class Avus2Integration {
         'headers' => $headers,
       ]);
 
-      if ($res->getStatusCode() === 200) {
+      if ($res->getStatusCode() !== 200) {
         throw new Avus2Exception('Avus2 integration failed: ' . $res->getBody()->getContents());
       }
     }

--- a/public/modules/custom/grants_application/src/Avus2Integration.php
+++ b/public/modules/custom/grants_application/src/Avus2Integration.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\grants_application;
 
 use Drupal\Component\Serialization\Json;
-use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\grants_metadata\AtvSchema;
 use Drupal\helfi_atv\AtvDocument;
 use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Sentry\Breadcrumb;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+use function Sentry\addBreadcrumb;
 
 /**
  * Avus2 integration.
@@ -17,43 +21,27 @@ class Avus2Integration {
 
   /**
    * The endpoint.
-   *
-   * @var string
    */
   private string $endpoint;
 
   /**
    * The username.
-   *
-   * @var string
    */
   private string $username;
 
   /**
    * The password.
-   *
-   * @var string
    */
   private string $password;
-
-  /**
-   * The logger.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  private LoggerChannelInterface $logger;
 
   /**
    * The constructor.
    */
   public function __construct(
-    private LoggerChannelFactoryInterface $loggerFactory,
     #[Autowire(service: 'grants_metadata.atv_schema')]
-    private AtvSchema $atvSchema,
-    private ClientInterface $httpClient,
+    private readonly AtvSchema $atvSchema,
+    private readonly ClientInterface $httpClient,
   ) {
-    $this->logger = $this->loggerFactory->get('avus2_integration');
-
     if ($schema = getenv('ATV_SCHEMA_PATH')) {
       $this->atvSchema->setSchema($schema);
     }
@@ -75,10 +63,10 @@ class Avus2Integration {
    * @param bool $integrationError
    *   Try submitting the application again from scratch.
    *
-   * @return bool
-   *   Successful submission.
+   * @throws \Drupal\grants_application\Avus2Exception
+   *   If the request fails.
    */
-  public function sendToAvus2(AtvDocument $document, string $application_number, string $save_id, bool $integrationError): bool {
+  public function sendToAvus2(AtvDocument $document, string $application_number, string $save_id, bool $integrationError): void {
 
     // The content contains also the data used by react form,
     // we don't want to send that.
@@ -87,30 +75,46 @@ class Avus2Integration {
     unset($content['compensation']['form_data']);
     $json = Json::encode($content);
 
-    try {
-      $headers = [];
+    $headers = [];
 
-      if ($integrationError) {
-        // We set the data source for integration to be used in controlling
-        // application testing in problematic cases.
-        $headers['X-hki-UpdateSource'] = 'RESEND';
-      }
-
-      // Get status from updated document.
-      $headers['X-Case-Status'] = $document->getStatus();
-
+    if ($integrationError) {
       // We set the data source for integration to be used in controlling
       // application testing in problematic cases.
-      $headers['X-hki-UpdateSource'] = 'USER';
+      // FIXME: this is immediately overridden to USER.
+      $headers['X-hki-UpdateSource'] = 'RESEND';
+    }
 
-      // Current environment as a header to be added to meta -fields.
-      $headers['X-hki-appEnv'] = Helper::getAppEnv();
-      // Set application number to meta as well to enable better searches.
-      $headers['X-hki-applicationNumber'] = $application_number;
+    // Get status from updated document.
+    $headers['X-Case-Status'] = $document->getStatus();
 
-      // Set new saveid to header.
-      $headers['X-hki-saveId'] = $save_id;
+    // We set the data source for integration to be used in controlling
+    // application testing in problematic cases.
+    $headers['X-hki-UpdateSource'] = 'USER';
 
+    // Current environment as a header to be added to meta -fields.
+    $headers['X-hki-appEnv'] = Helper::getAppEnv();
+    // Set application number to meta as well to enable better searches.
+    $headers['X-hki-applicationNumber'] = $application_number;
+
+    // Set new saveid to header.
+    $headers['X-hki-saveId'] = $save_id;
+
+    // Leave a trail for Sentry so a later exception has the context of the
+    // Avus2 request that preceded it.
+    addBreadcrumb(new Breadcrumb(
+      Breadcrumb::LEVEL_INFO,
+      Breadcrumb::TYPE_HTTP,
+      'avus2_integration',
+      'Sending application to Avus2',
+      [
+        'application_number' => $application_number,
+        'save_id' => $save_id,
+        'case_status' => $headers['X-Case-Status'],
+        'integration_error' => $integrationError,
+      ],
+    ));
+
+    try {
       $res = $this->httpClient->request('POST', $this->endpoint, [
         'auth' => [
           $this->username,
@@ -121,19 +125,12 @@ class Avus2Integration {
         'headers' => $headers,
       ]);
 
-      return $res->getStatusCode() === 200;
+      if ($res->getStatusCode() === 200) {
+        throw new Avus2Exception('Avus2 integration failed: ' . $res->getBody()->getContents());
+      }
     }
-    catch (\Exception $e) {
-      /*
-      $this->messenger->addError(
-      $this->t('Application saving failed, error has been logged.',
-      [],
-      ['context' => 'grants_handler']),
-      );
-       */
-      $this->logger->error('Error saving application: %msg', ['%msg' => $e->getMessage()]);
-      // \Sentry\captureException($e);
-      return FALSE;
+    catch (GuzzleException $e) {
+      throw new Avus2Exception($e->getMessage(), $e->getCode(), $e);
     }
   }
 

--- a/public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
+++ b/public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
@@ -22,7 +22,6 @@ use Drupal\grants_application\Form\FormSettingsServiceInterface;
 use Drupal\grants_application\Mapper\JsonMapperService;
 use Drupal\grants_application\JsonSchemaValidator;
 use Drupal\grants_application\User\UserInformationService;
-use Drupal\grants_attachments\AttachmentHandler;
 use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationStatusService;
 use Drupal\grants_handler\ApplicationSubmitType;
@@ -71,7 +70,6 @@ final class Application extends ResourceBase {
     private EventDispatcherInterface $dispatcher,
     private Avus2Integration $integration,
     private EventsService $eventsService,
-    private AttachmentHandler $attachmentHandler,
     private ApplicationStatusService $applicationStatusService,
     private JsonSchemaValidator $jsonSchemaValidator,
     private ContentLockInterface $contentLock,
@@ -104,7 +102,6 @@ final class Application extends ResourceBase {
       $container->get(EventDispatcherInterface::class),
       $container->get(Avus2Integration::class),
       $container->get('grants_events.events_service'),
-      $container->get('grants_attachments.attachment_handler'),
       $container->get('grants_handler.application_status_service'),
       $container->get(JsonSchemaValidator::class),
       $container->get('content_lock'),
@@ -411,8 +408,9 @@ final class Application extends ResourceBase {
         $document = $this->atvService->getDocument($application_number);
         $bankFileIsSet = $this->jsonMapperService->documentBankFileIsSet($document);
       }
-      catch(\throwable) {
+      catch(\throwable $e) {
         // Just to be safe.
+        Error::logException($this->logger, $e);
         return new JsonResponse(['error' => $this->t('Something went wrong')], 500);
       }
 

--- a/public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
+++ b/public/modules/custom/grants_application/src/Plugin/rest/resource/Application.php
@@ -12,8 +12,10 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
+use Drupal\Core\Utility\Error;
 use Drupal\grants_application\Atv\HelfiAtvService;
 use Drupal\grants_application\Avus2DataParser;
+use Drupal\grants_application\Avus2Exception;
 use Drupal\grants_application\Avus2Integration;
 use Drupal\grants_application\Entity\ApplicationSubmission;
 use Drupal\grants_application\Form\FormSettingsServiceInterface;
@@ -30,10 +32,13 @@ use Drupal\rest\Plugin\ResourceBase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
+use Sentry\Breadcrumb;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouteCollection;
+
+use function Sentry\addBreadcrumb;
 
 /**
  * Handle the ready applications.
@@ -131,6 +136,18 @@ final class Application extends ResourceBase {
     if (!$application_number) {
       return new JsonResponse([], 400);
     }
+
+    addBreadcrumb(new Breadcrumb(
+      Breadcrumb::LEVEL_INFO,
+      Breadcrumb::TYPE_HTTP,
+      'grants_application',
+      'GET application request received',
+      [
+        'form_identifier' => $form_identifier,
+        'application_number' => $application_number,
+      ],
+    ));
+
     // @todo Parse the last STATUS_UPDATE event here.
     // It can be used to determinate if this is editable.
     try {
@@ -283,6 +300,17 @@ final class Application extends ResourceBase {
       'form_data' => $form_data,
     ] = $content;
 
+    addBreadcrumb(new Breadcrumb(
+      Breadcrumb::LEVEL_INFO,
+      Breadcrumb::TYPE_HTTP,
+      'grants_application',
+      'POST application request received',
+      [
+        'form_identifier' => $form_identifier,
+        'application_number' => $application_number,
+      ],
+    ));
+
     // phpcs:enable
     try {
       $settings = $this->formSettingsService->getFormSettingsByFormIdentifier($form_identifier);
@@ -363,7 +391,7 @@ final class Application extends ResourceBase {
         $actualFile = $this->atvService->getAttachment($bankFile['href']);
       }
       catch (\Exception $e) {
-        $this->logger->error("Unable to get bank file: {$e->getMessage()}");
+        Error::logException($this->logger, $e);
         return new JsonResponse(['error' => $this->t('Something went wrong')], 500);
       }
 
@@ -467,17 +495,11 @@ final class Application extends ResourceBase {
     );
     $this->eventsService->addNewEventForApplication($latestDocument, $event);
 
-    $success = FALSE;
     try {
-      $success = $this->integration->sendToAvus2($latestDocument, $application_number, $save_id, $integrationError);
+      $this->integration->sendToAvus2($latestDocument, $application_number, $save_id, $integrationError);
     }
-    catch (\Exception $e) {
+    catch (Avus2Exception $e) {
       $this->logger->error('Avus2 -POST-request failed: ' . $e->getMessage());
-      return new JsonResponse(['error' => $this->t('An error occurred while sending the application. Please try again in a moment')], 500);
-    }
-
-    if (!$success) {
-      $this->logger->error('Avus2 -POST-request returned non-200 response');
       return new JsonResponse(['error' => $this->t('An error occurred while sending the application. Please try again in a moment')], 500);
     }
 
@@ -533,6 +555,17 @@ final class Application extends ResourceBase {
       'form_data' => $form_data,
       'attachments' => $attachments,
     ] = $content;
+
+    addBreadcrumb(new Breadcrumb(
+      Breadcrumb::LEVEL_INFO,
+      Breadcrumb::TYPE_HTTP,
+      'grants_application',
+      'PATCH application request received',
+      [
+        'form_identifier' => $form_identifier,
+        'application_number' => $application_number,
+      ],
+    ));
 
     try {
       $settings = $this->formSettingsService->getFormSettingsByFormIdentifier($form_identifier);
@@ -636,17 +669,11 @@ final class Application extends ResourceBase {
       return new JsonResponse(['error' => $this->t('An error occurred while sending the application. Please try again in a moment')], 500);
     }
 
-    $success = FALSE;
     try {
-      $success = $this->integration->sendToAvus2($latestDocument, $application_number, $save_id, FALSE);
+      $this->integration->sendToAvus2($latestDocument, $application_number, $save_id, FALSE);
     }
-    catch (\Exception $e) {
+    catch (Avus2Exception $e) {
       $this->logger->error('Avus2 -PATCH-request failed: ' . $e->getMessage());
-      return new JsonResponse(['error' => $this->t('An error occurred while sending the application. Please try again in a moment')], 500);
-    }
-
-    if (!$success) {
-      $this->logger->error('Avus2 -PATCH-request returned non-200 response');
       return new JsonResponse(['error' => $this->t('An error occurred while sending the application. Please try again in a moment')], 500);
     }
 

--- a/public/modules/custom/grants_application/src/Plugin/rest/resource/DraftApplication.php
+++ b/public/modules/custom/grants_application/src/Plugin/rest/resource/DraftApplication.php
@@ -26,11 +26,13 @@ use Drupal\rest\Plugin\ResourceBase;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Sentry\Breadcrumb;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouteCollection;
+use function Sentry\addBreadcrumb;
 
 /**
  * Handle the draft applications.
@@ -134,6 +136,17 @@ final class DraftApplication extends ResourceBase {
       // Cannot find form by application type id.
       return new JsonResponse([], 404);
     }
+
+    addBreadcrumb(new Breadcrumb(
+      Breadcrumb::LEVEL_INFO,
+      Breadcrumb::TYPE_HTTP,
+      'grants_application',
+      'GET application request received',
+      [
+        'form_identifier' => $form_identifier,
+        'application_number' => $application_number,
+      ],
+    ));
 
     try {
       $applicantType = $this->userInformationService->getApplicantType();
@@ -294,6 +307,17 @@ final class DraftApplication extends ResourceBase {
     $application_number = $this->applicationNumberService
       ->createNewApplicationNumber($env, $application_type_id);
 
+    addBreadcrumb(new Breadcrumb(
+      Breadcrumb::LEVEL_INFO,
+      Breadcrumb::TYPE_HTTP,
+      'grants_application',
+      'POST application request received',
+      [
+        'form_identifier' => $form_identifier,
+        'application_number' => $application_number,
+      ],
+    ));
+
     $langcode = $this->languageManager
       ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
       ->getId();
@@ -423,6 +447,17 @@ final class DraftApplication extends ResourceBase {
       // 'attachments' => $attachments,
       'form_data' => $form_data,
     ] = $content;
+
+    addBreadcrumb(new Breadcrumb(
+      Breadcrumb::LEVEL_INFO,
+      Breadcrumb::TYPE_HTTP,
+      'grants_application',
+      'PATCH application request received',
+      [
+        'form_identifier' => $form_identifier,
+        'application_number' => $application_number,
+      ],
+    ));
 
     try {
       $settings = $this->formSettingsService->getFormSettingsByFormIdentifier($form_identifier);

--- a/public/modules/custom/grants_application/tests/src/Kernel/Avus2IntegrationTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Avus2IntegrationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\grants_application\Kernel;
+
+use Drupal\grants_application\Avus2Exception;
+use Drupal\grants_application\Avus2Integration;
+use Drupal\helfi_atv\AtvDocument;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\Attributes\TestWith;
+
+/**
+ * Tests Avus2Integration class.
+ */
+#[Group('grants_application')]
+#[RunTestsInSeparateProcesses]
+final class Avus2IntegrationTest extends KernelTestBase {
+
+  use ApiTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    putenv('AVUSTUS2_ENDPOINT=https://example.com/avus2');
+    putenv('AVUSTUS2_USERNAME=user');
+    putenv('AVUSTUS2_PASSWORD=pass');
+    putenv('APP_ENV=testing');
+  }
+
+  /**
+   * A successful request is sent without the react form data.
+   */
+  public function testSendToAvus2Success(): void {
+    $history = [];
+    $integration = $this->getIntegration([new Response(200)], $history);
+
+    $integration->sendToAvus2($this->getSubmittedDocument(), 'TEST-058-0000001', 'save-id-123', FALSE);
+
+    $this->assertCount(1, $history);
+    /** @var \Psr\Http\Message\RequestInterface $request */
+    $request = $history[0]['request'];
+    $this->assertSame('POST', $request->getMethod());
+    $this->assertSame(getenv('AVUSTUS2_ENDPOINT'), (string) $request->getUri());
+
+    // The react form data must not be sent to Avus2.
+    $sentContent = json_decode((string) $request->getBody(), TRUE);
+    $this->assertArrayNotHasKey('form_data', $sentContent);
+    $this->assertArrayNotHasKey('form_data', $sentContent['compensation']);
+    $this->assertSame('avus2 data', $sentContent['compensation']['real']);
+
+    // The request carries the expected headers.
+    $this->assertSame('SUBMITTED', $request->getHeaderLine('X-Case-Status'));
+    $this->assertSame('USER', $request->getHeaderLine('X-hki-UpdateSource'));
+    $this->assertSame('TEST', $request->getHeaderLine('X-hki-appEnv'));
+    $this->assertSame('TEST-058-0000001', $request->getHeaderLine('X-hki-applicationNumber'));
+    $this->assertSame('save-id-123', $request->getHeaderLine('X-hki-saveId'));
+    $this->assertSame('Basic ' . base64_encode('user:pass'), $request->getHeaderLine('Authorization'));
+  }
+
+  /**
+   * A non-200 response or transport error is wrapped in an Avus2Exception.
+   */
+  #[TestWith(['response', 'integration rejected the application'])]
+  #[TestWith(['transport', 'connection refused'])]
+  public function testSendToAvus2Failures(string $kind, string $detail): void {
+    $failure = $kind === 'transport'
+      ? new ConnectException($detail, new Request('POST', 'https://example.com/avus2'))
+      : new Response(201, [], $detail);
+
+    $history = [];
+    $integration = $this->getIntegration([$failure], $history);
+
+    $this->expectException(Avus2Exception::class);
+    $integration->sendToAvus2($this->getSubmittedDocument(), 'TEST-058-0000001', 'save-id-123', FALSE);
+  }
+
+  /**
+   * Build the integration with a history-recording mock HTTP client.
+   *
+   * @param \Psr\Http\Message\ResponseInterface[]|\GuzzleHttp\Exception\GuzzleException[] $responses
+   *   The queued responses.
+   * @param array<mixed> $history
+   *   The captured request/response history.
+   */
+  private function getIntegration(array $responses, array &$history): Avus2Integration {
+    $client = $this->createMockHistoryMiddlewareHttpClient($history, $responses);
+
+    return new Avus2Integration(
+      $this->container->get('grants_metadata.atv_schema'),
+      $client,
+    );
+  }
+
+  /**
+   * Build a submitted document with react form data mixed into the content.
+   */
+  private function getSubmittedDocument(): AtvDocument {
+    $document = AtvDocument::create([
+      'id' => 'test-id',
+      'type' => 'type',
+      'status' => ['value' => 'SUBMITTED'],
+      'transaction_id' => '1234567890',
+      'business_id' => '1234567-1',
+      'tos_function_id' => '12345',
+      'tos_record_id' => '54321',
+      'metadata' => '{"name": "Name", "value": "Value"}',
+      'created_at' => '2024-06-06',
+      'updated_at' => '2024-06-07',
+      'user_id' => 'userId',
+      'document_language' => 'fi',
+    ]);
+    $document->setContent([
+      'form_data' => ['react' => 'only data'],
+      'compensation' => [
+        'real' => 'avus2 data',
+        'form_data' => ['react' => 'nested data'],
+      ],
+    ]);
+
+    return $document;
+  }
+
+}

--- a/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/ApplicationTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/ApplicationTest.php
@@ -375,6 +375,61 @@ final class ApplicationTest extends KernelTestBase {
   }
 
   /**
+   * Test that a failing bank account confirmation file upload returns an error.
+   */
+  public function testApplicationPostBankFileFailure(): void {
+    $this->applicationSubmission = ApplicationSubmission::create([
+      'id' => 1,
+      'uuid' => 'aaaaaaaa-1111-2222-3333-bbbcccdddeee',
+      'document_id' => 'bbbbbbbb-4444-5555-6666-fffggghhhiii',
+      'sub' => '123345678-abcd-1234-ab12-abcdefgh',
+      'business_id' => 'qwertyui-1234-1234-1234-qweasdzxcrty',
+      'draft' => TRUE,
+      'langcode' => 'fi',
+      'application_type_id' => 58,
+      'form_identifier' => 'liikunta_suunnistuskartta_avustu',
+      'side_document_id' => 'sidedocu-1111-2222-3333-mentidabcdef',
+      'application_number' => $this->applicationNumber,
+      'created' => '1765430954',
+      'changed' => '1765430954',
+    ]);
+    $this->applicationSubmission->save();
+
+    // The bank file is not yet attached to the document, so the resource
+    // attempts to fetch and upload it.
+    $jsonMapperService = $this->createMock(JsonMapperService::class);
+    $jsonMapperService->expects($this->any())->method('getSelectedBankFile')->willReturn([
+      'href' => 'foobar',
+      'filename' => 'bank-confirmation.pdf',
+    ]);
+    $jsonMapperService->expects($this->any())->method('documentBankFileIsSet')->willReturn(FALSE);
+    $this->container->set(JsonMapperService::class, $jsonMapperService);
+
+    // Fetching the bank confirmation attachment fails.
+    $helfiAtvService = $this->createMock(HelfiAtvService::class);
+    $helfiAtvService->expects($this->any())->method('getDocument')->with($this->applicationNumber)->willReturn($this->atvDocument);
+    $helfiAtvService->expects($this->any())->method('getDocumentById')->with($this->sideDocumentId)->willReturn($this->sideDocument);
+    $helfiAtvService->expects($this->any())->method('getAttachment')->willThrowException(new \Exception('Failed to fetch attachment'));
+    $this->container->set(HelfiAtvService::class, $helfiAtvService);
+
+    $form_identifier = 'liikunta_suunnistuskartta_avustu';
+    $content = json_encode([
+      'form_data' => json_decode(file_get_contents(__DIR__ . '/../../../../../fixtures/reactForm/form58-nofiles-formdata.json') ?: '', TRUE) ?? '',
+    ]);
+    $content = $content ?: NULL;
+
+    $uri = "/applications/$form_identifier/application/$this->applicationNumber";
+    $request = Request::create($uri, "POST", [], [], [], [], $content);
+    $request->headers->set('Content-Type', 'application/json');
+    $request->headers->set('Accept', 'application/json');
+
+    $http_kernel = $this->container->get('http_kernel');
+    $response = $http_kernel->handle($request);
+
+    $this->assertEquals(500, $response->getStatusCode());
+  }
+
+  /**
    * Override the user information service with a custom applicant type/profile.
    */
   private function overrideUserService(string $applicantType, GrantsProfile $profile): void {

--- a/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/ApplicationTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/ApplicationTest.php
@@ -19,6 +19,8 @@ use Drupal\rest\RequestHandler;
 use Drupal\Tests\grants_application\Kernel\KernelTestBase;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,50 +28,38 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @coversDefaultClass \Drupal\grants_application\Plugin\rest\resource\Application
- *
- * @group grants_application
  */
+#[Group('grants_application')]
+#[RunTestsInSeparateProcesses]
 final class ApplicationTest extends KernelTestBase {
 
   /**
    * The application submission.
-   *
-   * @var \Drupal\grants_application\Entity\ApplicationSubmission
    */
   private ApplicationSubmission $applicationSubmission;
 
   /**
    * The application number.
-   *
-   * @var string
    */
   private string $applicationNumber = "KERNELTEST-058-0000001";
 
   /**
    * The side document id.
-   *
-   * @var string
    */
   private string $sideDocumentId = 'sidedocu-1111-2222-3333-mentidabcdef';
 
   /**
    * The atv document.
-   *
-   * @var \Drupal\helfi_atv\AtvDocument
    */
   private AtvDocument $atvDocument;
 
   /**
    * The side document.
-   *
-   * @var \Drupal\helfi_atv\AtvDocument
    */
   private AtvDocument $sideDocument;
 
   /**
    * The request handler.
-   *
-   * @var \Drupal\rest\RequestHandler
    */
   protected RequestHandler $requestHandler;
 
@@ -285,7 +275,7 @@ final class ApplicationTest extends KernelTestBase {
     $this->container->set(JsonMapperService::class, $jsonMapperService);
 
     $integration = $this->createMock(Avus2Integration::class);
-    $integration->expects($this->any())->method('sendToAvus2')->willReturn(TRUE);
+    $integration->expects($this->any())->method('sendToAvus2');
     $this->container->set(Avus2Integration::class, $integration);
 
     $eventDispatcher = $this->createMock(EventDispatcherInterface::class);

--- a/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/ApplicationTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/ApplicationTest.php
@@ -17,6 +17,7 @@ use Drupal\helfi_helsinki_profiili\DTO\HelsinkiProfiiliUser;
 use Drupal\rest\Plugin\ResourceBase;
 use Drupal\rest\RequestHandler;
 use Drupal\Tests\grants_application\Kernel\KernelTestBase;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use PHPUnit\Framework\Attributes\Group;
@@ -32,6 +33,8 @@ use Symfony\Component\HttpFoundation\Response;
 #[Group('grants_application')]
 #[RunTestsInSeparateProcesses]
 final class ApplicationTest extends KernelTestBase {
+
+  use ApiTestTrait;
 
   /**
    * The application submission.
@@ -413,18 +416,11 @@ final class ApplicationTest extends KernelTestBase {
     $this->container->set(HelfiAtvService::class, $helfiAtvService);
 
     $form_identifier = 'liikunta_suunnistuskartta_avustu';
-    $content = json_encode([
+    $request = $this->getMockedRequest("/applications/$form_identifier/application/$this->applicationNumber", 'POST', document: [
       'form_data' => json_decode(file_get_contents(__DIR__ . '/../../../../../fixtures/reactForm/form58-nofiles-formdata.json') ?: '', TRUE) ?? '',
     ]);
-    $content = $content ?: NULL;
 
-    $uri = "/applications/$form_identifier/application/$this->applicationNumber";
-    $request = Request::create($uri, "POST", [], [], [], [], $content);
-    $request->headers->set('Content-Type', 'application/json');
-    $request->headers->set('Accept', 'application/json');
-
-    $http_kernel = $this->container->get('http_kernel');
-    $response = $http_kernel->handle($request);
+    $response = $this->processRequest($request);
 
     $this->assertEquals(500, $response->getStatusCode());
   }

--- a/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/DraftTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/DraftTest.php
@@ -18,6 +18,8 @@ use Drupal\rest\RequestHandler;
 use Drupal\Tests\grants_application\Kernel\KernelTestBase;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,50 +27,33 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @coversDefaultClass \Drupal\grants_application\Plugin\rest\resource\Application
- *
- * @group grants_application
  */
+#[Group('grants_application')]
+#[RunTestsInSeparateProcesses]
 final class DraftTest extends KernelTestBase {
 
   /**
-   * The application submission.
-   *
-   * @var \Drupal\grants_application\Entity\ApplicationSubmission
-   */
-  private ApplicationSubmission $applicationSubmission;
-
-  /**
    * The application number.
-   *
-   * @var string
    */
   private string $applicationNumber = "KERNELTEST-058-0000001";
 
   /**
    * The side document id.
-   *
-   * @var string
    */
   private string $sideDocumentId = 'sidedocu-1111-2222-3333-mentidabcdef';
 
   /**
    * The atv document.
-   *
-   * @var \Drupal\helfi_atv\AtvDocument
    */
   private AtvDocument $atvDocument;
 
   /**
    * The side document.
-   *
-   * @var \Drupal\helfi_atv\AtvDocument
    */
   private AtvDocument $sideDocument;
 
   /**
    * The request handler.
-   *
-   * @var \Drupal\rest\RequestHandler
    */
   protected RequestHandler $requestHandler;
 
@@ -284,7 +269,7 @@ final class DraftTest extends KernelTestBase {
     $this->container->set(JsonMapperService::class, $jsonMapperService);
 
     $integration = $this->createMock(Avus2Integration::class);
-    $integration->expects($this->any())->method('sendToAvus2')->willReturn(TRUE);
+    $integration->expects($this->any())->method('sendToAvus2');
     $this->container->set(Avus2Integration::class, $integration);
 
     $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
@@ -301,7 +286,7 @@ final class DraftTest extends KernelTestBase {
    */
   public function testDraftSideDocumentLogic(): void {
     // When we get an atv-document, make sure the side document exists as well.
-    $this->applicationSubmission = ApplicationSubmission::create([
+    $applicationSubmission = ApplicationSubmission::create([
       'id' => 1,
       'uuid' => 'aaaaaaaa-1111-2222-3333-bbbcccdddeee',
       'document_id' => 'bbbbbbbb-4444-5555-6666-fffggghhhiii',
@@ -315,7 +300,7 @@ final class DraftTest extends KernelTestBase {
       'created' => '1765430954',
       'changed' => '1765430954',
     ]);
-    $this->applicationSubmission->save();
+    $applicationSubmission->save();
 
     $helfiAtvService = $this->createMock(HelfiAtvService::class);
     $helfiAtvService->expects($this->any())->method('getDocument')->with($this->applicationNumber)->willReturn($this->atvDocument);

--- a/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/DraftTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Plugin/rest/resource/DraftTest.php
@@ -431,4 +431,79 @@ final class DraftTest extends KernelTestBase {
     $this->assertTrue($response instanceof JsonResponse && $response->isSuccessful());
   }
 
+  /**
+   * Create a draft submission to patch against.
+   */
+  private function createDraftSubmission(): void {
+    ApplicationSubmission::create([
+      'id' => 1,
+      'uuid' => 'aaaaaaaa-1111-2222-3333-bbbcccdddeee',
+      'document_id' => 'bbbbbbbb-4444-5555-6666-fffggghhhiii',
+      'sub' => '123345678-abcd-1234-ab12-abcdefgh',
+      'business_id' => 'qwertyui-1234-1234-1234-qweasdzxcrty',
+      'draft' => TRUE,
+      'langcode' => 'fi',
+      'application_type_id' => 58,
+      'form_identifier' => 'liikunta_suunnistuskartta_avustu',
+      'side_document_id' => $this->sideDocumentId,
+      'application_number' => $this->applicationNumber,
+      'created' => '1765430954',
+      'changed' => '1765430954',
+    ])->save();
+  }
+
+  /**
+   * Build and dispatch a PATCH request to the draft endpoint.
+   */
+  private function dispatchPatch(): Response {
+    $form_identifier = 'liikunta_suunnistuskartta_avustu';
+    $content = json_encode([
+      'form_data' => json_decode(file_get_contents(__DIR__ . '/../../../../../fixtures/reactForm/form58-nofiles-formdata.json') ?: '', TRUE) ?? '',
+    ]) ?: NULL;
+
+    $uri = "/applications/$form_identifier/$this->applicationNumber";
+    $request = Request::create($uri, "PATCH", [], [], [], [], $content);
+    $request->headers->set('Content-Type', 'application/json');
+    $request->headers->set('Accept', 'application/json');
+
+    return $this->container->get('http_kernel')->handle($request);
+  }
+
+  /**
+   * A successful PATCH saves the draft and returns the side document.
+   */
+  public function testDraftPatch(): void {
+    $this->createDraftSubmission();
+
+    // Capture the content of the documents that get saved during the request.
+    $savedContent = [];
+
+    $helfiAtvService = $this->createMock(HelfiAtvService::class);
+    $helfiAtvService->expects($this->any())->method('getDocument')->with($this->applicationNumber)->willReturn($this->atvDocument);
+    $helfiAtvService->expects($this->any())->method('getDocumentById')->with($this->sideDocumentId)->willReturn($this->sideDocument);
+    $helfiAtvService->expects($this->exactly(2))
+      ->method('updateExistingDocument')
+      ->willReturnCallback(function (AtvDocument $document) use (&$savedContent) {
+        $savedContent[$document->getId()] = $document->getContent();
+        return $document;
+      });
+    $this->container->set(HelfiAtvService::class, $helfiAtvService);
+
+    $response = $this->dispatchPatch();
+
+    $this->assertTrue($response instanceof JsonResponse && $response->isSuccessful());
+    $this->assertEquals(200, $response->getStatusCode());
+
+    // Both the side document and the application document were saved.
+    $this->assertEqualsCanonicalizing([$this->sideDocumentId, 'test-id'], array_keys($savedContent));
+
+    // The side document was saved with the form data from the request.
+    $formData = json_decode(file_get_contents(__DIR__ . '/../../../../../fixtures/reactForm/form58-nofiles-formdata.json') ?: '', TRUE);
+    $this->assertSame($formData, $savedContent[$this->sideDocumentId]);
+
+    // The response returns the saved side document, carrying the same content.
+    $responseData = json_decode($response->getContent() ?: '', TRUE);
+    $this->assertSame($formData, $responseData['content']);
+  }
+
 }

--- a/public/modules/custom/grants_attachments/src/AttachmentHandler.php
+++ b/public/modules/custom/grants_attachments/src/AttachmentHandler.php
@@ -10,7 +10,6 @@ use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\Messenger\Messenger;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\TempStore\TempStoreException;
 use Drupal\grants_attachments\Plugin\WebformElement\GrantsAttachments;
 use Drupal\grants_events\EventsService;
 use Drupal\grants_handler\ApplicationHelpers;
@@ -272,6 +271,8 @@ class AttachmentHandler {
   /**
    * Parse attachments from submitted data and create schema structured data.
    *
+   * WARNING: This method is ment to be called only from GrantsHandler.
+   *
    * @param array $form
    *   Form in question.
    * @param array $submittedFormData
@@ -280,8 +281,8 @@ class AttachmentHandler {
    * @param string $applicationNumber
    *   Generated application number.
    *
-   * @throws \Drupal\Core\Entity\EntityStorageException
-   * @throws \Drupal\grants_handler\EventException
+   * @throws \throwable
+   *   On failure.
    */
   public function parseAttachments(
     array $form,
@@ -325,18 +326,13 @@ class AttachmentHandler {
     }
 
     if (isset($submittedFormData["account_number"])) {
-      try {
-        $this->handleBankAccountConfirmation(
-          $submittedFormData["account_number"],
-          $applicationNumber,
-          $submittedFormData
-        );
-      }
-      catch (TempStoreException | GuzzleException $e) {
-        $this->logger->error('Error: %msg', [
-          '%msg' => $e->getMessage(),
-        ]);
-      }
+      // Let any exceptions fall through. They are caught
+      // by GrantsHandler::postSaveSubmit().
+      $this->handleBankAccountConfirmation(
+        $submittedFormData["account_number"],
+        $applicationNumber,
+        $submittedFormData
+      );
     }
   }
 
@@ -411,6 +407,9 @@ class AttachmentHandler {
    * @param bool $copyingProcess
    *   A boolean indicating if the method has been
    *   called when copying an application.
+   *
+   * @throws \throwable
+   *   If anything goes wrong.
    */
   public function handleBankAccountConfirmation(
     string $accountNumber,
@@ -428,28 +427,32 @@ class AttachmentHandler {
       $profileContent = $grantsProfileDocument->getContent();
     }
     catch (GrantsProfileException $e) {
-      $this->logger->error('Error: %msg', ['%msg' => $e->getMessage()]);
       $this->messenger->addError($this->t('Failed to load user.', [], ['context' => 'grants_attachments']));
-      return;
+      throw new \RuntimeException("Failed to load user", previous: $e);
     }
 
     // Get the selected account.
-    $selectedAccount = $this->getSelectedAccount($profileContent, $accountNumber);
+    $selectedAccount = NULL;
+    foreach ($profileContent['bankAccounts'] as $account) {
+      if ($account['bankAccount'] == $accountNumber) {
+        $selectedAccount = $account;
+        break;
+      }
+    }
     if (!$selectedAccount || !isset($selectedAccount['confirmationFile'])) {
-      return;
+      throw new \RuntimeException("Selected account not found");
     }
 
     // Get the selected accounts bank account attachment.
     $accountConfirmation = $grantsProfileDocument->getAttachmentForFilename($selectedAccount['confirmationFile']);
     if (!$accountConfirmation) {
-      return;
+      throw new \RuntimeException("Bank account confirmation not found");
     }
 
     // Load the ATV document.
     $applicationDocument = $this->getAtvDocument($applicationNumber);
-
     if (!$applicationDocument) {
-      return;
+      throw new \RuntimeException("Failed to load ATV document");
     }
 
     // Check if a user changed the bank account in the application.
@@ -742,30 +745,6 @@ class AttachmentHandler {
     $integrationId = rtrim(end($parts), '/');
     if (filter_var($integrationId, FILTER_VALIDATE_INT)) {
       return $integrationId;
-    }
-    return FALSE;
-  }
-
-  /**
-   * The getSelectedAccount method.
-   *
-   * This method loops through all the accounts on a
-   * profile and returns the one whose bank account number
-   * matches $accountNumber.
-   *
-   * @param array $profileContent
-   *   An array of profile data.
-   * @param string $accountNumber
-   *   An account number.
-   *
-   * @return array|bool
-   *   The found account or FALSE.
-   */
-  protected function getSelectedAccount(array $profileContent, string $accountNumber): array|bool {
-    foreach ($profileContent['bankAccounts'] as $account) {
-      if ($account['bankAccount'] == $accountNumber) {
-        return $account;
-      }
     }
     return FALSE;
   }

--- a/public/modules/custom/grants_handler/src/ApplicationInitService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationInitService.php
@@ -6,21 +6,19 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Utility\Error;
 use Drupal\grants_attachments\AttachmentHandler;
 use Drupal\grants_metadata\ApplicationDataService;
 use Drupal\grants_metadata\AtvSchema;
 use Drupal\grants_metadata\DocumentContentMapper;
 use Drupal\grants_profile\GrantsProfileService;
 use Drupal\helfi_atv\AtvDocument;
-use Drupal\helfi_atv\AtvDocumentNotFoundException;
-use Drupal\helfi_atv\AtvFailedToConnectException;
 use Drupal\helfi_atv\AtvService;
 use Drupal\helfi_helsinki_profiili\DTO\HelsinkiProfiiliUser;
 use Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData;
 use Drupal\helfi_helsinki_profiili\ProfiiliException;
 use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
-use GuzzleHttp\Exception\GuzzleException;
 
 /**
  * Init applications service.
@@ -303,8 +301,8 @@ class ApplicationInitService {
       $newDocument->setContent($appDocumentContent);
       $newDocument = $this->atvService->patchDocument($newDocumentId, $newDocument->toArray());
     }
-    catch (AtvDocumentNotFoundException | AtvFailedToConnectException | EventException | GuzzleException $e) {
-      $this->logger->error('Error: %msg', ['%msg' => $e->getMessage()]);
+    catch (\throwable $e) {
+      Error::logException($this->logger, $e);
     }
     return $newDocument;
   }

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1544,7 +1544,7 @@ submit the application only after you have provided all the necessary informatio
     // A required file operation failed during postSaveSubmit().
     if ($this->attachmentUploadFailed) {
       $this->messenger()->addError(
-        $this->t('application could not be submitted because a required file could not be saved. Please try again or contact support.')
+        $this->t('An error occurred while sending the application. Please try again in a moment')
       );
       return;
     }

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -12,6 +12,7 @@ use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\TempStore\TempStoreException;
 use Drupal\Core\TypedData\Exception\ReadOnlyException;
 use Drupal\Core\Url;
+use Drupal\Core\Utility\Error;
 use Drupal\grants_attachments\AttachmentHandler;
 use Drupal\grants_attachments\AttachmentRemover;
 use Drupal\grants_handler\ApplicationException;
@@ -78,8 +79,6 @@ final class GrantsHandler extends WebformHandlerBase {
 
   /**
    * Application type.
-   *
-   * @var string
    */
   protected string $applicationType = '';
 
@@ -87,29 +86,21 @@ final class GrantsHandler extends WebformHandlerBase {
    * Applicant type.
    *
    * Private / registered / UNregistered.
-   *
-   * @var string
    */
   protected string $applicantType = '';
 
   /**
    * Application type ID.
-   *
-   * @var string
    */
   protected string $applicationTypeID = '';
 
   /**
    * Generated application number.
-   *
-   * @var string
    */
   protected string $applicationNumber = '';
 
   /**
    * Application acting year options.
-   *
-   * @var array
    */
   protected array $applicationActingYears = [];
 
@@ -117,8 +108,6 @@ final class GrantsHandler extends WebformHandlerBase {
    * Status for updated submission.
    *
    * Old one if no update.
-   *
-   * @var string
    */
   protected string $newStatus;
 
@@ -129,134 +118,104 @@ final class GrantsHandler extends WebformHandlerBase {
 
   /**
    * Save form for methods where form is not available.
-   *
-   * @var array
    */
   protected array $formTemp;
 
   /**
    * Save form sate for methods where it's not available.
-   *
-   * @var \Drupal\Core\Form\FormStateInterface
    */
   protected FormStateInterface $formStateTemp;
 
   /**
    * Are we redirecting?
-   *
-   * @var bool
    */
   protected bool $isRedirect = FALSE;
 
   /**
-   * The account proxy interface.
+   * Whether a required attachment file operation failed during submit.
    *
-   * @var \Drupal\Core\Session\AccountProxyInterface
+   * Set in postSaveSubmit() and read in confirmForm() to halt the submission
+   * so an application with a missing file is not uploaded to the integration.
+   */
+  protected bool $attachmentUploadFailed = FALSE;
+
+  /**
+   * The account proxy interface.
    */
   protected AccountProxyInterface $currentUser;
 
   /**
    * The helsinki profiili user data service.
-   *
-   * @var \Drupal\helfi_helsinki_profiili\HelsinkiProfiiliUserData
    */
   protected HelsinkiProfiiliUserData $userExternalData;
 
   /**
    * The grants profile service.
-   *
-   * @var \Drupal\grants_profile\GrantsProfileService
    */
   protected GrantsProfileService $grantsProfileService;
 
   /**
    * The date formatter service.
-   *
-   * @var \Drupal\Core\Datetime\DateFormatter
    */
   protected DateFormatter $dateFormatter;
 
   /**
    * The attachment handler service.
-   *
-   * @var \Drupal\grants_attachments\AttachmentHandler
    */
   protected AttachmentHandler $attachmentHandler;
 
   /**
    * The grants handler navigation helper.
-   *
-   * @var \Drupal\grants_handler\GrantsHandlerNavigationHelper
    */
   protected GrantsHandlerNavigationHelper $grantsFormNavigationHelper;
 
   /**
    * The application validator.
-   *
-   * @var \Drupal\grants_handler\ApplicationValidator
    */
   protected ApplicationValidator $applicationValidator;
 
   /**
    * The application status service.
-   *
-   * @var \Drupal\grants_handler\ApplicationStatusService
    */
   protected ApplicationStatusService $applicationStatusService;
 
   /**
    * The form lock service.
-   *
-   * @var \Drupal\grants_handler\FormLockService
    */
   protected FormLockService $formLockService;
 
   /**
    * The drupal kernel.
-   *
-   * @var \Drupal\Core\DrupalKernel
    */
   protected DrupalKernel $kernel;
 
   /**
    * The request stack.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
   protected RequestStack $requestStack;
 
   /**
    * The application data service.
-   *
-   * @var \Drupal\grants_metadata\ApplicationDataService
    */
   protected ApplicationDataService $applicationDataService;
 
   /**
    * The application initialization service.
-   *
-   * @var \Drupal\grants_handler\ApplicationInitService
    */
   protected ApplicationInitService $applicationInitService;
 
   /**
    * The application uplaod service.
-   *
-   * @var \Drupal\grants_handler\ApplicationUploaderService
    */
   protected ApplicationUploaderService $applicationUploaderService;
 
   /**
    * The application getter service.
-   *
-   * @var \Drupal\grants_handler\ApplicationGetterService
    */
   protected ApplicationGetterService $applicationGetterService;
 
   /**
    * The attachment remover.
-   *
-   * @var \Drupal\grants_attachments\AttachmentRemover
    */
   protected AttachmentRemover $attachmentRemover;
 
@@ -1380,7 +1339,13 @@ submit the application only after you have provided all the necessary informatio
       );
     }
     catch (\Exception $e) {
-      $this->getLogger('grants_handler')->error($e->getMessage());
+      // File uploads failed. Halt the submission so the application is not
+      // marked SUBMITTED or uploaded to the integration in an inconsistent
+      // state. confirmForm() checks this flag, aborts the upload and shows
+      // the user-facing error.
+      $this->attachmentUploadFailed = TRUE;
+      Error::logException($this->getLogger('grants_handler'), $e);
+      return;
     }
 
     // Try to update status only if it's allowed.
@@ -1556,8 +1521,6 @@ submit the application only after you have provided all the necessary informatio
       $this->messenger->addError($this->t('Error saving application. please contact support.'));
       $this->getLogger('grants_handler')
         ->error('Error saving application: @error', ['@error' => $e->getMessage()]);
-
-      \Sentry\captureException($e);
     }
   }
 
@@ -1578,6 +1541,14 @@ submit the application only after you have provided all the necessary informatio
     FormStateInterface $form_state,
     WebformSubmissionInterface $webform_submission,
   ): void {
+    // A required file operation failed during postSaveSubmit().
+    if ($this->attachmentUploadFailed) {
+      $this->messenger()->addError(
+        $this->t('application could not be submitted because a required file could not be saved. Please try again or contact support.')
+      );
+      return;
+    }
+
     try {
       // Get new status from method that figures that out.
       $this->submittedFormData['status'] = $this->applicationStatusService->getNewStatus(

--- a/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
+++ b/public/modules/custom/grants_handler/src/Plugin/WebformHandler/GrantsHandler.php
@@ -1338,7 +1338,7 @@ submit the application only after you have provided all the necessary informatio
         $this->applicationNumber
       );
     }
-    catch (\Exception $e) {
+    catch (\throwable $e) {
       // File uploads failed. Halt the submission so the application is not
       // marked SUBMITTED or uploaded to the integration in an inconsistent
       // state. confirmForm() checks this flag, aborts the upload and shows


### PR DESCRIPTION
# [UHF-13131](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13131)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
Attempt to add more error handling around: https://sentry.hel.fi/organizations/city-of-helsinki/issues/112752. Added bunch of breadcrumbs to sentry to make future error tracking easier.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13131`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Submit form to avust2 using webform. Should work like before.
* [ ] Run:
```sh
mkdir -p public/sites/default/files/private/grants_profile
chmod a=rx public/sites/default/files/private/grants_profile
```
* [ ] Submit form to avust2 using webform. Should fail with error message
* [ ] Submit form to avust2 using new implementation. Should fail with error message.
* [ ] Check that the code follows our standards

<!--
Check list for the developer

Privacy
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.

E2E tests
- Make sure the tests pass when you run `make test-pw` on your local.
- Detailed instructions can be found here: https://github.com/City-of-Helsinki/hel-fi-drupal-grants/blob/dev/e2e/README.md#environment-setup

Application that are no longer used
- Archive the webform applications after they are no longer used. This stops users from sending old drafts of the archived application.
- Archived webforms must also be removed from the E2E tests since they can't be tested after archiving.
-->

## Links to related PRs
<!-- F.e. a related PR in another repository -->
*


[UHF-13131]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ