### PR TITLE
UHF-13365: Always change comma to dot when value is mapped as double

### DIFF
--- a/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
+++ b/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
@@ -78,6 +78,11 @@ class JsonHandler {
     foreach ($data as $key => $item) {
       $mappedItem = self::setLabelAndValue($item, $definition);
       $mappedItem['ID'] .= "_$key";
+
+      if ($mappedItem['value'] === "") {
+        $mappedItem['value'] = "0";
+      }
+
       if ($definition['data']['valueType'] === 'double') {
         if (is_int($mappedItem['value'])) {
           $mappedItem['value'] = (string) $mappedItem['value'];

--- a/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
+++ b/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
@@ -78,7 +78,9 @@ class JsonHandler {
     foreach ($data as $key => $item) {
       $mappedItem = self::setLabelAndValue($item, $definition);
       $mappedItem['ID'] .= "_$key";
-      $mappedItem['value'] = str_replace(',', '.', rtrim($mappedItem['value'], ','));
+      if ($definition['data']['valueType'] === 'double') {
+        $mappedItem['value'] = str_replace(',', '.', rtrim($mappedItem['value'], ','));
+      }
       $result[] = $mappedItem;
     }
 

--- a/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
+++ b/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
@@ -78,6 +78,7 @@ class JsonHandler {
     foreach ($data as $key => $item) {
       $mappedItem = self::setLabelAndValue($item, $definition);
       $mappedItem['ID'] .= "_$key";
+      $mappedItem['value'] = str_replace(',', '.', rtrim($mappedItem['value'], ','));
       $result[] = $mappedItem;
     }
 

--- a/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
+++ b/public/modules/custom/grants_application/src/Mapper/JsonHandler.php
@@ -79,6 +79,9 @@ class JsonHandler {
       $mappedItem = self::setLabelAndValue($item, $definition);
       $mappedItem['ID'] .= "_$key";
       if ($definition['data']['valueType'] === 'double') {
+        if (is_int($mappedItem['value'])) {
+          $mappedItem['value'] = (string) $mappedItem['value'];
+        }
         $mappedItem['value'] = str_replace(',', '.', rtrim($mappedItem['value'], ','));
       }
       $result[] = $mappedItem;

--- a/public/modules/custom/grants_application/src/Mapper/JsonMapper.php
+++ b/public/modules/custom/grants_application/src/Mapper/JsonMapper.php
@@ -153,7 +153,7 @@ class JsonMapper {
       // if end user sent empty value.
       $value = $definition['data']['value'];
     }
-    else if ($value && $definition['data']['valueType'] === 'double') {
+    else if ($value && is_string($value) && $definition['data']['valueType'] === 'double') {
       // Fields mapped as double should not have commas, replace with dot.
       $value = str_replace(',', '.', rtrim($value, ','));
     }

--- a/public/modules/custom/grants_application/src/Mapper/JsonMapper.php
+++ b/public/modules/custom/grants_application/src/Mapper/JsonMapper.php
@@ -154,6 +154,7 @@ class JsonMapper {
       $value = $definition['data']['value'];
     }
     else if ($value && $definition['data']['valueType'] === 'double') {
+      // Fields mapped as double should not have commas, replace with dot.
       $value = str_replace(',', '.', rtrim($value, ','));
     }
 

--- a/public/modules/custom/grants_application/src/Mapper/JsonMapper.php
+++ b/public/modules/custom/grants_application/src/Mapper/JsonMapper.php
@@ -141,15 +141,20 @@ class JsonMapper {
     $value = $this->getValue($dataSources[$definition['datasource']], $sourcePath);
 
     if (isset($definition['data']['valueType']) && $definition['data']['valueType'] === 'bool') {
+      // Bool values always true/false instead of 0/1.
       $value = $value ? 'true' : 'false';
     }
     else if (isset($definition['data']['valueType']) && $definition['data']['valueType'] === 'string' && $value === "") {
+      // Empty strings can usually be excluded from the submission.
       return;
     }
-    else if (!$value && $definition['data']['value'] !== ""){
-      // The mapping contains a default value and datasource does not
-      // have a value, we use the mapped default value.
+    else if (!$value && $definition['data']['value'] !== "") {
+      // Allow adding a default value to the mapping-file which is used
+      // if end user sent empty value.
       $value = $definition['data']['value'];
+    }
+    else if ($value && $definition['data']['valueType'] === 'double') {
+      $value = str_replace(',', '.', rtrim($value, ','));
     }
 
     $this->setTargetValue($data, $targetPath, $value, $definition);

--- a/public/modules/custom/grants_application/tests/fixtures/reactForm/form70-safer-nofiles-result.json
+++ b/public/modules/custom/grants_application/tests/fixtures/reactForm/form70-safer-nofiles-result.json
@@ -430,7 +430,7 @@
             {
               "ID": "tulot_field_0_0",
               "label": "tulon tyyppi",
-              "value": 1111,
+              "value": "1111",
               "valueType": "double"
             }
           ]
@@ -443,7 +443,7 @@
             {
               "ID": "menot_field_0_0",
               "label": "Menon tyyppi",
-              "value": 2222,
+              "value": "2222",
               "valueType": "double"
             }
           ]

--- a/public/modules/custom/grants_application/tests/fixtures/reactForm/form70-segregaatio-nofiles-result.json
+++ b/public/modules/custom/grants_application/tests/fixtures/reactForm/form70-segregaatio-nofiles-result.json
@@ -442,7 +442,7 @@
                         {
                             "ID": "talous_tulon_tyyppi_0",
                             "label": "Osallistumismaksut",
-                            "value": 1500,
+                            "value": "1500",
                             "valueType": "double"
                         }
                     ],
@@ -456,7 +456,7 @@
                         {
                             "ID": "talous_menon_tyyppi_0",
                             "label": "Henkilöstökulut",
-                            "value": 6000,
+                            "value": "6000",
                             "valueType": "double"
                         }
                     ],

--- a/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
+++ b/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
@@ -304,7 +304,9 @@ final class JsonMapperTest extends UnitTestCase {
           'float_with_comma' => '12,0',
           'income_section' => [
             'income' => [
-              ['label' => 'the label', 'amount' => '123,45']
+              ['label' => 'the label', 'amount' => '123,45'],
+              ['label' => 'the label 2', 'amount' => 123],
+              ['label' => 'the label 3', 'amount' => ""]
             ]
           ]
         ],
@@ -319,6 +321,9 @@ final class JsonMapperTest extends UnitTestCase {
     $this->assertEquals('12,0', $mappedData['compensation']['my_numbers']['float_with_comma']['value']);
     $this->assertEquals('123.45', $mappedData['compensation']['my_numbers']['income_with_dot'][0]['value']);
     $this->assertEquals('the label', $mappedData['compensation']['my_numbers']['income_with_dot'][0]['label']);
+    $this->assertEquals('123', $mappedData['compensation']['my_numbers']['income_with_dot'][1]['value']);
+    $this->assertEquals('0', $mappedData['compensation']['my_numbers']['income_with_dot'][2]['value']);
+
     // Float is still comma, only double is changed to dot.
     $this->assertEquals('123,45', $mappedData['compensation']['my_numbers']['income_with_comma'][0]['value']);
   }

--- a/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
+++ b/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
@@ -271,6 +271,18 @@ final class JsonMapperTest extends UnitTestCase {
           'label' => 'Float should not be affected',
         ],
       ],
+      "compensation.my_numbers.income_with_dot" => [
+        'datasource' => 'form_data',
+        'source' => 'number_data.income_section.income',
+        'mapping_type' => 'custom',
+        'custom_handler' => 'income',
+        'data' => [
+          'ID' => 'incomeLabel',
+          'valueType' => 'float',
+          'value' => '',
+          'label' => 'This is overwritten',
+        ],
+      ],
     ];
 
     $formData = [
@@ -278,6 +290,11 @@ final class JsonMapperTest extends UnitTestCase {
         'number_data' => [
           'double_with_comma' => '133,7',
           'float_with_comma' => '12,0',
+          'income_section' => [
+            'income' => [
+              ['label' => 'the label', 'amount' => '123,45']
+            ]
+          ]
         ],
       ],
     ];
@@ -288,6 +305,8 @@ final class JsonMapperTest extends UnitTestCase {
 
     $this->assertEquals('133.7', $mappedData['compensation']['my_numbers']['double_with_dot']['value']);
     $this->assertEquals('12,0', $mappedData['compensation']['my_numbers']['float_with_comma']['value']);
+    $this->assertEquals('123.45', $mappedData['compensation']['my_numbers']['income_with_dot'][0]['value']);
+    $this->assertEquals('the label', $mappedData['compensation']['my_numbers']['income_with_dot'][0]['label']);
   }
 
   /**

--- a/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
+++ b/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
@@ -245,6 +245,52 @@ final class JsonMapperTest extends UnitTestCase {
   }
 
   /**
+   * Double values should be mapped with dot.
+   */
+  public function testDoubleCommaToDotMapping(): void {
+    $mapping = [
+      "compensation.my_numbers.double_with_dot" => [
+        'datasource' => 'form_data',
+        'source' => 'number_data.double_with_comma',
+        'mapping_type' => 'default',
+        'data' => [
+          'ID' => 'justADoubleField',
+          'valueType' => 'double',
+          'value' => '',
+          'label' => 'Comma should be replaced by dot',
+        ],
+      ],
+      "compensation.my_numbers.float_with_comma" => [
+        'datasource' => 'form_data',
+        'source' => 'number_data.float_with_comma',
+        'mapping_type' => 'default',
+        'data' => [
+          'ID' => 'justAnotherNumericValue',
+          'valueType' => 'float',
+          'value' => '',
+          'label' => 'Comma should be replaced by dot',
+        ],
+      ],
+    ];
+
+    $formData = [
+      'form_data' => [
+        'number_data' => [
+          'double_with_comma' => '133,7',
+          'float_with_comma' => '12,0',
+        ],
+      ],
+    ];
+
+    $mapper = new JsonMapper();
+    $mapper->setMappings($mapping);
+    $mappedData = $mapper->map($formData);
+
+    $this->assertEquals('133.7', $mappedData['compensation']['my_numbers']['double_with_dot']['value']);
+    $this->assertEquals('12,0', $mappedData['compensation']['my_numbers']['float_with_comma']['value']);
+  }
+
+  /**
    * Combine the common data sources and the actual form into one.
    *
    * The end result contains data from react-form, user profile,...

--- a/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
+++ b/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
@@ -268,7 +268,7 @@ final class JsonMapperTest extends UnitTestCase {
           'ID' => 'justAnotherNumericValue',
           'valueType' => 'float',
           'value' => '',
-          'label' => 'Comma should be replaced by dot',
+          'label' => 'Float should not be affected',
         ],
       ],
     ];

--- a/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
+++ b/public/modules/custom/grants_application/tests/src/Unit/JsonMapperTest.php
@@ -278,6 +278,18 @@ final class JsonMapperTest extends UnitTestCase {
         'custom_handler' => 'income',
         'data' => [
           'ID' => 'incomeLabel',
+          'valueType' => 'double',
+          'value' => '',
+          'label' => 'This is overwritten',
+        ],
+      ],
+      "compensation.my_numbers.income_with_comma" => [
+        'datasource' => 'form_data',
+        'source' => 'number_data.income_section.income',
+        'mapping_type' => 'custom',
+        'custom_handler' => 'income',
+        'data' => [
+          'ID' => 'incomeLabel',
           'valueType' => 'float',
           'value' => '',
           'label' => 'This is overwritten',
@@ -307,6 +319,8 @@ final class JsonMapperTest extends UnitTestCase {
     $this->assertEquals('12,0', $mappedData['compensation']['my_numbers']['float_with_comma']['value']);
     $this->assertEquals('123.45', $mappedData['compensation']['my_numbers']['income_with_dot'][0]['value']);
     $this->assertEquals('the label', $mappedData['compensation']['my_numbers']['income_with_dot'][0]['label']);
+    // Float is still comma, only double is changed to dot.
+    $this->assertEquals('123,45', $mappedData['compensation']['my_numbers']['income_with_comma'][0]['value']);
   }
 
   /**


### PR DESCRIPTION
# [UHF-13365](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13365)

## What was done
When mapping react data to avus2-format, change all dots to commas if a field is mapped as double.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13365`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Log in as enduser
- Fill & submit any form with fields mapped as double
- Check that Avus2-json
  - The double-values should have dot instead of comma 


[UHF-13365]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ