### PR TITLE
UHF-13176 deleteafter 

### DIFF
--- a/public/modules/custom/grants_application/src/Form/FormSettings.php
+++ b/public/modules/custom/grants_application/src/Form/FormSettings.php
@@ -196,8 +196,12 @@ final class FormSettings {
   /**
    * Calculate delete after value for this application.
    *
-   * Draft: If continuous: 1 year, if not continuous: close-date + 1 month
-   * Submitted: 6 years.
+   * Draft - continuous:
+   * - With close-time: +1 month.
+   * - Without close-time: +1year.
+   * Draft - non-continuous
+   * - Close-time + 1 month
+   * Submitted: +6 Years.
    *
    * @return string
    *   The delete after value.
@@ -205,6 +209,14 @@ final class FormSettings {
   public function getDraftDeleteAfter(): string {
     $isContinuous = $this->settings['continuous'] ?? FALSE;
     $endDate = $this->settings['application_close'] ?? NULL;
+
+    if ($isContinuous && $endDate) {
+      return (new \DateTimeImmutable($endDate))->add(new \DateInterval('P1M'))->format('Y-m-d');
+    }
+
+    if ($isContinuous && !$endDate) {
+      return date('Y-m-d', strtotime('+1 year'));
+    }
 
     if (!$isContinuous && $endDate) {
       return (new \DateTimeImmutable($endDate))->add(new \DateInterval('P1M'))->format('Y-m-d');

--- a/public/modules/custom/grants_application/tests/src/Kernel/Form/FormSettingsServiceTest.php
+++ b/public/modules/custom/grants_application/tests/src/Kernel/Form/FormSettingsServiceTest.php
@@ -240,15 +240,23 @@ final class FormSettingsServiceTest extends KernelTestBase {
     $deleteAfter = $settings->getDraftDeleteAfter();
     $this->assertEquals('2030-02-01', $deleteAfter);
 
+    // Continuous application without close-time.
+    $settingsValues = [
+      'continuous' => TRUE,
+      'application_close' => NULL,
+    ];
+    $settings = new FormSettings($settingsValues, [], [], []);
+    $deleteAfter = $settings->getDraftDeleteAfter();
+    $this->assertEquals(date('Y-m-d', strtotime('+1 year')), $deleteAfter);
+
+    // Continuous application with close time.
     $settingsValues = [
       'continuous' => TRUE,
       'application_close' => '2030-01-01',
     ];
     $settings = new FormSettings($settingsValues, [], [], []);
-
-    // On continuous application, the draft is deleted after one year.
     $deleteAfter = $settings->getDraftDeleteAfter();
-    $this->assertEquals(date('Y-m-d', strtotime('+1 year')), $deleteAfter);
+    $this->assertEquals('2030-02-01', $deleteAfter);
 
     // Test bad settings.
     $settings = new FormSettings([], [], [], []);

--- a/public/modules/custom/grants_handler/src/ApplicationInitService.php
+++ b/public/modules/custom/grants_handler/src/ApplicationInitService.php
@@ -402,12 +402,22 @@ class ApplicationInitService {
   public function setDeleteAfter(array $settings, AtvDocument $atvDocument): void {
     $endDate = strtotime($settings['applicationClose']);
     $isContinuous = $settings['applicationContinuous'];
-
     $deleteAfter = new \DateTimeImmutable("+1 years");
+
+    if ($isContinuous && $endDate) {
+      $date = date('Y-m-d', $endDate);
+      $deleteAfter = (new \DateTimeImmutable($date))->add(new \DateInterval("P1M"));
+    }
+
+    if ($isContinuous && !$endDate) {
+      $deleteAfter = new \DateTimeImmutable("+1 years");
+    }
+
     if (!$isContinuous && $endDate) {
       $date = date('Y-m-d', $endDate);
       $deleteAfter = (new \DateTimeImmutable($date))->add(new \DateInterval("P1M"));
     }
+
     $atvDocument->setDeleteAfter($deleteAfter->format('Y-m-d'));
   }
 


### PR DESCRIPTION
# [UHF-13176](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13176)

## What was done
Update the logic for continuous applications

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch
  * `git fetch && git checkout UHF-13176`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test
- Log in as admin on incognito, and as enduser on non-incognito

Webform:
- Select one of the continuous forms, for example Yleisavustus
  - `fi/admin/structure/webform/manage/yleisavustushakemus/settings`
1. Continuous + end date is set
- As admin: Update the form settings
- As end user: Create draft as enduser (`/fi/uusi-hakemus/yleisavustushakemus`)
- As admin: Use resender to load the application and check that delete_after = `end date + 1month`
3. Continuous + end date not set
- As admin: Update the form settings
- Create a new draft as enduser (`/fi/uusi-hakemus/yleisavustushakemus`)
- As admin: Use resender to load the application and check that delete_after = `Now + 1 year`

React:
- Same with react: 
  - Metadata: `/fi/admin/tools/application-metadata/2/edit`
  - New application: `/fi/application/new/yleisavustushakemus`

[UHF-13176]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ