### PR TITLE
UHF-13340: allow user to edit the applications with broken saveid

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5195,6 +5195,13 @@
                 "drupal/search_api": "^1.0"
             },
             "type": "drupal-module",
+            "extra": {
+                "patches": {
+                    "drupal/core": {
+                        "[#3014514] Make igbinary the default serializer, if available": "./public/modules/contrib/helfi_api_base/patches/3014514.patch"
+                    }
+                }
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],

--- a/composer.lock
+++ b/composer.lock
@@ -2612,50 +2612,6 @@
             }
         },
         {
-            "name": "drupal/big_pipe_sessionless",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/big_pipe_sessionless.git",
-                "reference": "2.2.0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/big_pipe_sessionless-2.2.0.zip",
-                "reference": "2.2.0",
-                "shasum": "e894f61cb862511b3a79ed256f83c2c8fb98d5c7"
-            },
-            "require": {
-                "drupal/core": "^8 || ^9 || ^10 || ^11 || ^12"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "2.2.0",
-                    "datestamp": "1698145025",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Leers",
-                    "homepage": "https://www.drupal.org/user/99777"
-                }
-            ],
-            "description": "Accelerates Page Cache misses using the BigPipe technique.",
-            "homepage": "https://www.drupal.org/project/big_pipe_sessionless",
-            "support": {
-                "source": "https://git.drupalcode.org/project/big_pipe_sessionless"
-            }
-        },
-        {
             "name": "drupal/block_field",
             "version": "1.0.0-rc5",
             "source": {
@@ -5200,21 +5156,20 @@
         },
         {
             "name": "drupal/helfi_api_base",
-            "version": "2.8.22",
+            "version": "2.8.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base.git",
-                "reference": "1d8a9b09c8a96e307e95aaf2104693fbcc09ee5e"
+                "reference": "4a48121a426bda15c67948c38255e17498977a16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-api-base/zipball/1d8a9b09c8a96e307e95aaf2104693fbcc09ee5e",
-                "reference": "1d8a9b09c8a96e307e95aaf2104693fbcc09ee5e",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-api-base/zipball/4a48121a426bda15c67948c38255e17498977a16",
+                "reference": "4a48121a426bda15c67948c38255e17498977a16",
                 "shasum": ""
             },
             "require": {
                 "city-of-helsinki/php-logger-extra": "^1.0",
-                "drupal/big_pipe_sessionless": "^2.0",
                 "drupal/entity": "^1.0",
                 "drupal/health_check": "^3.0",
                 "drupal/monolog": "^3.0",
@@ -5240,22 +5195,15 @@
                 "drupal/search_api": "^1.0"
             },
             "type": "drupal-module",
-            "extra": {
-                "patches": {
-                    "drupal/big_pipe_sessionless": {
-                        "Drupal 11 support (https://drupal.org/i/3428235)": "https://www.drupal.org/files/issues/2025-05-07/3428235.d11.patch"
-                    }
-                }
-            },
             "license": [
                 "GPL-2.0-or-later"
             ],
             "description": "Helfi - API Base",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/tree/2.8.22",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/tree/2.8.23",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/issues"
             },
-            "time": "2026-05-11T07:18:21+00:00"
+            "time": "2026-06-25T08:55:56+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",

--- a/composer.lock
+++ b/composer.lock
@@ -7066,17 +7066,17 @@
         },
         {
             "name": "drupal/paragraphs",
-            "version": "1.20.0",
+            "version": "1.21.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/paragraphs.git",
-                "reference": "8.x-1.20"
+                "reference": "8.x-1.21"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.20.zip",
-                "reference": "8.x-1.20",
-                "shasum": "68051cc8c025aa3f62fd44a219d158361928a4ad"
+                "url": "https://ftp.drupal.org/files/projects/paragraphs-8.x-1.21.zip",
+                "reference": "8.x-1.21",
+                "shasum": "5638fab65f5c9cf954ef369411b2ee64d41e21f9"
             },
             "require": {
                 "drupal/core": "^10.3 || ^11",
@@ -7089,7 +7089,7 @@
                 "drupal/entity_usage": "2.x-dev",
                 "drupal/feeds": "^3",
                 "drupal/field_group": "3.x-dev",
-                "drupal/inline_entity_form": "3.x-dev",
+                "drupal/inline_entity_form": "^3",
                 "drupal/paragraphs-paragraphs_library": "*",
                 "drupal/replicate": "1.x-dev",
                 "drupal/search_api": "^1",
@@ -7101,8 +7101,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.20",
-                    "datestamp": "1767269542",
+                    "version": "8.x-1.21",
+                    "datestamp": "1782326108",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/public/modules/custom/grants_metadata/src/ApplicationDataService.php
+++ b/public/modules/custom/grants_metadata/src/ApplicationDataService.php
@@ -155,15 +155,15 @@ final class ApplicationDataService {
       if ($this->isDataNotSavedToAvus($saveIdToValidate, $submissionData, $applicationNumber, $latestSaveid)) {
         return 'DATA_NOT_SAVED_AVUS2';
       }
-
-      if ($this->hasPendingFileUploads($submissionData, $applicationNumber, $latestSaveid, $saveIdToValidate)) {
-        return 'FILE_UPLOAD_PENDING';
-      }
     }
     else {
       if (!$this->hasNewAvus2SaveEvent($submissionData)) {
         return 'DATA_NOT_SAVED_AVUS2';
       }
+    }
+
+    if ($this->hasPendingFileUploads($submissionData, $applicationNumber, $latestSaveid, $saveIdToValidate)) {
+      return 'FILE_UPLOAD_PENDING';
     }
 
     return 'OK';

--- a/public/modules/custom/grants_metadata/src/ApplicationDataService.php
+++ b/public/modules/custom/grants_metadata/src/ApplicationDataService.php
@@ -331,6 +331,10 @@ final class ApplicationDataService {
    *   The application has an save event which is created after drupal submit.
    */
   private function hasNewAvus2SaveEvent(array $submissionData): bool {
+    if ($submissionData['status'] === 'DRAFT') {
+      return TRUE;
+    }
+
     if (
       !$submissionData['form_timestamp_submitted'] ||
       !$submitTimestamp = strtotime($submissionData['form_timestamp_submitted'])

--- a/public/modules/custom/grants_metadata/src/ApplicationDataService.php
+++ b/public/modules/custom/grants_metadata/src/ApplicationDataService.php
@@ -145,19 +145,49 @@ final class ApplicationDataService {
       return 'OK';
     }
 
-    if ($this->isSaveIdMismatch($saveIdToValidate, $latestSaveid, $applicationNumber)) {
-      return 'DATA_NOT_SAVED_ATV';
-    }
+    // #UHF-13340 if eventTarget is missing on APP_OK-event, we need to use
+    // timestamps to figure out if application is editable.
+    if ($this->eventTargetsExist($submissionData)) {
+      if ($this->isSaveIdMismatch($saveIdToValidate, $latestSaveid, $applicationNumber)) {
+        return 'DATA_NOT_SAVED_ATV';
+      }
 
-    if ($this->isDataNotSavedToAvus($saveIdToValidate, $submissionData, $applicationNumber, $latestSaveid)) {
-      return 'DATA_NOT_SAVED_AVUS2';
+      if ($this->hasPendingFileUploads($submissionData, $applicationNumber, $latestSaveid, $saveIdToValidate)) {
+        return 'FILE_UPLOAD_PENDING';
+      }
     }
-
-    if ($this->hasPendingFileUploads($submissionData, $applicationNumber, $latestSaveid, $saveIdToValidate)) {
-      return 'FILE_UPLOAD_PENDING';
+    else {
+      if (!$this->hasNewAvus2SaveEvent($submissionData)) {
+        return 'DATA_NOT_SAVED_AVUS2';
+      }
     }
 
     return 'OK';
+  }
+
+  /**
+   * The atv document's events have the eventTarget set.
+   *
+   * A missing eventTarget in APP_OK event means that the integration has
+   * failed to save the lastest saveid to the document. Missing saveid causes
+   * problems when checking if application should be editable.
+   *
+   * @param array<mixed> $submissionData
+   *   The submission data.
+   *
+   * @return bool
+   *   Application has event targets set on APP_OK-event.
+   */
+  private function eventTargetsExist(array $submissionData): bool {
+    $applicationEvents = $this->eventsService->filterEvents($submissionData['events'] ?? [], 'INTEGRATION_INFO_APP_OK');
+
+    foreach ($applicationEvents['events'] as $event) {
+      if (!isset($event['eventTarget'])) {
+        return FALSE;
+      }
+    }
+
+    return TRUE;
   }
 
   /**
@@ -283,6 +313,52 @@ final class ApplicationDataService {
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Document has new APP_OK -event.
+   *
+   * Allow end users to open applications with missing saveids.
+   *
+   * @param array<mixed> $submissionData
+   *   The submission data.
+   *
+   * @return bool
+   *   The application has an save event which is created after drupal submit.
+   */
+  private function hasNewAvus2SaveEvent(array $submissionData): bool {
+    if (
+      !$submissionData['form_timestamp_submitted'] ||
+      !$submitTimestamp = strtotime($submissionData['form_timestamp_submitted'])
+    ) {
+      return FALSE;
+    }
+
+    $applicationEvents = $this->eventsService->filterEvents(
+      $submissionData['events'] ?? [], 'INTEGRATION_INFO_APP_OK'
+    );
+
+    $appOkAfterSubmit = FALSE;
+    foreach ($applicationEvents['events'] as $event) {
+      try {
+        $eventCreatedDateTime = new \DateTime($event['timeCreated'], new \DateTimeZone('UTC'));
+      }
+      catch (\Exception $e) {
+        continue;
+      }
+
+      $eventCreatedTimestamp = $eventCreatedDateTime->setTimezone(new \DateTimeZone('Europe/Helsinki'))
+        ->getTimestamp();
+
+      if (
+        $eventCreatedTimestamp &&
+        $eventCreatedTimestamp >= $submitTimestamp
+      ) {
+        $appOkAfterSubmit = TRUE;
+      }
+    }
+
+    return $appOkAfterSubmit;
   }
 
   /**

--- a/public/modules/custom/grants_metadata/src/ApplicationDataService.php
+++ b/public/modules/custom/grants_metadata/src/ApplicationDataService.php
@@ -152,6 +152,10 @@ final class ApplicationDataService {
         return 'DATA_NOT_SAVED_ATV';
       }
 
+      if ($this->isDataNotSavedToAvus($saveIdToValidate, $submissionData, $applicationNumber, $latestSaveid)) {
+        return 'DATA_NOT_SAVED_AVUS2';
+      }
+
       if ($this->hasPendingFileUploads($submissionData, $applicationNumber, $latestSaveid, $saveIdToValidate)) {
         return 'FILE_UPLOAD_PENDING';
       }


### PR DESCRIPTION
# [UHF-13340](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13340)

## What was done
Allow users to edit submitted applications even when integration fails to update the saveids.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13340`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Log in as enduser
- Open one of the broken webform-applications
  - Should now open normally
- Open one of older, working webform-applications
  - Should still work.   

[UHF-13340]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ