### PR TITLE
UHF-13396: added TYPA as grand industry

### DIFF
--- a/conf/cmi/grants_metadata.settings.yml
+++ b/conf/cmi/grants_metadata.settings.yml
@@ -7,6 +7,7 @@ third_party_options:
     PEL: PEL
     KUVA: KUVA
     KASKO: KASKO
+    TYPA: TYPA
   applicant_types:
     registered_community: 'Rekisteröity yhdistys'
     unregistered_community: 'Rekisteröitymätön yhteisö tai ryhmä'

--- a/public/modules/custom/grants_application/form_configuration/form_configuration.json
+++ b/public/modules/custom/grants_application/form_configuration/form_configuration.json
@@ -29,6 +29,11 @@
       "labels": {
         "und": "KASKO"
       }
+    },
+    "TYPA": {
+      "labels": {
+        "und": "TYPA"
+      }
     }
   },
   "applicant_types": {


### PR DESCRIPTION
# [UHF-13396](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13396)

## What was done
Added new industry

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-0000_insert_correct_branch`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Create new metadata for a new application-form or create a new webform 
- The indusrtry-dropdown should now have TYPA

[UHF-13396]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ